### PR TITLE
Share allocated attributes + fix 1% health-as-damage monogram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ Key monogram chains:
 - **Life Buff** (amulet, 100 stacks): +1% life per stack
 - **ElementForCritChance** (helmet): +3% element per 1% crit over 100%
 - **ElementalToHp%.Fire** (ring): +2% life per 30% fire damage
-- **GainDamageForHPLoseArmor** (bracer): +1% life as flat damage
+- **GainDamageForHPLoseArmor** (bracer): +1% of max Health as flat damage (both types; enables `damageFromHealth`, which feeds `edpsPhysFlat` + `edpsElemFlat`)
 
 ### Slot monogram pools
 Defined in `SLOT_MONOGRAMS` in `src/utils/monogramRegistry.js`:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
 import { parseShareFromHash, decodeFilterShare, decodeCharacterShare } from './utils/shareUrl';
-import { masteryShareToData } from './models/CharacterShareModel';
+import { masteryShareToData, allocatedAttributesShareToData } from './models/CharacterShareModel';
 
 const TABS = [
   { id: 'upload', label: 'Upload', icon: '📂' },
@@ -74,7 +74,8 @@ export default function App() {
       const decoded = decodeCharacterShare(parsed.data);
       if (decoded) {
         const masteryData = masteryShareToData(decoded.sk ?? null);
-        itemStore.loadFromShare(decoded.e ?? [], masteryData);
+        const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
+        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes);
         setActiveTab('character');
         log('Loaded shared character build');
       }

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -24,7 +24,8 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
   const handleShare = useCallback(async () => {
     const payload = createCharacterSharePayload(
       itemStore.equipped,
-      characterData?.stanceContext ?? null
+      characterData?.stanceContext ?? null,
+      itemStore.metadata?.allocatedAttributes ?? null
     );
     const url = buildCharacterShareUrl(payload);
     try {

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -66,8 +66,9 @@ export function useItemStore() {
    *
    * @param {import('../models/CharacterShareModel').EquippedItemShare[]} itemShares
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
+   * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
 
     setEquipped(equippedItems);
@@ -77,7 +78,7 @@ export function useItemStore() {
       filename: 'Shared Build',
       loadedAt: new Date().toISOString(),
       stanceContext: convertMasteryToStanceContext(masteryData),
-      allocatedAttributes: {},
+      allocatedAttributes: allocatedAttributes || {},
       sharedMastery: masteryData,
     });
   }, []);

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -54,6 +54,11 @@ export const CHARACTER_SHARE_VERSION = 1;
  * @property {number} v - Schema version
  * @property {EquippedItemShare[]} [e] - Equipped items (omitted if none)
  * @property {MasteryShare} [sk] - Mastery snapshot (omitted if none)
+ * @property {Array<[number|string, number]>} [at] - Allocated attribute points
+ *   [[statEnc, value], ...] (omitted if none). These are the character's base
+ *   attribute pool from the save's Attributes_21_* block — NOT on any item, so
+ *   without this a shared build under-counts totals (e.g. luck) and every
+ *   highestAttribute-driven derived stat.
  */
 
 // ---------------------------------------------------------------------------
@@ -118,13 +123,54 @@ export function createMasteryShare(stanceContext) {
 }
 
 /**
- * Build a full character share payload from equipped items and optional stanceContext.
+ * Convert the character's allocated attribute pool to compact share form.
+ * Input shape matches parseAllocatedAttributes(): { statId: { value, sourceName } }.
+ * Plain numeric values are also accepted.
+ *
+ * @param {Object<string, {value:number}|number>|null} allocatedAttributes
+ * @returns {Array<[number|string, number]>|null} [[statEnc, value], ...] or null if empty
+ */
+export function createAllocatedAttributesShare(allocatedAttributes) {
+  if (!allocatedAttributes) return null;
+  const entries = Object.entries(allocatedAttributes);
+  if (entries.length === 0) return null;
+
+  const out = [];
+  for (const [statId, raw] of entries) {
+    const value = typeof raw === 'number' ? raw : Number(raw?.value ?? 0);
+    if (!value) continue; // skip zeros to keep URLs short
+    out.push([encodeIdOrString(STAT_DICT, statId), value]);
+  }
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Reconstruct the allocated attribute pool from a decoded `at` array.
+ * Returns the same shape parseAllocatedAttributes() produces so it can be
+ * dropped straight into itemStore.metadata.allocatedAttributes.
+ *
+ * @param {Array<[number|string, number]>|null|undefined} at
+ * @returns {Object<string, {value:number, sourceName:string}>}
+ */
+export function allocatedAttributesShareToData(at) {
+  const result = {};
+  for (const [enc, value] of at || []) {
+    const statId = decodeIdOrString(STAT_DICT, enc) || String(enc);
+    result[statId] = { value: value ?? 0, sourceName: 'Allocated Points' };
+  }
+  return result;
+}
+
+/**
+ * Build a full character share payload from equipped items, optional
+ * stanceContext, and the character's allocated attribute pool.
  *
  * @param {import('./Item').Item[]} equippedItems
  * @param {{ activeStance: object }|null} [stanceContext]
+ * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -133,6 +179,9 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null)
 
   const mastery = createMasteryShare(stanceContext);
   if (mastery) payload.sk = mastery;
+
+  const at = createAllocatedAttributesShare(allocatedAttributes);
+  if (at) payload.at = at;
 
   return payload;
 }

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -222,16 +222,18 @@ export const DERIVED_STATS = {
     layer: LAYERS.PRIMARY_DERIVED,
     dependencies: ['totalHealth'],
     config: {
+      enabled: false, // gated by the "1% of max Health as damage" monogram
       sourceStat: 'totalHealth',
-      percentage: 1,  // 1% of health as damage
+      percentage: 1,  // 1% of max health as flat damage (both types)
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
+      if (!config.enabled) return 0;
       const source = stats[config.sourceStat] || 0;
       return Math.floor(source * (config.percentage / 100));
     },
     format: v => `+${v.toFixed(0)}`,
-    description: 'Flat damage gained from percentage of total health',
+    description: 'Flat damage from 1% of max health (both types; monogram-gated)',
   },
 
   /**

--- a/src/utils/monogramConfigs.js
+++ b/src/utils/monogramConfigs.js
@@ -133,12 +133,14 @@ export const MONOGRAM_CALC_CONFIGS = {
 
   // ===========================================================================
   // GAIN DAMAGE FOR HP LOSE ARMOR (Bracer Monogram)
-  // 1% of total life as flat damage
+  // Gain base Damage equal to 1% of max Health (both damage types).
+  // Feeds edpsPhysFlat + edpsElemFlat via damageFromHealth. (Previously wired
+  // to damageFromLife, which the flat pools never read — so it never populated.)
   // ===========================================================================
   'GainDamageForHPLoseArmor': {
-    displayName: 'Damage from Life',
+    displayName: 'Damage from Health',
     effects: [
-      { derivedStatId: 'damageFromLife', config: { enabled: true, lifePercent: 1 } },
+      { derivedStatId: 'damageFromHealth', config: { enabled: true, sourceStat: 'totalHealth', percentage: 1 } },
     ],
   },
 
@@ -709,6 +711,7 @@ export const MONOGRAM_CALC_CONFIGS = {
     displayName: 'Circle Damage from HP',
     derivedStatId: 'damageFromHealth',
     config: {
+      enabled: true,
       sourceStat: 'totalHealth',
       percentage: 1,
     },

--- a/src/utils/stanceSkills.js
+++ b/src/utils/stanceSkills.js
@@ -95,7 +95,11 @@ export const STANCE_KEYSTONE_BREAKPOINT = 5000;
 export const STANCE_MASTERY_STEP = 350;
 
 function findHostPlayerStruct(saveData) {
-  return saveData?.root?.properties?.HostPlayerData_0?.Struct?.Struct || null;
+  // WASM `to_json()` output is root-wrapped; some converters emit `properties`
+  // at the top level. Handle both so allocated attributes / stance data parse
+  // regardless of the save's outer shape.
+  const props = saveData?.root?.properties || saveData?.properties;
+  return props?.HostPlayerData_0?.Struct?.Struct || null;
 }
 
 export function inferWeaponStance(equippedItems = []) {

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -8,10 +8,13 @@ import {
   createItemShare,
   createMasteryShare,
   createCharacterSharePayload,
+  createAllocatedAttributesShare,
+  allocatedAttributesShareToData,
   itemShareToItem,
   masteryShareToData,
   CHARACTER_SHARE_VERSION,
 } from '../src/models/CharacterShareModel.js';
+import { calculateDerivedStats } from '../src/utils/derivedStats.js';
 import {
   encodeId, decodeId, encodeIdOrString, decodeIdOrString,
   STAT_DICT, MONOGRAM_DICT, KEYSTONE_DICT,
@@ -535,5 +538,67 @@ describe('CharacterShareModel — real-world fixture round-trip', () => {
     expect(encoded.length).toBeLessThan(8192);
     // Log actual size for visibility
     console.log(`Full build payload size: ${encoded.length} chars (${equipped.length} items)`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allocated attributes (base attribute pool) round-trip
+// ---------------------------------------------------------------------------
+describe('CharacterShareModel — allocated attributes', () => {
+  const allocated = {
+    luck: { value: 535, sourceName: 'Allocated Points' },
+    strength: { value: 420, sourceName: 'Allocated Points' },
+  };
+
+  it('createAllocatedAttributesShare compresses stat IDs and skips zeros', () => {
+    const at = createAllocatedAttributesShare({
+      ...allocated,
+      dexterity: { value: 0 }, // zero → skipped to keep URLs short
+    });
+    expect(at).toEqual([
+      [encodeIdOrString(STAT_DICT, 'luck'), 535],
+      [encodeIdOrString(STAT_DICT, 'strength'), 420],
+    ]);
+  });
+
+  it('returns null for empty / missing allocated attributes', () => {
+    expect(createAllocatedAttributesShare(null)).toBeNull();
+    expect(createAllocatedAttributesShare({})).toBeNull();
+    expect(createAllocatedAttributesShare({ luck: { value: 0 } })).toBeNull();
+  });
+
+  it('round-trips allocated attributes through the full payload + URL codec', () => {
+    const payload = createCharacterSharePayload([], null, allocated);
+    expect(payload.at).toBeTruthy();
+
+    const decoded = decodeCharacterShare(encodeCharacterShare(payload));
+    const restored = allocatedAttributesShareToData(decoded.at);
+
+    expect(restored.luck.value).toBe(535);
+    expect(restored.strength.value).toBe(420);
+    expect(restored.luck.sourceName).toBe('Allocated Points');
+  });
+
+  it('omits `at` when no allocated attributes are provided (backward compatible)', () => {
+    const payload = createCharacterSharePayload([], null, null);
+    expect(payload.at).toBeUndefined();
+    // Old links (no `at`) decode to an empty pool, not a crash.
+    expect(allocatedAttributesShareToData(undefined)).toEqual({});
+  });
+
+  it('feature parity: shared totals include the base pool (the luck-977 regression)', () => {
+    // Before this fix the share carried only gear (~100 luck); the allocated
+    // pool (~535) was dropped. Verify aggregating restored allocated + gear
+    // reproduces the in-game total under the same luckBonus.
+    const restored = allocatedAttributesShareToData(
+      createCharacterSharePayload([], null, allocated).at
+    );
+    const gearLuck = 60.94;   // sum of equipped luck affixes
+    const luckBonus = 0.6397; // sum of luckBonus affixes (~64%)
+    const baseLuck = restored.luck.value + gearLuck;
+    const r = calculateDerivedStats({ luck: baseLuck, luckBonus });
+    // floor((535 + 60.94) × 1.6397) ≈ 977 — matches the save, not ~100.
+    expect(r.totalLuck).toBe(Math.floor(baseLuck * (1 + luckBonus)));
+    expect(r.totalLuck).toBeGreaterThan(900);
   });
 });

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -526,6 +526,22 @@ describe('derivedStats', () => {
       expect(r.edpsPhysAdditive).toBeCloseTo(1.75, 2);
       expect(r.edpsElemPrimary).toBe(0);
     });
+
+    it('1% max-health-as-damage monogram is gated and populates BOTH flat pools', () => {
+      const base = { damage: 100, elementalDamage: 50, health: 10000 };
+      // Off by default — no phantom health contribution to flat damage.
+      const off = calculateDerivedStats(base);
+      expect(off.damageFromHealth).toBe(0);
+      expect(off.edpsPhysFlat).toBe(100);
+      expect(off.edpsElemFlat).toBe(50);
+      // When the monogram enables it: +1% of totalHealth (100) into both pools.
+      const on = calculateDerivedStats(base, {
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1 },
+      });
+      expect(on.damageFromHealth).toBe(100);
+      expect(on.edpsPhysFlat).toBe(200);
+      expect(on.edpsElemFlat).toBe(150);
+    });
   });
 });
 


### PR DESCRIPTION
Two fixes, both validated end-to-end against a mostly-elemental luck build that
runs the 1%-health monogram.

## 1. Character shares now carry allocated attributes

Shares captured only equipped-item stats + mastery, dropping the character's
allocated attribute pool (`Attributes_21_*`). A shared build under-counted
totals — luck showed ~100 (gear only) instead of 977 — and skewed every
`highestAttribute`-driven derived stat / eDPS bucket.

- New optional `at` payload field (`[[statEnc, value], ...]`, same STAT_DICT int
  compression as base stats) via `createAllocatedAttributesShare` /
  `allocatedAttributesShareToData`. Threaded through `createCharacterSharePayload`
  → `CharacterTab` (share) → `loadFromShare` → `App` (load).
- Backward compatible: omitted when empty; old links decode to `{}`.
- `findHostPlayerStruct` now handles both root-wrapped and top-level
  `properties` save shapes.

**Validated:** real save parses 535 allocated luck → `floor((535 + 60.9 gear) ×
1.64) = 977`, matching the in-game value. Full encode→decode round-trip (3.8KB
URL) preserves 17 items + allocated luck.

## 2. 1% health-as-damage monogram now populates flat damage

`GainDamageForHPLoseArmor` enabled `damageFromLife`, but the flat pools
(`edpsPhysFlat`/`edpsElemFlat`) only read `damageFromHealth` — so the monogram
never affected flat. Separately, `damageFromHealth` was always-on (phantom 1%
health in flat with no monogram).

- Gate `damageFromHealth` behind `enabled` (default off).
- Point `GainDamageForHPLoseArmor` at `damageFromHealth` (1% of max Health, both
  types — already feeds both flat pools).
- `DamageCircle.DamageForStats.Highest` passes `enabled: true`.

**Validated:** monogram off → no contribution; on → +1% health into both pools.
The monogram is present on the test build's bracer and survives share round-trip.

## Tests

243 pass; build clean. New coverage: allocated-attr encode/decode + URL
round-trip + backward compat + luck-977 parity; health-monogram gating into both
flat pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB)_