### PR TITLE
Fix character share corruption: make STAT_DICT append-only again

### DIFF
--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -258,21 +258,6 @@ export const STAT_REGISTRY = {
     format: v => `+${(v * 100).toFixed(0)}%`,
     description: 'Damage Bonus',
   },
-  elementalDamage: {
-    id: 'elementalDamage',
-    name: 'Elemental Damage (Flat)',
-    category: 'offense',
-    patterns: [
-      'Base.ElementalDamage',
-      'ElementalDamage',
-    ],
-    canonical: 'Base.ElementalDamage',
-    isPercent: false,
-    format: v => `+${v.toFixed(0)}`,
-    description: 'Flat base elemental damage (split from physical Base.Damage)',
-    // Anchored so the generic `damage` regex (Damage$) can never claim this.
-    regexPatterns: ['ElementalDamage$', '\\.ElementalDamage$'],
-  },
   damageMultiplier: {
     id: 'damageMultiplier',
     name: 'Damage Multiplier',
@@ -1474,6 +1459,32 @@ export const STAT_REGISTRY = {
     format: v => `+${(v * 100).toFixed(0)}%`,
     description: 'Lightning Plasma damage multiplier',
     displayOnly: true,
+  },
+
+  // ---------------------------------------------------------------------------
+  // APPEND-ONLY ZONE
+  // shareCodec's STAT_DICT = Object.keys(STAT_REGISTRY), so registry order is the
+  // wire format for character share URLs. New stats MUST be appended here, never
+  // inserted mid-registry (that shifts every later index and corrupts old links).
+  // ---------------------------------------------------------------------------
+
+  // Flat base elemental damage (ele/phys split). Resolution relies on exact
+  // pattern match (which wins over the generic `damage` regex regardless of
+  // order), so appending here is safe for both decoding and stat resolution.
+  elementalDamage: {
+    id: 'elementalDamage',
+    name: 'Elemental Damage (Flat)',
+    category: 'offense',
+    patterns: [
+      'Base.ElementalDamage',
+      'ElementalDamage',
+    ],
+    canonical: 'Base.ElementalDamage',
+    isPercent: false,
+    format: v => `+${v.toFixed(0)}`,
+    description: 'Flat base elemental damage (split from physical Base.Damage)',
+    // Anchored so the generic `damage` regex (Damage$) can never claim this.
+    regexPatterns: ['ElementalDamage$', '\\.ElementalDamage$'],
   },
 };
 

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -65,6 +65,22 @@ describe('shareCodec', () => {
     expect(WEAPON_TYPE_DICT.length).toBeGreaterThan(0);
   });
 
+  it('STAT_DICT is append-only: legacy wire-format indices are pinned', () => {
+    // STAT_DICT = Object.keys(STAT_REGISTRY), so registry order IS the character
+    // share wire format. Inserting a stat mid-registry shifts every later index
+    // and corrupts previously-generated share links. These pins fail loudly if
+    // that ever happens again (regression: elementalDamage was inserted at 16,
+    // shifting armor 45→46 and mis-decoding old links).
+    expect(STAT_DICT[0]).toBe('strength');
+    expect(STAT_DICT[14]).toBe('damage');
+    expect(STAT_DICT[15]).toBe('damageBonus');
+    expect(STAT_DICT[45]).toBe('armor');
+    expect(STAT_DICT[78]).toBe('ferocityOfWolvesDamage');
+    // New stats must be appended after the historical ability block.
+    expect(STAT_DICT.indexOf('elementalDamage'))
+      .toBeGreaterThan(STAT_DICT.indexOf('lightningPlasmaDamage'));
+  });
+
   it('WEAPON_TYPE_DICT covers all STANCE_DEFS ids (no string fallback for any stance)', () => {
     // Previously used SkillTree.js WEAPON_TYPE values ('mauls', 'oneHand', 'archery', etc.)
     // which mismatched STANCE_DEFS ids ('maul', 'sword', 'bow', etc.), causing string fallback.


### PR DESCRIPTION
## Problem

Shared character links decoded to the **wrong stats/items** — flat values showing up on percent stats, so builds looked "x10'd" and mismatched. Example from a reported link: a helmet's `enc 45` (armor = 72) decoded as `twohandCritChance`, i.e. every stat at index ≥16 was shifted by one.

## Root cause

`shareCodec`'s `STAT_DICT = Object.keys(STAT_REGISTRY)`, so **registry order is the character-share wire format** and must be append-only (the file even says so). The ele/phys-split work inserted `elementalDamage` mid-registry (index 16, before `damageMultiplier`), bumping `armor` 45→46 and every later stat by +1. Links generated against the prior ordering then decode against a shifted table.

## Fix

- Move `elementalDamage` to the **end** of `STAT_REGISTRY`, restoring every legacy stat to its original index. Verified the reported link now decodes correctly (`armor=72`; the spear shows `damage` / `spearCritChance` / `spearCritDamage` / `spearDamage`).
- Stat resolution is unaffected — exact pattern match wins over the generic `Damage$` regex regardless of order, so the ele/phys split still works (`Base.ElementalDamage → elementalDamage`).
- Added an **APPEND-ONLY ZONE** comment in the registry.
- Added a regression test pinning legacy `STAT_DICT` indices (`strength=0`, `damage=14`, `damageBonus=15`, `armor=45`, `ferocityOfWolvesDamage=78`) and requiring new stats to sort after the ability block — any future mid-registry insert now fails CI loudly.

## Tests

237 pass; build clean.

## Note

The broken `elementalDamage`-at-16 ordering is currently live on gh-pages. Any link generated in that window (`armor=46`) will look shifted once this deploys, but those are dev-window links — this restores the contract-correct ordering that matches all older links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB)_