### PR TITLE
Fix 1%-health monogram (real max health) + fossil attack-speed x100

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,7 @@ export default function App() {
       if (decoded) {
         const masteryData = masteryShareToData(decoded.sk ?? null);
         const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
-        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes);
+        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0);
         setActiveTab('character');
         log('Loaded shared character build');
       }

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -15,6 +15,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     timestamp: itemStore.metadata.loadedAt,
     stanceContext: itemStore.metadata.stanceContext,
     characterStats: itemStore.metadata.allocatedAttributes,
+    maxHealth: itemStore.metadata.maxHealth,
   } : saveData ? {
     filename: saveData.filename,
     equippedItems: saveData.equippedItems || [],
@@ -25,7 +26,8 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     const payload = createCharacterSharePayload(
       itemStore.equipped,
       characterData?.stanceContext ?? null,
-      itemStore.metadata?.allocatedAttributes ?? null
+      itemStore.metadata?.allocatedAttributes ?? null,
+      itemStore.metadata?.maxHealth ?? 0
     );
     const url = buildCharacterShareUrl(payload);
     try {

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -21,7 +21,7 @@ export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
  * @returns {Object} Aggregated and calculated stats
  */
 export function useDerivedStats(options = {}) {
-  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null } = options;
+  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, maxHealth = 0 } = options;
 
   // Aggregate base stats from all equipped items WITH source tracking
   // Returns { [statId]: { total: number, sources: [{ itemName, slot, value }] } }
@@ -234,19 +234,21 @@ export function useDerivedStats(options = {}) {
   // Post ele/phys split, stance feeds the single physical additive bucket
   // (SCHD is merged in — no separate standalone multiplier).
   const finalConfigOverrides = useMemo(() => {
-    if (!detectedStance) return configOverrides;
-    return {
-      ...configOverrides,
-      edpsPhysAdditive: {
-        ...(configOverrides.edpsPhysAdditive || {}),
-        stance: detectedStance,
-      },
-      edpsElemCrit: {
-        ...(configOverrides.edpsElemCrit || {}),
-        stance: detectedStance,
-      },
-    };
-  }, [configOverrides, detectedStance]);
+    const merged = { ...configOverrides };
+
+    if (detectedStance) {
+      merged.edpsPhysAdditive = { ...(configOverrides.edpsPhysAdditive || {}), stance: detectedStance };
+      merged.edpsElemCrit = { ...(configOverrides.edpsElemCrit || {}), stance: detectedStance };
+    }
+
+    // The 1%-of-max-Health monogram needs real max health (gear can't supply it).
+    // Inject it into the damageFromHealth override the monogram already created.
+    if (maxHealth > 0 && merged.damageFromHealth) {
+      merged.damageFromHealth = { ...merged.damageFromHealth, maxHealth };
+    }
+
+    return merged;
+  }, [configOverrides, detectedStance, maxHealth]);
 
   // Calculate all derived stats
   const calculatedStats = useMemo(() => {

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
-import { parseStanceContext, parseAllocatedAttributes, convertMasteryToStanceContext } from '../utils/stanceSkills';
+import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -45,6 +45,7 @@ export function useItemStore() {
     const equippedItems = extractEquippedItems(saveJson);
     const stanceContext = parseStanceContext(saveJson, equippedItems);
     const allocatedAttributes = parseAllocatedAttributes(saveJson);
+    const maxHealth = parseMaxHealth(saveJson);
 
     // Extract all inventory items using unified Item model
     const { items: inventoryItems, totalCount } = transformAllItems(saveJson);
@@ -57,6 +58,7 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       stanceContext,
       allocatedAttributes,
+      maxHealth,
     });
   }, []);
 
@@ -68,7 +70,7 @@ export function useItemStore() {
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
    * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
 
     setEquipped(equippedItems);
@@ -79,6 +81,7 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       stanceContext: convertMasteryToStanceContext(masteryData),
       allocatedAttributes: allocatedAttributes || {},
+      maxHealth: maxHealth || 0,
       sharedMastery: masteryData,
     });
   }, []);

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -59,6 +59,8 @@ export const CHARACTER_SHARE_VERSION = 1;
  *   attribute pool from the save's Attributes_21_* block — NOT on any item, so
  *   without this a shared build under-counts totals (e.g. luck) and every
  *   highestAttribute-driven derived stat.
+ * @property {number} [hp] - Character max health (omitted if 0). Not derivable
+ *   from gear; needed by the 1%-of-max-Health monogram.
  */
 
 // ---------------------------------------------------------------------------
@@ -170,7 +172,7 @@ export function allocatedAttributesShareToData(at) {
  * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -182,6 +184,10 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
 
   const at = createAllocatedAttributesShare(allocatedAttributes);
   if (at) payload.at = at;
+
+  // Character max health (for the 1%-of-max-Health monogram); not derivable
+  // from gear. Rounded to keep the URL short.
+  if (maxHealth > 0) payload.hp = Math.round(maxHealth);
 
   return payload;
 }

--- a/src/models/itemTransformer.js
+++ b/src/models/itemTransformer.js
@@ -216,6 +216,29 @@ function extractTagFromGameplayTag(obj) {
 }
 
 /**
+ * Normalize stat values whose stored scale is inconsistent across sources.
+ *
+ * Attack speed is normally stored as a decimal fraction (0.01 = 1%, 0.10 = 10%),
+ * but some items (notably fossils) store it as already-multiplied percent-points
+ * (e.g. 454.12 = 454%). Left raw, the latter renders 100x too large (45412%) and
+ * blows past the 300% cap. Since a real attack-speed decimal never approaches the
+ * cap-region needed to exceed ~6, any value >= 10 is treated as percent-points
+ * and divided by 100 to bring it onto the decimal scale everything else expects.
+ *
+ * @param {string} rawTag - Full attribute tag path
+ * @param {number|null} value - Raw stored value
+ * @returns {number|null} Normalized value
+ */
+const ATTACK_SPEED_PERCENT_POINTS_THRESHOLD = 10;
+export function normalizeStatValue(rawTag, value) {
+  if (typeof value === 'number' && /AttackSpeed/i.test(rawTag || '') &&
+      Math.abs(value) >= ATTACK_SPEED_PERCENT_POINTS_THRESHOLD) {
+    return value / 100;
+  }
+  return value;
+}
+
+/**
  * Check if a tag is a monogram (modifier) rather than a regular stat
  * @param {string} rawTag - Full tag path
  * @returns {boolean}
@@ -281,7 +304,7 @@ function extractStatsAndMonograms(node) {
           // Regular stat
           stats.push({
             stat: tagInfo.stat,
-            value: value,
+            value: normalizeStatValue(tagInfo.rawTag, value),
             rawTag: tagInfo.rawTag,
           });
         }

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -225,11 +225,14 @@ export const DERIVED_STATS = {
       enabled: false, // gated by the "1% of max Health as damage" monogram
       sourceStat: 'totalHealth',
       percentage: 1,  // 1% of max health as flat damage (both types)
+      maxHealth: 0,   // real max health from save/share; preferred over totalHealth
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
       if (!config.enabled) return 0;
-      const source = stats[config.sourceStat] || 0;
+      // Prefer the character's real max health (from save/share) — the
+      // gear-summed totalHealth misses base/VIT-derived health entirely.
+      const source = config.maxHealth || stats[config.sourceStat] || 0;
       return Math.floor(source * (config.percentage / 100));
     },
     format: v => `+${v.toFixed(0)}`,

--- a/src/utils/stanceSkills.js
+++ b/src/utils/stanceSkills.js
@@ -224,6 +224,28 @@ export function parseAllocatedAttributes(saveData) {
 }
 
 /**
+ * Read the character's max health from save player data.
+ *
+ * The 1%-of-max-Health monogram needs the real total health, which is NOT
+ * derivable from gear (it comes mostly from base/VIT). The save stores the
+ * player's health as a Double in `Health_29_*`. NOTE: this is current health,
+ * which equals max at full HP — there is no separate stored max, so this is the
+ * best available proxy.
+ *
+ * @param {Object} saveData
+ * @returns {number} Max health (0 if unavailable)
+ */
+export function parseMaxHealth(saveData) {
+  const hostPlayerStruct = findHostPlayerStruct(saveData);
+  if (!hostPlayerStruct) return 0;
+  const key = Object.keys(hostPlayerStruct).find(k => k.startsWith('Health_'));
+  if (!key) return 0;
+  const node = hostPlayerStruct[key];
+  const value = node?.Double ?? node?.Float ?? null;
+  return typeof value === 'number' ? value : 0;
+}
+
+/**
  * Reconstruct a stanceContext from decoded share mastery data.
  * Used by loadFromShare so useDerivedStats gets proper stance/mastery effects
  * even when no save file is loaded.

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -586,6 +586,15 @@ describe('CharacterShareModel — allocated attributes', () => {
     expect(allocatedAttributesShareToData(undefined)).toEqual({});
   });
 
+  it('carries character max health (hp) for the 1%-health monogram', () => {
+    const payload = createCharacterSharePayload([], null, null, 5977.49);
+    expect(payload.hp).toBe(5977); // rounded
+    const decoded = decodeCharacterShare(encodeCharacterShare(payload));
+    expect(decoded.hp).toBe(5977);
+    // Omitted when 0 (backward compatible).
+    expect(createCharacterSharePayload([], null, null, 0).hp).toBeUndefined();
+  });
+
   it('feature parity: shared totals include the base pool (the luck-977 regression)', () => {
     // Before this fix the share carried only gear (~100 luck); the allocated
     // pool (~535) was dropped. Verify aggregating restored allocated + gear

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -542,6 +542,18 @@ describe('derivedStats', () => {
       expect(on.edpsPhysFlat).toBe(200);
       expect(on.edpsElemFlat).toBe(150);
     });
+
+    it('health monogram prefers real max health (from save/share) over gear-summed totalHealth', () => {
+      // Gear health is only 69 here; the character's real max health is 5977.
+      const base = { damage: 100, elementalDamage: 50, health: 69 };
+      const r = calculateDerivedStats(base, {
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1, maxHealth: 5977 },
+      });
+      // 1% of 5977 = 59 (not 1% of gear 69 = 0)
+      expect(r.damageFromHealth).toBe(59);
+      expect(r.edpsPhysFlat).toBe(159);
+      expect(r.edpsElemFlat).toBe(109);
+    });
   });
 });
 

--- a/test/itemTransformer.test.js
+++ b/test/itemTransformer.test.js
@@ -5,6 +5,7 @@ import {
   isItemStruct,
   isWeaponType,
   WEAPON_PATTERNS,
+  normalizeStatValue,
 } from '../src/models/itemTransformer.js';
 import { Rarity } from '../src/models/Item.js';
 
@@ -427,6 +428,27 @@ describe('itemTransformer', () => {
 
       expect(result.totalCount).toBe(1);
       expect(result.items[0].displayName).toBe('Chest Piece');
+    });
+  });
+
+  describe('normalizeStatValue (attack speed scale)', () => {
+    const TAG = 'EasyRPG.Attributes.Base.AttackSpeed';
+
+    it('divides percent-points attack speed (>=10) onto the decimal scale', () => {
+      // Fossil stores 454.12 (game shows +454.12) — must become 4.5412 so the
+      // x100 display formatting yields ~454%, not 45412%.
+      expect(normalizeStatValue(TAG, 454.12)).toBeCloseTo(4.5412, 4);
+    });
+
+    it('leaves normal decimal attack speed untouched', () => {
+      expect(normalizeStatValue(TAG, 0.01)).toBe(0.01); // stones = 1%
+      expect(normalizeStatValue(TAG, 0.1)).toBe(0.1);   // = 10%
+      expect(normalizeStatValue(TAG, 3.0)).toBe(3.0);   // 300% cap region, still decimal
+    });
+
+    it('never touches non-attack-speed stats or non-numbers', () => {
+      expect(normalizeStatValue('EasyRPG.Attributes.Base.Armor%', 434)).toBe(434);
+      expect(normalizeStatValue(TAG, null)).toBe(null);
     });
   });
 });


### PR DESCRIPTION
Two issues from the live elemental build.

## 1. 1%-of-max-Health monogram showed 0

The wiring (PR #60) was correct, but `damageFromHealth` read gear-summed
`totalHealth` (~69 — only the fossil's MaxHealth affix), missing the character's
real max health (~5977, which comes from base/VIT and isn't on any item).

- New `parseMaxHealth` reads the player's health (`Health_29` Double) from the
  save. Threaded through itemStore metadata → CharacterTab → `useDerivedStats`,
  which injects it into the `damageFromHealth` override.
- `damageFromHealth` now prefers real max health over `totalHealth`.
- Carried in character shares via a new optional `hp` field (backward
  compatible: omitted when 0).
- Caveat: `Health_29` is current health (= max at full); no separate stored max
  exists, so it's the best proxy.

**Result on the test build:** `damageFromHealth = 59` (1% of 5977), feeding both
physical and elemental flat pools (phys 81→140, elem 121→180).

## 2. Fossil attack speed rendered 45412%

Normal sources store attack speed as a decimal (Attack Speed Stone = 0.01 = 1%),
but fossils store percent-points (454.12 = 454%, shown raw in-game). The ×100
display formatting blew the fossil up to 45412%.

- `normalizeStatValue` at the parse layer divides attack-speed values ≥10 by 100
  onto the decimal scale. Fossil → ~454%, stones/normal gear untouched. Fixes
  tooltip, calc, and share consistently.

## Tests

Attack-speed normalization, max-health-preferred monogram, and `hp` share
round-trip. **248 pass; build clean.** Validated end-to-end on the reported save:
share round-trip preserves 17 items + allocated luck + `hp=5977`, and the fossil
attack speed is stored normalized (4.5412 → displays 454%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB)_