### PR TITLE
Add skill tree tab with keystones, weapon/crafting skills UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ src/
 │   ├── upload/          # File upload tab
 │   ├── character/       # Equipment/inventory display tab
 │   ├── filter/          # Attribute search/filtering tab
-│   └── items/           # Items browsing tab
+│   ├── items/           # Items browsing tab
+│   └── skilltree/       # Skill tree display/editing tab
 ├── hooks/               # Custom React hooks
 ├── models/              # Clean data models (Item, SkillTree, transformers)
 ├── utils/               # Core logic (parsing, filtering, WASM)
@@ -58,16 +59,20 @@ uesave-wasm/pkg/         # Pre-built WASM module (do not modify)
 | Skill tree data model | `src/models/SkillTree.js` |
 | Skill tree extraction | `src/utils/skillTreeParser.js` |
 | Skill/card/keystone registry | `src/utils/skillTreeRegistry.js` |
+| Skill tree tab UI | `src/components/skilltree/SkillTreeTab.jsx` |
+| Skill tree state/store | `src/hooks/useSkillTreeStore.js` |
 | Styling/theming | `src/styles/index.css` |
 
 ## Tab Architecture
 
 Tabs defined in `App.jsx` TABS array:
 ```jsx
-{ id: 'upload', label: 'Upload', icon: '📁' }
+{ id: 'upload', label: 'Upload', icon: '📂' }
 { id: 'character', label: 'Character', icon: '🧙' }
-{ id: 'filter', label: 'Filter', icon: '🔍' }
+{ id: 'skilltree', label: 'Skill Tree', icon: '🌳' }
 { id: 'items', label: 'Items', icon: '🎒' }
+{ id: 'filter', label: 'Filter', icon: '🔍' }
+{ id: 'stats', label: 'Stats', icon: '📊' }
 ```
 
 **To add a new tab:**
@@ -87,14 +92,21 @@ App.jsx (state holder)
 │   ├── inventory[]       → All items from save
 │   ├── equippedSlotMap   → Items by slot key
 │   └── metadata          → Filename, load time
+├── skillTreeStore  → Skill tree store (useSkillTreeStore hook)
+│   ├── skillTreeData     → Parsed SkillTreeData from save
+│   ├── keystoneSelections → Manual keystone checkbox state
+│   ├── skillOverrides    → Per-skill enable/level overrides
+│   ├── skillValues       → User-entered stat values
+│   ├── effectiveSkillStats → Computed stats for useDerivedStats
+│   └── skillConfigOverrides → Computed config overrides for eDPS
 ├── sharedFilterModel → Decoded filter from URL hash (consumed once)
 ├── status/statusType → UI feedback messages
 ├── logs            → Debug log buffer
 └── wasmReady       → WASM initialization flag
 
 Tab callbacks:
-- onFileLoaded(data) → Sets saveData, loads itemStore, switches to Character tab
-- onClearSave()      → Clears saveData and itemStore, returns to Upload tab
+- onFileLoaded(data) → Sets saveData, loads itemStore + skillTreeStore, switches to Character tab
+- onClearSave()      → Clears saveData, itemStore + skillTreeStore, returns to Upload tab
 - onLog(msg)         → Adds to log buffer
 - onStatusChange(msg, type) → Updates status bar
 ```
@@ -305,12 +317,27 @@ Save data at `HostPlayerData_0.Struct.Struct.CharacterSkills_77_*` contains 4 sk
   - `CRAFTING_SKILL_REGISTRY` - 40 crafting/elven entries mapped to branches
   - `CARD_REGISTRY` - 16 card entries (skeleton, effects TBD)
   - `TREE_KEYSTONES` - Manually curated main-tree keystones (proximity, mastery, affinity, utility)
+- `src/hooks/useSkillTreeStore.js` - Central store for skill tree state and overrides
+- `src/components/skilltree/SkillTreeTab.jsx` - Tab UI with sub-components
+
+### Skill Tree Tab (hybrid auto-detect + manual input)
+The Skill Tree tab uses a hybrid approach:
+- **Auto-detected** from save: weapon stances (94 skills), crafting/elven tree (40 skills), cards (16)
+- **Manual checklist**: 14 main-tree keystones (opaque IDs can't be auto-mapped)
+- **User-editable values**: skills with `statId` show a value input (flat or percent based on `STAT_REGISTRY.isPercent`)
+- **Overrides**: toggle skills on/off, edit paragon levels, enter stat values
+- **Integration**: `effectiveSkillStats` and `skillConfigOverrides` feed into `useDerivedStats`
 
 ### Main tree keystones (user-input checklist)
 Opaque node IDs can't be auto-detected. `TREE_KEYSTONES` provides a checklist of notable effects that overlap with monograms or grant unique bonuses:
 - Close/Far Distance (proximity damage), Melee/Ranged Mastery (damage/armor)
 - Fire/Arcane/Lightning Affinity (CDR ~35%, damage ~100% additive)
 - Extra inventory slots, extra potions
+
+### Skill Tree → eDPS integration
+- Affinity damage keystones → `edpsAD.affinityDamage` config override
+- Proximity keystones → `edpsEMulti` distance flags
+- Weapon/crafting skills with `statId` + user-entered values → base stat aggregation via `useDerivedStats`
 
 ### TODO: Card registry
 Card effects need population. Cards have L1/L2/L3 base stats; L6 doubles L3 and removes from further choice. Currently stored as skeleton entries with empty effects arrays.
@@ -330,6 +357,7 @@ npm run test:coverage  # With coverage report
 - `test/itemTransformer.test.js` - Save file parsing tests
 - `test/shareUrl.test.js` - URL sharing encode/decode tests
 - `test/skillTreeParser.test.js` - Skill tree parsing/registry tests
+- `test/useSkillTreeStore.test.js` - Skill tree store logic tests
 
 ### Key Testable Modules
 | Module | Pure Functions | Notes |
@@ -340,6 +368,7 @@ npm run test:coverage  # With coverage report
 | `shareUrl.js` | `encodeFilterShare()`, `decodeFilterShare()`, `parseShareFromHash()` | URL sharing |
 | `skillTreeParser.js` | `extractSkillTree()`, `categorizeSkill()` | Skill tree extraction |
 | `skillTreeRegistry.js` | `getWeaponSkillDef()`, `getCraftingSkillDef()`, `getCardDef()` | Skill/card/keystone lookups |
+| `useSkillTreeStore.js` | `computeEffectiveStats()`, `computeConfigOverrides()` | Stat aggregation from skills |
 
 ## Test Fixtures
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,15 +5,18 @@ import { CharacterTab } from './components/character';
 import { FilterTab } from './components/filter';
 import { ItemsTab } from './components/items';
 import { StatsTab } from './components/stats';
+import { SkillTreeTab } from './components/skilltree';
 import { initWasm } from './utils/wasm';
 import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
+import { useSkillTreeStore } from './hooks/useSkillTreeStore';
 import { parseShareFromHash, decodeFilterShare } from './utils/shareUrl';
 
 const TABS = [
   { id: 'upload', label: 'Upload', icon: '📂' },
   { id: 'character', label: 'Character', icon: '🧙' },
+  { id: 'skilltree', label: 'Skills', icon: '🌳' },
   { id: 'items', label: 'Items', icon: '🎒' },
   { id: 'filter', label: 'Filter', icon: '🔍' },
   { id: 'stats', label: 'Stats', icon: '📊' },
@@ -33,6 +36,9 @@ export default function App() {
 
   // Central item store - all UI reads from here, not from raw saveData
   const itemStore = useItemStore();
+
+  // Skill tree store - manages skill tree data and user overrides
+  const skillTreeStore = useSkillTreeStore();
 
   // Initialize WASM and detect platform
   useEffect(() => {
@@ -92,6 +98,8 @@ export default function App() {
     setSaveData(data);
     // Load items into central store from parsed save data
     itemStore.loadFromSave(data.parsed || data.raw, data.filename);
+    // Load skill tree data
+    skillTreeStore.loadFromSave(data.parsed || data.raw);
     setActiveTab('character');
     log(`🎮 Save loaded: ${data.filename}`);
   }, [log, itemStore]);
@@ -99,16 +107,17 @@ export default function App() {
   const handleClearSave = useCallback(() => {
     setSaveData(null);
     itemStore.clear();
+    skillTreeStore.clear();
     setActiveTab('upload');
     log('🗑️ Save data cleared');
-  }, [log, itemStore]);
+  }, [log, itemStore, skillTreeStore]);
 
   // Determine which tabs are disabled
   const disabledTabs = itemStore.hasItems
     ? []
     : filterTabUnlocked
-      ? ['character', 'items']
-      : ['character', 'items', 'filter'];
+      ? ['character', 'skilltree', 'items']
+      : ['character', 'skilltree', 'items', 'filter'];
 
   return (
     <div className="app">
@@ -127,9 +136,17 @@ export default function App() {
             <CharacterTab
               saveData={saveData}
               itemStore={itemStore}
+              skillTreeStore={skillTreeStore}
               onClearSave={handleClearSave}
               onLog={log}
               onStatusChange={handleStatusChange}
+            />
+          )}
+          {activeTab === 'skilltree' && saveData && (
+            <SkillTreeTab
+              skillTreeStore={skillTreeStore}
+              saveData={saveData}
+              onLog={log}
             />
           )}
           {activeTab === 'items' && saveData && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import { parseShareFromHash, decodeFilterShare } from './utils/shareUrl';
 const TABS = [
   { id: 'upload', label: 'Upload', icon: '📂' },
   { id: 'character', label: 'Character', icon: '🧙' },
-  { id: 'skilltree', label: 'Skills', icon: '🌳' },
+  { id: 'skilltree', label: 'Skill Tree', icon: '🌳' },
   { id: 'items', label: 'Items', icon: '🎒' },
   { id: 'filter', label: 'Filter', icon: '🔍' },
   { id: 'stats', label: 'Stats', icon: '📊' },

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '../common';
 import { CharacterPanel } from './CharacterPanel';
 
-export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
+export function CharacterTab({ saveData, itemStore, skillTreeStore, onClearSave, onLog }) {
   // Build characterData from itemStore (central source of truth)
   // Falls back to saveData for backward compatibility
   const characterData = itemStore?.hasItems ? {
@@ -16,6 +16,12 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     equippedItems: saveData.equippedItems || [],
     timestamp: saveData.timestamp,
   } : null;
+
+  // Attach skill tree effects if available
+  if (characterData && skillTreeStore?.isLoaded) {
+    characterData.skillTreeStats = skillTreeStore.effectiveSkillStats;
+    characterData.skillTreeConfigOverrides = skillTreeStore.skillConfigOverrides;
+  }
 
   return (
     <div className="tab-content active">

--- a/src/components/skilltree/CardsSection.jsx
+++ b/src/components/skilltree/CardsSection.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { getCardDef } from '../../utils/skillTreeRegistry';
+import { getCardsByFamily } from '../../models/SkillTree';
+
+/**
+ * Crystal cards display (visual only, effects TBD)
+ *
+ * @param {Object} props
+ * @param {Array} props.cards - Card skill entries from save
+ * @param {Object} props.skillTreeData - Full skill tree data for family grouping
+ */
+export function CardsSection({ cards, skillTreeData }) {
+  if (!cards || cards.length === 0) return null;
+
+  const families = skillTreeData ? getCardsByFamily(skillTreeData) : {};
+
+  return (
+    <div className="skill-section">
+      <div className="skill-section-header">
+        <span className="skill-section-title">Crystal Cards</span>
+        <span className="skill-section-subtitle">{cards.length} cards allocated (effects TBD)</span>
+      </div>
+
+      <div className="cards-grid">
+        {cards.map(card => {
+          const def = getCardDef(card.rowName);
+          const name = def?.name || card.rowName;
+
+          return (
+            <div key={card.rowName} className="card-item">
+              <span className="card-name">{name}</span>
+              <span className="card-level">Lv {card.level}{def?.maxLevel ? ` / ${def.maxLevel}` : ''}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/skilltree/CraftingSkillsSection.jsx
+++ b/src/components/skilltree/CraftingSkillsSection.jsx
@@ -1,0 +1,116 @@
+import React, { useState, useCallback } from 'react';
+import { SkillRow } from './SkillRow';
+import { getCraftingSkillDef } from '../../utils/skillTreeRegistry';
+
+const BRANCH_LABELS = {
+  armor: 'Armor',
+  damage: 'Damage',
+  crafting: 'Crafting',
+  exp: 'Experience',
+  luck: 'Luck',
+  timeTear: 'Time Tear',
+  utility: 'Utility',
+};
+
+const BRANCH_ORDER = ['armor', 'damage', 'luck', 'crafting', 'exp', 'timeTear', 'utility'];
+
+/**
+ * Crafting/Elven skills grouped by branch
+ *
+ * @param {Object} props
+ * @param {Array} props.crafting - Crafting skill entries from save
+ * @param {Object} props.skillOverrides - { [rowName]: { enabled, level } }
+ * @param {Function} props.onOverride - (rowName, override) => void
+ * @param {Object} props.skillValues - { [rowName]: number }
+ * @param {Function} props.onValueChange - (rowName, value) => void
+ * @param {Function} props.isSkillEnabled - (rowName) => boolean
+ * @param {Function} props.getEffectiveLevel - (rowName, saveLevel) => number
+ */
+export function CraftingSkillsSection({
+  crafting,
+  skillOverrides,
+  onOverride,
+  skillValues,
+  onValueChange,
+  isSkillEnabled,
+  getEffectiveLevel,
+}) {
+  const [collapsed, setCollapsed] = useState({});
+
+  const toggleCollapse = useCallback((branch) => {
+    setCollapsed(prev => ({ ...prev, [branch]: !prev[branch] }));
+  }, []);
+
+  if (!crafting || crafting.length === 0) return null;
+
+  // Group by branch
+  const grouped = {};
+  for (const skill of crafting) {
+    const def = getCraftingSkillDef(skill.rowName);
+    const branch = def?.branch || 'utility';
+    if (!grouped[branch]) grouped[branch] = [];
+    grouped[branch].push(skill);
+  }
+
+  const activeBranches = BRANCH_ORDER.filter(b => grouped[b] && grouped[b].length > 0);
+
+  return (
+    <div className="skill-section">
+      <div className="skill-section-header">
+        <span className="skill-section-title">Crafting / Elven Tree</span>
+        <span className="skill-section-subtitle">Auto-detected from save</span>
+      </div>
+
+      {activeBranches.map(branch => {
+        const skills = grouped[branch];
+        const isCollapsed = collapsed[branch];
+        const label = BRANCH_LABELS[branch] || branch;
+
+        return (
+          <div key={branch} className="weapon-group">
+            <button
+              className="weapon-group-header"
+              onClick={() => toggleCollapse(branch)}
+            >
+              <span className="collapse-icon">{isCollapsed ? '▶' : '▼'}</span>
+              <span className="weapon-label">{label}</span>
+              <span className="weapon-count">{skills.length} skills</span>
+            </button>
+
+            {!isCollapsed && (
+              <div className="weapon-skills-list">
+                {skills.map(skill => {
+                  const def = getCraftingSkillDef(skill.rowName);
+                  const name = def?.name || skill.rowName;
+                  const statId = def?.statId;
+                  const isParagon = def?.paragon;
+                  const enabled = isSkillEnabled(skill.rowName);
+                  const effectiveLevel = getEffectiveLevel(skill.rowName, skill.level);
+
+                  return (
+                    <SkillRow
+                      key={skill.rowName}
+                      name={name}
+                      level={skill.level}
+                      type={isParagon ? 'paragon' : (statId ? 'stat' : 'utility')}
+                      statId={statId}
+                      perLevel={isParagon}
+                      enabled={enabled}
+                      onToggle={() => onOverride(skill.rowName, { enabled: !enabled })}
+                      userValue={skillValues[skill.rowName]}
+                      onValueChange={statId ? (v) => onValueChange(skill.rowName, v) : undefined}
+                      effectiveLevel={isParagon ? effectiveLevel : undefined}
+                      onLevelChange={isParagon
+                        ? (v) => onOverride(skill.rowName, { level: v })
+                        : undefined}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/skilltree/CraftingSkillsSection.jsx
+++ b/src/components/skilltree/CraftingSkillsSection.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { SkillRow } from './SkillRow';
 import { getCraftingSkillDef } from '../../utils/skillTreeRegistry';
+import { STAT_REGISTRY } from '../../utils/statRegistry';
 
 const BRANCH_LABELS = {
   armor: 'Armor',
@@ -84,6 +85,7 @@ export function CraftingSkillsSection({
                   const name = def?.name || skill.rowName;
                   const statId = def?.statId;
                   const isParagon = def?.paragon;
+                  const statIsPercent = statId ? (STAT_REGISTRY[statId]?.isPercent ?? true) : true;
                   const enabled = isSkillEnabled(skill.rowName);
                   const effectiveLevel = getEffectiveLevel(skill.rowName, skill.level);
 
@@ -95,6 +97,7 @@ export function CraftingSkillsSection({
                       type={isParagon ? 'paragon' : (statId ? 'stat' : 'utility')}
                       statId={statId}
                       perLevel={isParagon}
+                      isPercent={statIsPercent}
                       enabled={enabled}
                       onToggle={() => onOverride(skill.rowName, { enabled: !enabled })}
                       userValue={skillValues[skill.rowName]}

--- a/src/components/skilltree/KeystoneChecklist.jsx
+++ b/src/components/skilltree/KeystoneChecklist.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { StatInput } from '../character/StatInput';
+import { TREE_KEYSTONES } from '../../utils/skillTreeRegistry';
+
+const CATEGORY_LABELS = {
+  proximity: 'Proximity',
+  mastery: 'Mastery',
+  affinity: 'Affinity',
+  utility: 'Utility',
+};
+
+const CATEGORY_ORDER = ['proximity', 'mastery', 'affinity', 'utility'];
+
+/**
+ * Manual checklist for main tree keystones grouped by category
+ *
+ * @param {Object} props
+ * @param {Object} props.selections - { [keystoneId]: boolean }
+ * @param {Function} props.onToggle - (keystoneId) => void
+ * @param {Object} props.skillValues - { [keystoneId]: number }
+ * @param {Function} props.onValueChange - (keystoneId, value) => void
+ */
+export function KeystoneChecklist({ selections, onToggle, skillValues, onValueChange }) {
+  // Group keystones by category
+  const grouped = {};
+  for (const keystone of Object.values(TREE_KEYSTONES)) {
+    if (!grouped[keystone.category]) {
+      grouped[keystone.category] = [];
+    }
+    grouped[keystone.category].push(keystone);
+  }
+
+  return (
+    <div className="skill-section">
+      <div className="skill-section-header">
+        <span className="skill-section-title">Main Tree Keystones</span>
+        <span className="skill-section-subtitle">Manual selection (can't auto-detect from save)</span>
+      </div>
+
+      <div className="keystone-grid">
+        {CATEGORY_ORDER.map(category => {
+          const keystones = grouped[category];
+          if (!keystones || keystones.length === 0) return null;
+
+          return (
+            <div key={category} className="keystone-category">
+              <div className="keystone-category-label">{CATEGORY_LABELS[category]}</div>
+              {keystones.map(keystone => {
+                const checked = !!selections[keystone.id];
+                const hasStatId = !!keystone.statId;
+
+                return (
+                  <div key={keystone.id} className="keystone-item">
+                    <label className="keystone-toggle">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => onToggle(keystone.id)}
+                      />
+                      <span className="keystone-name">{keystone.name}</span>
+                      {keystone.overlaps && (
+                        <span className="keystone-overlap-badge" title="Overlaps with monogram effect">
+                          overlap
+                        </span>
+                      )}
+                    </label>
+                    <span className="keystone-desc">{keystone.description}</span>
+                    {hasStatId && checked && (
+                      <div className="keystone-value-input">
+                        <StatInput
+                          value={skillValues[keystone.id] || 0}
+                          onChange={(v) => onValueChange(keystone.id, v)}
+                          min={0}
+                          step={1}
+                          isPercent
+                          placeholder="0"
+                        />
+                        <span className="skill-stat-id">{keystone.statId}</span>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/skilltree/KeystoneChecklist.jsx
+++ b/src/components/skilltree/KeystoneChecklist.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StatInput } from '../character/StatInput';
 import { TREE_KEYSTONES } from '../../utils/skillTreeRegistry';
+import { STAT_REGISTRY } from '../../utils/statRegistry';
 
 const CATEGORY_LABELS = {
   proximity: 'Proximity',
@@ -71,8 +72,8 @@ export function KeystoneChecklist({ selections, onToggle, skillValues, onValueCh
                           value={skillValues[keystone.id] || 0}
                           onChange={(v) => onValueChange(keystone.id, v)}
                           min={0}
-                          step={1}
-                          isPercent
+                          step={(STAT_REGISTRY[keystone.statId]?.isPercent ?? true) ? 1 : 10}
+                          isPercent={STAT_REGISTRY[keystone.statId]?.isPercent ?? true}
                           placeholder="0"
                         />
                         <span className="skill-stat-id">{keystone.statId}</span>

--- a/src/components/skilltree/SkillRow.jsx
+++ b/src/components/skilltree/SkillRow.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { StatInput } from '../character/StatInput';
+
+/**
+ * A single skill row with toggle, name, level display, and optional value input
+ *
+ * @param {Object} props
+ * @param {string} props.name - Display name
+ * @param {number} props.level - Skill level from save
+ * @param {string} props.type - Skill type badge (ability, stat, buff, paragon, utility)
+ * @param {string} [props.statId] - Stat this skill contributes to
+ * @param {boolean} [props.perLevel] - Whether value scales with level
+ * @param {boolean} props.enabled - Whether skill is active
+ * @param {Function} props.onToggle - Toggle enabled state
+ * @param {number} [props.userValue] - User-entered stat value
+ * @param {Function} [props.onValueChange] - Called with new value
+ * @param {number} [props.effectiveLevel] - Override level (for paragon editing)
+ * @param {Function} [props.onLevelChange] - Called with new level
+ */
+export function SkillRow({
+  name,
+  level,
+  type,
+  statId,
+  perLevel,
+  enabled,
+  onToggle,
+  userValue,
+  onValueChange,
+  effectiveLevel,
+  onLevelChange,
+}) {
+  const isParagon = type === 'paragon';
+  const displayLevel = effectiveLevel !== undefined ? effectiveLevel : level;
+
+  const typeBadgeClass = {
+    ability: 'skill-badge-ability',
+    stat: 'skill-badge-stat',
+    buff: 'skill-badge-buff',
+    paragon: 'skill-badge-paragon',
+    utility: 'skill-badge-utility',
+  }[type] || 'skill-badge-stat';
+
+  return (
+    <div className={`skill-row ${!enabled ? 'skill-row-disabled' : ''}`}>
+      <label className="skill-toggle">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={onToggle}
+        />
+        <span className="skill-name">{name}</span>
+      </label>
+
+      <span className={`skill-badge ${typeBadgeClass}`}>{type}</span>
+
+      {isParagon && onLevelChange ? (
+        <div className="skill-level-input">
+          <span className="skill-level-label">Lv</span>
+          <StatInput
+            value={displayLevel}
+            onChange={onLevelChange}
+            min={0}
+            step={1}
+            disabled={!enabled}
+            placeholder="0"
+          />
+        </div>
+      ) : (
+        <span className="skill-level">Lv {displayLevel}</span>
+      )}
+
+      {statId && onValueChange && (
+        <div className="skill-value-input">
+          <StatInput
+            value={userValue || 0}
+            onChange={onValueChange}
+            min={0}
+            step={1}
+            isPercent
+            disabled={!enabled}
+            placeholder="0"
+          />
+          <span className="skill-stat-id">{statId}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/skilltree/SkillRow.jsx
+++ b/src/components/skilltree/SkillRow.jsx
@@ -10,6 +10,7 @@ import { StatInput } from '../character/StatInput';
  * @param {string} props.type - Skill type badge (ability, stat, buff, paragon, utility)
  * @param {string} [props.statId] - Stat this skill contributes to
  * @param {boolean} [props.perLevel] - Whether value scales with level
+ * @param {boolean} [props.isPercent] - Whether stat value is a percentage (vs flat)
  * @param {boolean} props.enabled - Whether skill is active
  * @param {Function} props.onToggle - Toggle enabled state
  * @param {number} [props.userValue] - User-entered stat value
@@ -23,6 +24,7 @@ export function SkillRow({
   type,
   statId,
   perLevel,
+  isPercent = true,
   enabled,
   onToggle,
   userValue,
@@ -76,8 +78,8 @@ export function SkillRow({
             value={userValue || 0}
             onChange={onValueChange}
             min={0}
-            step={1}
-            isPercent
+            step={isPercent ? 1 : 10}
+            isPercent={isPercent}
             disabled={!enabled}
             placeholder="0"
           />

--- a/src/components/skilltree/SkillTreeTab.css
+++ b/src/components/skilltree/SkillTreeTab.css
@@ -1,0 +1,341 @@
+/* Skill Tree Tab Styles */
+
+.skilltree-empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-secondary);
+}
+
+.skilltree-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.skilltree-meta {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.skilltree-meta-item {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.skilltree-meta-item strong {
+  color: var(--text-primary);
+}
+
+.skilltree-reset-btn {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+}
+
+/* Sections */
+.skill-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.skill-section-header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.skill-section-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.skill-section-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+/* Keystone Checklist */
+.keystone-grid {
+  padding: 0.75rem 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.keystone-category {
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.keystone-category-label {
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.5px;
+}
+
+.keystone-item {
+  margin-bottom: 0.5rem;
+}
+
+.keystone-item:last-child {
+  margin-bottom: 0;
+}
+
+.keystone-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.keystone-toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.keystone-name {
+  color: var(--text-primary);
+}
+
+.keystone-overlap-badge {
+  font-size: 0.65rem;
+  background: var(--warning);
+  color: #000;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.keystone-desc {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-left: 1.5rem;
+  margin-top: 0.15rem;
+}
+
+.keystone-value-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 1.5rem;
+  margin-top: 0.35rem;
+}
+
+/* Weapon / Crafting Groups */
+.weapon-group {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.weapon-group:last-child {
+  border-bottom: none;
+}
+
+.weapon-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.weapon-group-header:hover {
+  background: var(--bg-tertiary);
+}
+
+.collapse-icon {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  width: 1rem;
+}
+
+.weapon-label {
+  font-weight: 600;
+}
+
+.weapon-count {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.weapon-xp {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+
+.weapon-skills-list {
+  padding: 0 0.5rem 0.5rem;
+}
+
+/* Individual Skill Row */
+.skill-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+}
+
+.skill-row:hover {
+  background: var(--bg-tertiary);
+}
+
+.skill-row-disabled {
+  opacity: 0.5;
+}
+
+.skill-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  min-width: 0;
+  flex: 1;
+}
+
+.skill-toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.skill-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.skill-badge {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.skill-badge-ability {
+  background: #7c3aed;
+  color: #fff;
+}
+
+.skill-badge-stat {
+  background: #2563eb;
+  color: #fff;
+}
+
+.skill-badge-buff {
+  background: var(--success);
+  color: #fff;
+}
+
+.skill-badge-paragon {
+  background: var(--warning);
+  color: #000;
+}
+
+.skill-badge-utility {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.skill-level {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+  min-width: 3rem;
+}
+
+.skill-level-input {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.skill-level-label {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.skill-value-input {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.skill-stat-id {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-style: italic;
+}
+
+/* Cards Grid */
+.cards-grid {
+  padding: 0.75rem 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+.card-item {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.card-name {
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.card-level {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .keystone-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .skill-row {
+    flex-wrap: wrap;
+  }
+
+  .skill-value-input {
+    margin-left: 1.5rem;
+    margin-top: 0.25rem;
+    width: 100%;
+  }
+}

--- a/src/components/skilltree/SkillTreeTab.jsx
+++ b/src/components/skilltree/SkillTreeTab.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { KeystoneChecklist } from './KeystoneChecklist';
+import { WeaponSkillsSection } from './WeaponSkillsSection';
+import { CraftingSkillsSection } from './CraftingSkillsSection';
+import { CardsSection } from './CardsSection';
+import { countMainNodeTypes } from '../../models/SkillTree';
+import './SkillTreeTab.css';
+
+/**
+ * Skill Tree tab - displays auto-detected skills and manual keystone checklist
+ *
+ * @param {Object} props
+ * @param {Object} props.skillTreeStore - From useSkillTreeStore
+ * @param {Object} props.saveData - Raw save data (for reference)
+ * @param {Function} props.onLog - Logging callback
+ */
+export function SkillTreeTab({ skillTreeStore, saveData, onLog }) {
+  const {
+    skillTreeData,
+    keystoneSelections,
+    skillOverrides,
+    skillValues,
+    toggleKeystone,
+    overrideSkill,
+    setSkillValue,
+    resetOverrides,
+    isSkillEnabled,
+    getEffectiveLevel,
+  } = skillTreeStore;
+
+  if (!skillTreeData) {
+    return (
+      <div className="tab-content active">
+        <div className="skilltree-empty">No skill tree data available.</div>
+      </div>
+    );
+  }
+
+  const { metadata } = skillTreeData;
+  const mainNodeCounts = countMainNodeTypes(skillTreeData);
+
+  return (
+    <div className="tab-content active">
+      {/* Header with metadata */}
+      <div className="skilltree-header">
+        <div className="skilltree-meta">
+          <span className="skilltree-meta-item">
+            <strong>{metadata.totalNodes}</strong> total nodes
+          </span>
+          <span className="skilltree-meta-item">
+            <strong>{metadata.skillPoints}</strong> skill points
+          </span>
+          <span className="skilltree-meta-item">
+            <strong>{metadata.elvenCounter}</strong> elven counter
+          </span>
+        </div>
+        <button className="btn skilltree-reset-btn" onClick={resetOverrides}>
+          Reset All
+        </button>
+      </div>
+
+      {/* Main tree summary (opaque IDs, count only) */}
+      <div className="skill-section">
+        <div className="skill-section-header">
+          <span className="skill-section-title">Main Passive Tree</span>
+          <span className="skill-section-subtitle">
+            {skillTreeData.mainTree.length} nodes ({mainNodeCounts.small} small, {mainNodeCounts.large} large, {mainNodeCounts.dropdown} dropdown)
+          </span>
+        </div>
+      </div>
+
+      {/* Keystones - manual checklist */}
+      <KeystoneChecklist
+        selections={keystoneSelections}
+        onToggle={toggleKeystone}
+        skillValues={skillValues}
+        onValueChange={setSkillValue}
+      />
+
+      {/* Weapon stances - auto-detected */}
+      <WeaponSkillsSection
+        weaponStances={skillTreeData.weaponStances}
+        skillOverrides={skillOverrides}
+        onOverride={overrideSkill}
+        skillValues={skillValues}
+        onValueChange={setSkillValue}
+        isSkillEnabled={isSkillEnabled}
+        getEffectiveLevel={getEffectiveLevel}
+      />
+
+      {/* Crafting/Elven - auto-detected */}
+      <CraftingSkillsSection
+        crafting={skillTreeData.crafting}
+        skillOverrides={skillOverrides}
+        onOverride={overrideSkill}
+        skillValues={skillValues}
+        onValueChange={setSkillValue}
+        isSkillEnabled={isSkillEnabled}
+        getEffectiveLevel={getEffectiveLevel}
+      />
+
+      {/* Cards - visual only */}
+      <CardsSection
+        cards={skillTreeData.cards}
+        skillTreeData={skillTreeData}
+      />
+    </div>
+  );
+}

--- a/src/components/skilltree/WeaponSkillsSection.jsx
+++ b/src/components/skilltree/WeaponSkillsSection.jsx
@@ -1,0 +1,115 @@
+import React, { useState, useCallback } from 'react';
+import { SkillRow } from './SkillRow';
+import { getWeaponSkillDef } from '../../utils/skillTreeRegistry';
+import { WEAPON_TYPE } from '../../models/SkillTree';
+
+const WEAPON_LABELS = {
+  [WEAPON_TYPE.SPEAR]: 'Spear',
+  [WEAPON_TYPE.MAULS]: 'Mauls',
+  [WEAPON_TYPE.ONE_HAND]: 'One-Hand',
+  [WEAPON_TYPE.TWO_HAND]: 'Two-Hand',
+  [WEAPON_TYPE.ARCHERY]: 'Archery',
+  [WEAPON_TYPE.MAGERY]: 'Magery',
+  [WEAPON_TYPE.SCYTHE]: 'Scythe',
+  [WEAPON_TYPE.UNARMED]: 'Unarmed',
+};
+
+/**
+ * Collapsible weapon stance skills grouped by weapon type
+ *
+ * @param {Object} props
+ * @param {Object} props.weaponStances - { [weaponType]: WeaponStanceData }
+ * @param {Object} props.skillOverrides - { [rowName]: { enabled, level } }
+ * @param {Function} props.onOverride - (rowName, override) => void
+ * @param {Object} props.skillValues - { [rowName]: number }
+ * @param {Function} props.onValueChange - (rowName, value) => void
+ * @param {Function} props.isSkillEnabled - (rowName) => boolean
+ * @param {Function} props.getEffectiveLevel - (rowName, saveLevel) => number
+ */
+export function WeaponSkillsSection({
+  weaponStances,
+  skillOverrides,
+  onOverride,
+  skillValues,
+  onValueChange,
+  isSkillEnabled,
+  getEffectiveLevel,
+}) {
+  const [collapsed, setCollapsed] = useState({});
+
+  const toggleCollapse = useCallback((weaponType) => {
+    setCollapsed(prev => ({ ...prev, [weaponType]: !prev[weaponType] }));
+  }, []);
+
+  if (!weaponStances) return null;
+
+  // Only show weapon types with allocated skills
+  const activeStances = Object.entries(weaponStances)
+    .filter(([, data]) => data.skills.length > 0)
+    .sort(([, a], [, b]) => b.skills.length - a.skills.length);
+
+  if (activeStances.length === 0) return null;
+
+  return (
+    <div className="skill-section">
+      <div className="skill-section-header">
+        <span className="skill-section-title">Weapon Stances</span>
+        <span className="skill-section-subtitle">Auto-detected from save</span>
+      </div>
+
+      {activeStances.map(([weaponType, stanceData]) => {
+        const isCollapsed = collapsed[weaponType];
+        const label = WEAPON_LABELS[weaponType] || weaponType;
+
+        return (
+          <div key={weaponType} className="weapon-group">
+            <button
+              className="weapon-group-header"
+              onClick={() => toggleCollapse(weaponType)}
+            >
+              <span className="collapse-icon">{isCollapsed ? '▶' : '▼'}</span>
+              <span className="weapon-label">{label}</span>
+              <span className="weapon-count">{stanceData.skills.length} skills</span>
+              {stanceData.xp > 0 && (
+                <span className="weapon-xp">XP: {stanceData.xp.toLocaleString()}</span>
+              )}
+            </button>
+
+            {!isCollapsed && (
+              <div className="weapon-skills-list">
+                {stanceData.skills.map(skill => {
+                  const def = getWeaponSkillDef(skill.rowName);
+                  const name = def?.name || skill.rowName;
+                  const type = def?.type || 'stat';
+                  const statId = def?.statId;
+                  const perLevel = def?.perLevel;
+                  const enabled = isSkillEnabled(skill.rowName);
+                  const effectiveLevel = getEffectiveLevel(skill.rowName, skill.level);
+
+                  return (
+                    <SkillRow
+                      key={skill.rowName}
+                      name={name}
+                      level={skill.level}
+                      type={type}
+                      statId={statId}
+                      perLevel={perLevel}
+                      enabled={enabled}
+                      onToggle={() => onOverride(skill.rowName, { enabled: !enabled })}
+                      userValue={skillValues[skill.rowName]}
+                      onValueChange={statId ? (v) => onValueChange(skill.rowName, v) : undefined}
+                      effectiveLevel={type === 'paragon' ? effectiveLevel : undefined}
+                      onLevelChange={type === 'paragon'
+                        ? (v) => onOverride(skill.rowName, { level: v })
+                        : undefined}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/skilltree/WeaponSkillsSection.jsx
+++ b/src/components/skilltree/WeaponSkillsSection.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { SkillRow } from './SkillRow';
 import { getWeaponSkillDef } from '../../utils/skillTreeRegistry';
+import { STAT_REGISTRY } from '../../utils/statRegistry';
 import { WEAPON_TYPE } from '../../models/SkillTree';
 
 const WEAPON_LABELS = {
@@ -83,6 +84,7 @@ export function WeaponSkillsSection({
                   const type = def?.type || 'stat';
                   const statId = def?.statId;
                   const perLevel = def?.perLevel;
+                  const statIsPercent = statId ? (STAT_REGISTRY[statId]?.isPercent ?? true) : true;
                   const enabled = isSkillEnabled(skill.rowName);
                   const effectiveLevel = getEffectiveLevel(skill.rowName, skill.level);
 
@@ -94,6 +96,7 @@ export function WeaponSkillsSection({
                       type={type}
                       statId={statId}
                       perLevel={perLevel}
+                      isPercent={statIsPercent}
                       enabled={enabled}
                       onToggle={() => onOverride(skill.rowName, { enabled: !enabled })}
                       userValue={skillValues[skill.rowName]}

--- a/src/components/skilltree/index.js
+++ b/src/components/skilltree/index.js
@@ -1,0 +1,1 @@
+export { SkillTreeTab } from './SkillTreeTab';

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -21,7 +21,7 @@ export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
  * @returns {Object} Aggregated and calculated stats
  */
 export function useDerivedStats(options = {}) {
-  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null } = options;
+  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, skillTreeStats = {}, skillTreeConfigOverrides = {} } = options;
 
   // Aggregate base stats from all equipped items WITH source tracking
   // Returns { [statId]: { total: number, sources: [{ itemName, slot, value }] } }
@@ -36,6 +36,18 @@ export function useDerivedStats(options = {}) {
         total: value,
         sources: [{ itemName: sourceName, slot: 'base', value }],
       };
+    }
+
+    // Merge skill tree stats (from useSkillTreeStore)
+    for (const [statId, data] of Object.entries(skillTreeStats)) {
+      if (!data || !data.total) continue;
+      if (!stats[statId]) {
+        stats[statId] = { total: 0, sources: [] };
+      }
+      stats[statId].total += data.total;
+      if (data.sources) {
+        stats[statId].sources.push(...data.sources);
+      }
     }
 
     // Active stance mastery defaults: +1% stance-specific damage per mastery level
@@ -103,7 +115,7 @@ export function useDerivedStats(options = {}) {
     }
 
     return stats;
-  }, [equippedItems, itemOverrides, characterStats, stanceContext]);
+  }, [equippedItems, itemOverrides, characterStats, stanceContext, skillTreeStats]);
 
   // Flatten to simple { [statId]: total } for backward compatibility
   const aggregatedBaseStats = useMemo(() => {
@@ -227,15 +239,23 @@ export function useDerivedStats(options = {}) {
     return null;
   }, [equippedItems]);
 
-  // Merge stance detection into config overrides for eDPS
+  // Merge stance detection and skill tree overrides into config overrides for eDPS
   const finalConfigOverrides = useMemo(() => {
-    if (!detectedStance) return configOverrides;
-    return {
-      ...configOverrides,
-      edpsAdditiveMulti: { stance: detectedStance },
-      edpsSCHD: { stance: detectedStance },
-    };
-  }, [configOverrides, detectedStance]);
+    const merged = { ...configOverrides };
+
+    // Merge skill tree config overrides (additive with monogram configs)
+    for (const [statId, config] of Object.entries(skillTreeConfigOverrides)) {
+      merged[statId] = { ...merged[statId], ...config };
+    }
+
+    // Merge stance detection
+    if (detectedStance) {
+      merged.edpsAdditiveMulti = { ...merged.edpsAdditiveMulti, stance: detectedStance };
+      merged.edpsSCHD = { ...merged.edpsSCHD, stance: detectedStance };
+    }
+
+    return merged;
+  }, [configOverrides, detectedStance, skillTreeConfigOverrides]);
 
   // Calculate all derived stats
   const calculatedStats = useMemo(() => {

--- a/src/hooks/useSkillTreeStore.js
+++ b/src/hooks/useSkillTreeStore.js
@@ -1,0 +1,246 @@
+import { useState, useCallback, useMemo } from 'react';
+import { extractSkillTree } from '../utils/skillTreeParser';
+import {
+  getWeaponSkillDef,
+  getCraftingSkillDef,
+  TREE_KEYSTONES,
+} from '../utils/skillTreeRegistry';
+
+/**
+ * Central store for skill tree data with override support
+ *
+ * Manages auto-detected skills from save files, manual keystone selections,
+ * and user-entered stat values. Computes effective stats and config overrides
+ * for integration with the derived stats calculation engine.
+ *
+ * @returns {Object} Skill tree store state and methods
+ */
+export function useSkillTreeStore() {
+  // Parsed skill tree data from save file
+  const [skillTreeData, setSkillTreeData] = useState(null);
+
+  // Manual keystone selections: { [keystoneId]: boolean }
+  const [keystoneSelections, setKeystoneSelections] = useState({});
+
+  // Per-skill overrides: { [rowName]: { enabled: boolean, level?: number } }
+  const [skillOverrides, setSkillOverrides] = useState({});
+
+  // User-entered stat values: { [rowName]: number }
+  const [skillValues, setSkillValuesState] = useState({});
+
+  /**
+   * Load skill tree from parsed save data
+   */
+  const loadFromSave = useCallback((saveJson) => {
+    const data = extractSkillTree(saveJson);
+    setSkillTreeData(data);
+    // Reset user state on new load
+    setKeystoneSelections({});
+    setSkillOverrides({});
+    setSkillValuesState({});
+  }, []);
+
+  /**
+   * Clear all skill tree state
+   */
+  const clear = useCallback(() => {
+    setSkillTreeData(null);
+    setKeystoneSelections({});
+    setSkillOverrides({});
+    setSkillValuesState({});
+  }, []);
+
+  /**
+   * Toggle a keystone selection
+   */
+  const toggleKeystone = useCallback((keystoneId) => {
+    setKeystoneSelections(prev => ({
+      ...prev,
+      [keystoneId]: !prev[keystoneId],
+    }));
+  }, []);
+
+  /**
+   * Override a skill's enabled state or level
+   */
+  const overrideSkill = useCallback((rowName, override) => {
+    setSkillOverrides(prev => ({
+      ...prev,
+      [rowName]: { ...prev[rowName], ...override },
+    }));
+  }, []);
+
+  /**
+   * Set the numeric stat value for a skill
+   */
+  const setSkillValue = useCallback((rowName, value) => {
+    setSkillValuesState(prev => ({
+      ...prev,
+      [rowName]: value,
+    }));
+  }, []);
+
+  /**
+   * Reset all user overrides and values
+   */
+  const resetOverrides = useCallback(() => {
+    setSkillOverrides({});
+    setSkillValuesState({});
+    setKeystoneSelections({});
+  }, []);
+
+  const isLoaded = skillTreeData !== null;
+
+  /**
+   * Check if a skill is effectively enabled
+   * Default: enabled if present in save data
+   */
+  const isSkillEnabled = useCallback((rowName) => {
+    const override = skillOverrides[rowName];
+    if (override && override.enabled !== undefined) return override.enabled;
+    return true; // default: enabled if in save
+  }, [skillOverrides]);
+
+  /**
+   * Get effective level for a skill (override or save level)
+   */
+  const getEffectiveLevel = useCallback((rowName, saveLevel) => {
+    const override = skillOverrides[rowName];
+    if (override && override.level !== undefined) return override.level;
+    return saveLevel;
+  }, [skillOverrides]);
+
+  /**
+   * Aggregate stats from all active skills with user-entered values
+   * Returns { [statId]: { total: number, sources: [] } } for useDerivedStats
+   */
+  const effectiveSkillStats = useMemo(() => {
+    if (!skillTreeData) return {};
+
+    const stats = {};
+
+    const addStat = (statId, value, sourceName) => {
+      if (!statId || !value) return;
+      if (!stats[statId]) {
+        stats[statId] = { total: 0, sources: [] };
+      }
+      stats[statId].total += value;
+      stats[statId].sources.push({
+        itemName: sourceName,
+        slot: 'skillTree',
+        value,
+      });
+    };
+
+    // Process weapon stance skills
+    for (const [, stanceData] of Object.entries(skillTreeData.weaponStances)) {
+      for (const skill of stanceData.skills) {
+        if (!isSkillEnabled(skill.rowName)) continue;
+
+        const def = getWeaponSkillDef(skill.rowName);
+        if (!def || !def.statId) continue;
+
+        const userValue = skillValues[skill.rowName];
+        if (userValue === undefined || userValue === 0) continue;
+
+        const level = getEffectiveLevel(skill.rowName, skill.level);
+        const value = def.perLevel ? userValue * level : userValue;
+        addStat(def.statId, value, def.name);
+      }
+    }
+
+    // Process crafting skills
+    for (const skill of skillTreeData.crafting) {
+      if (!isSkillEnabled(skill.rowName)) continue;
+
+      const def = getCraftingSkillDef(skill.rowName);
+      if (!def || !def.statId) continue;
+
+      const userValue = skillValues[skill.rowName];
+      if (userValue === undefined || userValue === 0) continue;
+
+      const level = getEffectiveLevel(skill.rowName, skill.level);
+      const value = def.paragon ? userValue * level : userValue;
+      addStat(def.statId, value, def.name);
+    }
+
+    // Process keystone selections with statIds
+    for (const [keystoneId, selected] of Object.entries(keystoneSelections)) {
+      if (!selected) continue;
+      const keystone = TREE_KEYSTONES[keystoneId];
+      if (!keystone || !keystone.statId) continue;
+
+      const userValue = skillValues[keystoneId];
+      if (userValue === undefined || userValue === 0) continue;
+
+      addStat(keystone.statId, userValue, keystone.name);
+    }
+
+    return stats;
+  }, [skillTreeData, skillOverrides, skillValues, keystoneSelections, isSkillEnabled, getEffectiveLevel]);
+
+  /**
+   * Build config overrides from keystone selections for derived stats
+   * Maps keystones to eDPS config overrides
+   */
+  const skillConfigOverrides = useMemo(() => {
+    const overrides = {};
+
+    // Affinity damage keystones → edpsAD affinityDamage
+    const affinityDamageKeystones = ['fireAffinityDamage', 'arcaneAffinityDamage', 'lightningAffinityDamage'];
+    let totalAffinityDamage = 0;
+    for (const id of affinityDamageKeystones) {
+      if (keystoneSelections[id]) {
+        // Default ~100% additive per affinity, or use user value
+        totalAffinityDamage += skillValues[id] || 1.0;
+      }
+    }
+    if (totalAffinityDamage > 0) {
+      overrides.edpsAD = {
+        ...(overrides.edpsAD || {}),
+        affinityDamage: totalAffinityDamage,
+      };
+    }
+
+    // Proximity keystones → edpsEMulti distanceProcs
+    if (keystoneSelections.closeDistance) {
+      overrides.edpsEMulti = {
+        ...(overrides.edpsEMulti || {}),
+        closeDistanceKeystone: true,
+      };
+    }
+    if (keystoneSelections.farDistance) {
+      overrides.edpsEMulti = {
+        ...(overrides.edpsEMulti || {}),
+        farDistanceKeystone: true,
+      };
+    }
+
+    return overrides;
+  }, [keystoneSelections, skillValues]);
+
+  return {
+    // State
+    skillTreeData,
+    keystoneSelections,
+    skillOverrides,
+    skillValues,
+    isLoaded,
+
+    // Computed
+    effectiveSkillStats,
+    skillConfigOverrides,
+
+    // Actions
+    loadFromSave,
+    clear,
+    toggleKeystone,
+    overrideSkill,
+    setSkillValue,
+    resetOverrides,
+    isSkillEnabled,
+    getEffectiveLevel,
+  };
+}
+
+export default useSkillTreeStore;

--- a/test/useSkillTreeStore.test.js
+++ b/test/useSkillTreeStore.test.js
@@ -5,6 +5,7 @@ import {
   getCraftingSkillDef,
   TREE_KEYSTONES,
 } from '../src/utils/skillTreeRegistry.js';
+import { STAT_REGISTRY } from '../src/utils/statRegistry.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -172,6 +173,38 @@ describe('useSkillTreeStore logic', () => {
 
       expect(stats.health).toBeDefined();
       expect(stats.health.total).toBeCloseTo(0.05);
+    });
+
+    it('handles flat value crafting skills (health is flat, not percent)', () => {
+      // health in STAT_REGISTRY has isPercent: false
+      expect(STAT_REGISTRY.health.isPercent).toBe(false);
+      // Armor_Health_Low maps to 'health' — a flat stat
+      const skillValues = { 'Armor_Health_Low': 500 }; // flat value, not percent
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.health.total).toBe(500);
+    });
+
+    it('handles percent value weapon skills (spearDamage is percent)', () => {
+      // spearDamage in STAT_REGISTRY has isPercent: true
+      expect(STAT_REGISTRY.spearDamage.isPercent).toBe(true);
+      // SpearMediumDmg maps to 'spearDamage' — a percent stat
+      const skillValues = { 'SpearMediumDmg': 0.15 }; // stored as decimal
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.spearDamage.total).toBeCloseTo(0.15);
+    });
+
+    it('handles mixed flat and percent stats from different skills', () => {
+      const skillValues = {
+        'Damage_Bonus1_Bot': 100,      // damage is flat (isPercent: false)
+        'SpearMediumDmg': 0.15,        // spearDamage is percent (isPercent: true)
+      };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      // Both should be present with correct values
+      expect(stats.damage?.total).toBe(100);
+      expect(stats.spearDamage?.total).toBeCloseTo(0.15);
     });
 
     it('aggregates keystone stat with user value', () => {

--- a/test/useSkillTreeStore.test.js
+++ b/test/useSkillTreeStore.test.js
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { extractSkillTree } from '../src/utils/skillTreeParser.js';
+import {
+  getWeaponSkillDef,
+  getCraftingSkillDef,
+  TREE_KEYSTONES,
+} from '../src/utils/skillTreeRegistry.js';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Tests for skill tree store logic.
+ * Since useSkillTreeStore is a React hook, we test the core computation
+ * logic that the hook's useMemo depends on, using the same algorithm.
+ */
+
+let skillsFixture;
+let skillTreeData;
+
+beforeAll(() => {
+  const fixturePath = path.join(import.meta.dirname, 'fixtures', 'dr-character-skills.json');
+  skillsFixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  skillTreeData = extractSkillTree(skillsFixture);
+});
+
+// Replicate the effectiveSkillStats computation from useSkillTreeStore
+function computeEffectiveStats(skillTreeData, skillOverrides, skillValues, keystoneSelections) {
+  const stats = {};
+
+  const isEnabled = (rowName) => {
+    const override = skillOverrides[rowName];
+    if (override && override.enabled !== undefined) return override.enabled;
+    return true;
+  };
+
+  const getLevel = (rowName, saveLevel) => {
+    const override = skillOverrides[rowName];
+    if (override && override.level !== undefined) return override.level;
+    return saveLevel;
+  };
+
+  const addStat = (statId, value, sourceName) => {
+    if (!statId || !value) return;
+    if (!stats[statId]) stats[statId] = { total: 0, sources: [] };
+    stats[statId].total += value;
+    stats[statId].sources.push({ itemName: sourceName, slot: 'skillTree', value });
+  };
+
+  // Weapon skills
+  for (const stanceData of Object.values(skillTreeData.weaponStances)) {
+    for (const skill of stanceData.skills) {
+      if (!isEnabled(skill.rowName)) continue;
+      const def = getWeaponSkillDef(skill.rowName);
+      if (!def || !def.statId) continue;
+      const userValue = skillValues[skill.rowName];
+      if (userValue === undefined || userValue === 0) continue;
+      const level = getLevel(skill.rowName, skill.level);
+      const value = def.perLevel ? userValue * level : userValue;
+      addStat(def.statId, value, def.name);
+    }
+  }
+
+  // Crafting skills
+  for (const skill of skillTreeData.crafting) {
+    if (!isEnabled(skill.rowName)) continue;
+    const def = getCraftingSkillDef(skill.rowName);
+    if (!def || !def.statId) continue;
+    const userValue = skillValues[skill.rowName];
+    if (userValue === undefined || userValue === 0) continue;
+    const level = getLevel(skill.rowName, skill.level);
+    const value = def.paragon ? userValue * level : userValue;
+    addStat(def.statId, value, def.name);
+  }
+
+  // Keystones
+  for (const [keystoneId, selected] of Object.entries(keystoneSelections)) {
+    if (!selected) continue;
+    const keystone = TREE_KEYSTONES[keystoneId];
+    if (!keystone || !keystone.statId) continue;
+    const userValue = skillValues[keystoneId];
+    if (userValue === undefined || userValue === 0) continue;
+    addStat(keystone.statId, userValue, keystone.name);
+  }
+
+  return stats;
+}
+
+// Replicate skillConfigOverrides computation
+function computeConfigOverrides(keystoneSelections, skillValues) {
+  const overrides = {};
+
+  const affinityDamageKeystones = ['fireAffinityDamage', 'arcaneAffinityDamage', 'lightningAffinityDamage'];
+  let totalAffinityDamage = 0;
+  for (const id of affinityDamageKeystones) {
+    if (keystoneSelections[id]) {
+      totalAffinityDamage += skillValues[id] || 1.0;
+    }
+  }
+  if (totalAffinityDamage > 0) {
+    overrides.edpsAD = { affinityDamage: totalAffinityDamage };
+  }
+
+  if (keystoneSelections.closeDistance) {
+    overrides.edpsEMulti = { ...(overrides.edpsEMulti || {}), closeDistanceKeystone: true };
+  }
+  if (keystoneSelections.farDistance) {
+    overrides.edpsEMulti = { ...(overrides.edpsEMulti || {}), farDistanceKeystone: true };
+  }
+
+  return overrides;
+}
+
+describe('useSkillTreeStore logic', () => {
+  describe('effectiveSkillStats', () => {
+    it('returns empty stats when no values are entered', () => {
+      const stats = computeEffectiveStats(skillTreeData, {}, {}, {});
+      expect(Object.keys(stats)).toHaveLength(0);
+    });
+
+    it('aggregates weapon skill stat with user value', () => {
+      // SpearMediumDmg has statId: 'spearDamage'
+      const skillValues = { 'SpearMediumDmg': 0.15 };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.spearDamage).toBeDefined();
+      expect(stats.spearDamage.total).toBeCloseTo(0.15);
+      expect(stats.spearDamage.sources).toHaveLength(1);
+      expect(stats.spearDamage.sources[0].slot).toBe('skillTree');
+    });
+
+    it('multiplies paragon skill value by level', () => {
+      // SpearsDamage is paragon, perLevel=true, fixture level=5
+      const skillValues = { 'SpearsDamage': 0.01 }; // 1% per level
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.spearDamage).toBeDefined();
+      expect(stats.spearDamage.total).toBeCloseTo(0.05); // 1% * 5 levels
+    });
+
+    it('respects level override for paragon skills', () => {
+      const skillValues = { 'SpearsDamage': 0.01 };
+      const skillOverrides = { 'SpearsDamage': { level: 100 } };
+      const stats = computeEffectiveStats(skillTreeData, skillOverrides, skillValues, {});
+
+      expect(stats.spearDamage.total).toBeCloseTo(1.0); // 1% * 100 levels
+    });
+
+    it('excludes disabled skills', () => {
+      const skillValues = { 'SpearMediumDmg': 0.15 };
+      const skillOverrides = { 'SpearMediumDmg': { enabled: false } };
+      const stats = computeEffectiveStats(skillTreeData, skillOverrides, skillValues, {});
+
+      expect(stats.spearDamage).toBeUndefined();
+    });
+
+    it('aggregates multiple skills to same statId', () => {
+      // SpearMediumDmg and Spear_Damage_Buff both map to spearDamage
+      const skillValues = {
+        'SpearMediumDmg': 0.10,
+        'Spear_Damage_Buff': 0.20,
+      };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.spearDamage.total).toBeCloseTo(0.30);
+      expect(stats.spearDamage.sources).toHaveLength(2);
+    });
+
+    it('aggregates crafting skill with user value', () => {
+      // Armor_Health_Low has statId: 'health'
+      const skillValues = { 'Armor_Health_Low': 0.05 };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, {});
+
+      expect(stats.health).toBeDefined();
+      expect(stats.health.total).toBeCloseTo(0.05);
+    });
+
+    it('aggregates keystone stat with user value', () => {
+      // fireAffinityDamage has statId: 'fireDamageBonus'
+      const keystoneSelections = { fireAffinityDamage: true };
+      const skillValues = { fireAffinityDamage: 1.0 };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, keystoneSelections);
+
+      expect(stats.fireDamageBonus).toBeDefined();
+      expect(stats.fireDamageBonus.total).toBeCloseTo(1.0);
+    });
+
+    it('ignores unchecked keystones', () => {
+      const keystoneSelections = { fireAffinityDamage: false };
+      const skillValues = { fireAffinityDamage: 1.0 };
+      const stats = computeEffectiveStats(skillTreeData, {}, skillValues, keystoneSelections);
+
+      expect(stats.fireDamageBonus).toBeUndefined();
+    });
+  });
+
+  describe('skillConfigOverrides', () => {
+    it('returns empty overrides when no keystones selected', () => {
+      const overrides = computeConfigOverrides({}, {});
+      expect(Object.keys(overrides)).toHaveLength(0);
+    });
+
+    it('sets affinityDamage for single affinity keystone', () => {
+      const overrides = computeConfigOverrides({ fireAffinityDamage: true }, {});
+      expect(overrides.edpsAD).toBeDefined();
+      expect(overrides.edpsAD.affinityDamage).toBe(1.0); // default
+    });
+
+    it('sums affinityDamage for multiple affinities with custom values', () => {
+      const keystoneSelections = {
+        fireAffinityDamage: true,
+        arcaneAffinityDamage: true,
+      };
+      const skillValues = {
+        fireAffinityDamage: 0.8,
+        arcaneAffinityDamage: 1.2,
+      };
+      const overrides = computeConfigOverrides(keystoneSelections, skillValues);
+      expect(overrides.edpsAD.affinityDamage).toBeCloseTo(2.0);
+    });
+
+    it('sets distance keystone flags', () => {
+      const overrides = computeConfigOverrides({ closeDistance: true }, {});
+      expect(overrides.edpsEMulti).toBeDefined();
+      expect(overrides.edpsEMulti.closeDistanceKeystone).toBe(true);
+    });
+
+    it('sets both distance keystones', () => {
+      const overrides = computeConfigOverrides(
+        { closeDistance: true, farDistance: true },
+        {},
+      );
+      expect(overrides.edpsEMulti.closeDistanceKeystone).toBe(true);
+      expect(overrides.edpsEMulti.farDistanceKeystone).toBe(true);
+    });
+  });
+
+  describe('fixture data integrity', () => {
+    it('fixture has weapon skills with known statIds', () => {
+      let skillsWithStatId = 0;
+      for (const stanceData of Object.values(skillTreeData.weaponStances)) {
+        for (const skill of stanceData.skills) {
+          const def = getWeaponSkillDef(skill.rowName);
+          if (def?.statId) skillsWithStatId++;
+        }
+      }
+      // At least some weapon skills should have statIds
+      expect(skillsWithStatId).toBeGreaterThan(10);
+    });
+
+    it('fixture has crafting skills with known statIds', () => {
+      let skillsWithStatId = 0;
+      for (const skill of skillTreeData.crafting) {
+        const def = getCraftingSkillDef(skill.rowName);
+        if (def?.statId) skillsWithStatId++;
+      }
+      expect(skillsWithStatId).toBeGreaterThan(3);
+    });
+
+    it('PolearmDamage paragon has high level in fixture', () => {
+      const maulsSkills = skillTreeData.weaponStances.mauls.skills;
+      const paragon = maulsSkills.find(s => s.rowName === 'PolearmDamage');
+      expect(paragon).toBeDefined();
+      expect(paragon.level).toBe(732);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a complete Skill Tree tab to the character builder, enabling users to view auto-detected skills from save files and manually configure keystones, weapon stances, and crafting skills. Integrates skill tree stats into the derived stats calculation engine.

## Key Changes

### New Components
- **SkillTreeTab.jsx** – Main tab component displaying skill tree metadata, keystones, weapon stances, crafting skills, and crystal cards
- **KeystoneChecklist.jsx** – Manual checklist for main tree keystones grouped by category (proximity, mastery, affinity, utility) with stat value inputs
- **WeaponSkillsSection.jsx** – Collapsible weapon stance skills grouped by weapon type with level and value editing
- **CraftingSkillsSection.jsx** – Collapsible crafting/elven skills grouped by branch with level and value editing
- **SkillRow.jsx** – Reusable skill row component with toggle, badge, level display, and optional stat value input
- **CardsSection.jsx** – Crystal cards display (visual only, effects TBD)
- **SkillTreeTab.css** – Complete styling for skill tree UI (341 lines) with responsive grid layouts, collapsible sections, and badge variants

### State Management
- **useSkillTreeStore.js** – Central React hook managing:
  - Skill tree data from parsed save files
  - Manual keystone selections
  - Per-skill overrides (enabled state, level adjustments)
  - User-entered stat values
  - Computed effective stats aggregated from all sources
  - Config overrides for derived stats (affinity damage, proximity keystones)

### Integration
- **useDerivedStats.js** – Extended to accept `skillTreeStats` and `skillTreeConfigOverrides` parameters, merging skill tree contributions into final stat calculations
- **App.jsx** – Added SkillTreeTab to tab navigation and integrated useSkillTreeStore hook
- **CharacterTab.jsx** – Updated to pass skillTreeStore to derived stats calculations

### Testing
- **useSkillTreeStore.test.js** – Comprehensive test suite (299 lines) covering:
  - Effective stat computation from weapon/crafting skills and keystones
  - Level overrides and enabled/disabled skill filtering
  - Stat aggregation from multiple sources
  - Paragon skill level multiplication
  - Config override generation for affinity and proximity keystones
  - Flat vs. percent stat handling

### Documentation
- Updated CLAUDE.md with skill tree component structure and file locations

## Implementation Details

- **Auto-detection**: Weapon stances and crafting skills are automatically extracted from save files and displayed read-only with XP/level info
- **Manual keystones**: Main tree keystones require manual checkbox selection since they can't be auto-detected from save data
- **Stat aggregation**: Skills contribute to derived stats only when enabled and have user-entered values; paragon skills multiply by level
- **Config overrides**: Affinity damage keystones sum their values for eDPS calculations; proximity keystones toggle distance-based proc flags
- **Responsive design**: Grid layouts adapt to mobile screens; skill rows wrap value inputs on narrow viewports

https://claude.ai/code/session_01GoRqnUjSxx3Nj71jEW2NQZ