### PR TITLE
Allow scrolling and interaction on item tooltips

### DIFF
--- a/src/components/character/InventorySlot.jsx
+++ b/src/components/character/InventorySlot.jsx
@@ -1,16 +1,60 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { ItemDetailTooltip } from './ItemDetailTooltip';
 
 export function InventorySlot({ label, name, type, empty = false, item = null }) {
   const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipHovered, setTooltipHovered] = useState(false);
   const slotRef = useRef(null);
+  const hideTimeoutRef = useRef(null);
+
+  const clearHideTimeout = () => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  };
+
+  const scheduleHide = () => {
+    clearHideTimeout();
+    hideTimeoutRef.current = setTimeout(() => {
+      if (!tooltipHovered) {
+        setShowTooltip(false);
+      }
+    }, 100);
+  };
+
+  const handleSlotEnter = () => {
+    clearHideTimeout();
+    setShowTooltip(true);
+  };
+
+  const handleSlotLeave = () => {
+    scheduleHide();
+  };
+
+  const handleTooltipEnter = () => {
+    clearHideTimeout();
+    setTooltipHovered(true);
+    setShowTooltip(true);
+  };
+
+  const handleTooltipLeave = () => {
+    setTooltipHovered(false);
+    setShowTooltip(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      clearHideTimeout();
+    };
+  }, []);
 
   return (
     <div
       ref={slotRef}
       className={`inventory-slot${empty ? ' empty' : ''}`}
-      onMouseEnter={() => setShowTooltip(true)}
-      onMouseLeave={() => setShowTooltip(false)}
+      onMouseEnter={handleSlotEnter}
+      onMouseLeave={handleSlotLeave}
     >
       {label && <div className="slot-label">{label}</div>}
       <div className="slot-item-name">{name}</div>
@@ -21,6 +65,8 @@ export function InventorySlot({ label, name, type, empty = false, item = null })
           item={{ item }}
           visible={showTooltip}
           slotRef={slotRef}
+          onMouseEnter={handleTooltipEnter}
+          onMouseLeave={handleTooltipLeave}
         />
       )}
     </div>

--- a/src/components/character/ItemDetailTooltip.jsx
+++ b/src/components/character/ItemDetailTooltip.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useLayoutEffect, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
-export function ItemDetailTooltip({ item, visible, slotRef }) {
+export function ItemDetailTooltip({ item, visible, slotRef, onMouseEnter, onMouseLeave }) {
   const tooltipRef = useRef(null);
   const [position, setPosition] = useState({ top: -9999, left: -9999 });
   const [isPositioned, setIsPositioned] = useState(false);
@@ -89,13 +90,16 @@ export function ItemDetailTooltip({ item, visible, slotRef }) {
   }, [visible, item, isPositioned]);
 
   if (!visible || !item || !item.item) return null;
+  if (typeof document === 'undefined') return null;
 
   const itemData = item.item;
 
-  return (
+  return createPortal(
     <div
       ref={tooltipRef}
       className="item-tooltip"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
         position: 'fixed',
         top: `${position.top}px`,
@@ -133,6 +137,7 @@ export function ItemDetailTooltip({ item, visible, slotRef }) {
           <div className="tooltip-item-row">{itemData.itemRow}</div>
         </div>
       )}
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -680,7 +680,7 @@ h1::before {
   padding: 1rem;
   z-index: 9999;
   box-shadow: 0 8px 16px rgba(0,0,0,0.5);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .tooltip-header {


### PR DESCRIPTION
### Motivation
- Long item tooltips can require scrollbars, but the tooltip was not interactive so users could not hover or scroll it. 
- Moving the cursor from the slot to the tooltip caused flicker and premature hide due to immediate `onMouseLeave` behavior. 
- Tooltips should be rendered relative to the viewport and remain usable without breaking existing positioning logic. 

### Description
- Keep tooltips open when the pointer enters them by adding `tooltipHovered` state, delayed hide timers, and handlers in `InventorySlot` (`handleSlotEnter`, `handleSlotLeave`, `handleTooltipEnter`, `handleTooltipLeave`).
- Pass `onMouseEnter`/`onMouseLeave` props to `ItemDetailTooltip` and attach them to the tooltip root element. 
- Enable pointer interaction by changing `.item-tooltip` CSS to `pointer-events: auto` and add timer cleanup with `useEffect` to clear timeouts on unmount. 
- Ensure tooltip is rendered into the viewport with `createPortal` into `document.body` and guard rendering when `document` is unavailable. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebd90c93c8326b65ab6e229f672e8)