### PR TITLE
Render item tooltip in a portal to fix off-screen positioning

### DIFF
--- a/src/components/character/ItemDetailTooltip.jsx
+++ b/src/components/character/ItemDetailTooltip.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useLayoutEffect, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 export function ItemDetailTooltip({ item, visible, slotRef }) {
   const tooltipRef = useRef(null);
@@ -89,10 +90,11 @@ export function ItemDetailTooltip({ item, visible, slotRef }) {
   }, [visible, item, isPositioned]);
 
   if (!visible || !item || !item.item) return null;
+  if (typeof document === 'undefined') return null;
 
   const itemData = item.item;
 
-  return (
+  return createPortal(
     <div
       ref={tooltipRef}
       className="item-tooltip"
@@ -133,6 +135,7 @@ export function ItemDetailTooltip({ item, visible, slotRef }) {
           <div className="tooltip-item-row">{itemData.itemRow}</div>
         </div>
       )}
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
### Motivation
- Tooltips anchored to inventory slots could jump far offscreen on certain browsers because fixed positioning was affected by slot transforms and layout timing. 
- The tooltip must be positioned relative to the viewport, not the slot container, to avoid transform/overflow issues. 
- Avoid rendering tooltips when `document` is unavailable (e.g. SSR) to prevent runtime errors. 

### Description
- Render the tooltip via `createPortal` into `document.body` so its `position: fixed` is measured against the viewport. 
- Added a guard `if (typeof document === 'undefined') return null` to skip rendering when `document` isn't present. 
- Kept existing positioning logic, double `requestAnimationFrame` timing, and opacity transition intact in `src/components/character/ItemDetailTooltip.jsx`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebd90c93c8326b65ab6e229f672e8)