### PR TITLE
Fix tooltip affix display: percentage formatting and stance naming

### DIFF
--- a/src/utils/attributeDisplay.js
+++ b/src/utils/attributeDisplay.js
@@ -4,13 +4,14 @@
 // Display mappings are now generated from the unified stat registry.
 // To add new display names, update src/utils/statRegistry.js
 
-import { DISPLAY_MAP, warnUnknownAttribute } from './statRegistry.js';
+import { DISPLAY_MAP, FORMAT_MAP, warnUnknownAttribute } from './statRegistry.js';
 
 // Use the display map generated from the stat registry
 const ATTRIBUTE_DISPLAY_MAP = DISPLAY_MAP;
 
 // Pre-compute sorted patterns (longest first for better matching)
 const SORTED_PATTERNS = Object.keys(ATTRIBUTE_DISPLAY_MAP).sort((a, b) => b.length - a.length);
+const SORTED_FORMAT_PATTERNS = Object.keys(FORMAT_MAP).sort((a, b) => b.length - a.length);
 
 // Extract the most relevant part of an attribute name for fallback display
 function extractFallbackName(fullName) {
@@ -98,29 +99,48 @@ export function getDisplayName(attributeName) {
   return extractFallbackName(tail);
 }
 
+// Find the stat registry format function for an attribute name
+function findFormatFunction(attributeName) {
+  if (!attributeName) return null;
+
+  const tail = extractAttributeTail(attributeName);
+
+  // Try exact match on tail
+  if (FORMAT_MAP[tail]) return FORMAT_MAP[tail];
+
+  // Try pattern matching (longest first, same approach as getDisplayName)
+  for (const pattern of SORTED_FORMAT_PATTERNS) {
+    if (tail.endsWith(pattern)) return FORMAT_MAP[pattern];
+  }
+  for (const pattern of SORTED_FORMAT_PATTERNS) {
+    if (tail.includes(pattern)) return FORMAT_MAP[pattern];
+  }
+
+  return null;
+}
+
 // Format an attribute value for display
 export function formatAttributeValue(value, attributeName = '') {
   if (value === null || value === undefined) return '';
 
-  // If it's a percentage attribute, format with 1 decimal place
-  if (attributeName.includes('%') || attributeName.includes('Percent')) {
-    if (typeof value === 'number') {
-      // If value is between 0-1, treat as fraction and convert to percentage
+  if (typeof value === 'number') {
+    // Use stat registry format function if available (handles ability % stats
+    // like Death Blades, Electric Dragons that lack % in their raw tag)
+    const formatFn = findFormatFunction(attributeName);
+    if (formatFn) return formatFn(value);
+
+    // Fallback: percentage heuristic based on attribute name containing % or Percent
+    if (attributeName.includes('%') || attributeName.includes('Percent')) {
       if (value > 0 && value < 1) {
         return `${(value * 100).toFixed(1)}%`;
       }
-      // Otherwise it's already a percentage value
       return `${value.toFixed(1)}%`;
     }
-  }
 
-  // For regular numeric values
-  if (typeof value === 'number') {
-    // If it's a whole number, don't show decimals
+    // Regular numeric values
     if (Number.isInteger(value)) {
       return value.toString();
     }
-    // Otherwise show 1 decimal place
     return value.toFixed(1);
   }
 

--- a/src/utils/stanceSkills.js
+++ b/src/utils/stanceSkills.js
@@ -33,7 +33,7 @@ export const STANCE_DEFS = {
   },
   sword: {
     id: 'sword',
-    name: 'One-Handed',
+    name: 'Swords',
     skillKey: 'OneHandSkill',
     damageStatId: 'swordDamage',
     keystoneAbility: 'Shroud',

--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -546,7 +546,7 @@ export const STAT_REGISTRY = {
 
   swordDamage: {
     id: 'swordDamage',
-    name: 'One-Handed Damage',
+    name: 'Swords Damage',
     category: 'stance',
     patterns: [
       'Damage.OneHanded%6',
@@ -561,11 +561,11 @@ export const STAT_REGISTRY = {
     canonical: 'Damage.OneHanded%6',
     isPercent: true,
     format: v => `+${(v * 100).toFixed(0)}%`,
-    description: 'Sword/One-Handed damage bonus',
+    description: 'Swords damage bonus',
   },
   swordCritDamage: {
     id: 'swordCritDamage',
-    name: 'One-Handed Critical Damage',
+    name: 'Swords Critical Damage',
     category: 'stance',
     patterns: [
       'Damage.OneHandCritcalDamage%6',  // Game typo: "Critcal" not "Critical"
@@ -584,11 +584,11 @@ export const STAT_REGISTRY = {
     canonical: 'Damage.OneHandCritcalDamage%6',
     isPercent: true,
     format: v => `+${(v * 100).toFixed(0)}%`,
-    description: 'Sword critical damage bonus',
+    description: 'Swords critical damage bonus',
   },
   swordCritChance: {
     id: 'swordCritChance',
-    name: 'One-Handed Critical Chance',
+    name: 'Swords Critical Chance',
     category: 'stance',
     patterns: [
       'Damage.OneHandedCritcalChance%6',  // Game typo: "Critcal" not "Critical"
@@ -607,7 +607,7 @@ export const STAT_REGISTRY = {
     canonical: 'Damage.OneHandedCritcalChance%6',
     isPercent: true,
     format: v => `${(v * 100).toFixed(1)}%`,
-    description: 'Sword critical chance bonus',
+    description: 'Swords critical chance bonus',
   },
 
   spearDamage: {
@@ -631,7 +631,7 @@ export const STAT_REGISTRY = {
   },
   spearCritDamage: {
     id: 'spearCritDamage',
-    name: 'Polearm Critical Damage',
+    name: 'Spear Critical Damage',
     category: 'stance',
     patterns: [
       'Damage.SpearCritcalDamage%6',  // Game typo: "Critcal" not "Critical"
@@ -643,8 +643,6 @@ export const STAT_REGISTRY = {
       'SpearCriticalDamage%6',
       'SpearCriticalDamage%',
       'SpearCritDamage',
-      'Damage.Spear%6',
-      'Spear%',
     ],
     canonical: 'Damage.SpearCritcalDamage%6',
     isPercent: true,
@@ -653,7 +651,7 @@ export const STAT_REGISTRY = {
   },
   spearCritChance: {
     id: 'spearCritChance',
-    name: 'Polearm Critical Chance',
+    name: 'Spear Critical Chance',
     category: 'stance',
     patterns: [
       'Damage.SpearCritcalChance%6',  // Game typo: "Critcal" not "Critical"
@@ -1614,7 +1612,24 @@ export function warnUnknownAttribute(attributeName) {
   }
 }
 
+/**
+ * Generate pattern → format function map from registry
+ * Parallel to DISPLAY_MAP but for value formatting
+ */
+export function generateFormatMap() {
+  const formatMap = {};
+  for (const stat of Object.values(STAT_REGISTRY)) {
+    if (stat.format) {
+      for (const pattern of stat.patterns) {
+        formatMap[pattern] = stat.format;
+      }
+    }
+  }
+  return formatMap;
+}
+
 // Pre-generated exports for convenience
 export const STAT_DEFINITIONS = generateStatDefinitions();
 export const STAT_TYPES = generateStatTypes();
 export const DISPLAY_MAP = generateDisplayMap();
+export const FORMAT_MAP = generateFormatMap();


### PR DESCRIPTION
- Use stat registry format functions for tooltip value formatting instead
  of relying solely on '%' in attribute names. Fixes ability stats like
  Death Blades, Electric Dragons showing raw decimals (0.51) instead of
  percentages (51%).
- Rename "Polearm Critical Damage/Chance" to "Spear Critical Damage/Chance"
- Rename "One-Handed Damage/Crit Damage/Crit Chance" to "Swords ..."
- Update sword stance display name from "One-Handed" to "Swords"
- Remove overlapping patterns from spearCritDamage that collided with
  spearDamage in the display map

https://claude.ai/code/session_01N2KyEXGTo3SitCWcSBFBBf