### PR TITLE
External-bonuses bucket, buff-aware health residual, additive monogram stacking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ Key monogram chains:
 - **Life Buff** (amulet, 100 stacks): +1% life per stack
 - **ElementForCritChance** (helmet): +3% element per 1% crit over 100%
 - **ElementalToHp%.Fire** (ring): +2% life per 30% fire damage
-- **GainDamageForHPLoseArmor** (bracer): +1% of max Health as flat damage (both types; enables `damageFromHealth`, which feeds `edpsPhysFlat` + `edpsElemFlat`)
+- **GainDamageForHPLoseArmor** (bracer): +1% of max Health as flat damage (both types; enables `damageFromHealth`, which feeds `edpsPhysFlat` + `edpsElemFlat`). Base = saved max health (`Health_29`, bakes in permanent flat×% incl. untracked tree/cards) × (1 + temp life bonuses: DrawLife, MoreLife.Highest, Shroud, circle, overcrit, life-from-element) — temp buffs are NOT in the saved value. Active buffs (row/stacks/time) are parsed from `AbilitySystemSaveData → StatusEffects` via `parseStatusEffects` into `metadata.statusEffects` (informational for now).
 
 ### Slot monogram pools
 Defined in `SLOT_MONOGRAMS` in `src/utils/monogramRegistry.js`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,18 @@ contribute through the external-bonuses residual.
 per-stat bucket outside any item: `{ statId: { value, sourceName } }`, merged
 into aggregation by `useDerivedStats` (source label shows in tooltips), carried
 in character shares (`xb`), editable via `itemStore.setExternalBonus`. Seeded at
-load: the flat-health residual `savedHealth / (1 + gear health%) − gear flat`
-attributes the untracked levelup-tree/card health so `totalHealth` matches the
-save — this backs the 1%-of-max-Health monogram. As card/tree mappings land,
-parsed contributions shrink the seeded residual instead of changing totals.
+load: the flat-health residual
+`savedHealth / ((1 + gear health%) × (1 + save-time temp life%)) − gear flat`
+attributes the untracked levelup-tree/card health so unbuffed `totalHealth`
+matches the save — this backs the 1%-of-max-Health monogram.
+
+IMPORTANT (verified on a fully-buffed save): `Health_29` INCLUDES buffs active
+at save time. `computeSaveTimeTempLifePct` reruns the engine with stack counts
+pinned from `StatusEffects` (`BUFF_STACK_MAP` in monogramConfigs: Buff_Bloodlust
+/ Buff_Life / Buff_DarkEssence) to divide them out; a buff absent from
+StatusEffects contributes 0. At full buff the monogram value equals exactly
+1% × saved health (division and re-multiplication cancel). As card/tree mappings
+land, parsed contributions shrink the seeded residual instead of changing totals.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,16 @@ fold into eDPS yet.
 2. Specify `layer`, `dependencies`, `calculate()`, and `format()`
 3. If triggered by monogram, add entry to `MONOGRAM_CALC_CONFIGS` in `src/hooks/useDerivedStats.js`
 
+### Monogram instance stacking
+Duplicate copies of many monograms stack ADDITIVELY (verified in-game). The hook
+counts instances per monogram ID and passes `instanceCount` into the effect
+config; stats that stack multiply by it. Currently instance-scaled:
+`bloodlustLifeBonus` (MoreLife rings), `damageFromHealth` (N × 1% health),
+`essence` (N × Dark Essence), `potionSlotsFromAttributes`,
+`elementFromCritChance` (ele per overcrit), `critChanceFromEssence`,
+`critDamageFromEssence`, `bloodlustDrawBloodBonus` (bracer + blood ring).
+`computeSaveTimeTempLifePct` mirrors the same counting for residual seeding.
+
 ### Monogram calculation configs
 Located in `src/hooks/useDerivedStats.js` - `MONOGRAM_CALC_CONFIGS`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,8 +353,25 @@ Opaque node IDs can't be auto-detected. `TREE_KEYSTONES` provides a checklist of
 - Fire/Arcane/Lightning Affinity (CDR ~35%, damage ~100% additive)
 - Extra inventory slots, extra potions
 
-### TODO: Card registry
-Card effects need population. Cards have L1/L2/L3 base stats; L6 doubles L3 and removes from further choice. Currently stored as skeleton entries with empty effects arrays.
+### Card registry: archetypes known, ID mapping TBD
+`CARD_ARCHETYPES` in `skillTreeRegistry.js` holds the known in-game effect
+templates (attribute cards, elemental cards, remains) with per-level-1 values in
+registry conventions. Level scaling: effect = base × stored level (final upgrade
+doubles L3, stored as level 6). `CARD_ID_TO_ARCHETYPE` maps `CARD{N}_{variant}`
+IDs to `{ archetype, param }` (param = concrete attribute/element statId) — this
+mapping is the remaining per-season verification work; `getCardEffects(rowName,
+level)` returns scaled effects or null when unmapped. Unmapped cards implicitly
+contribute through the external-bonuses residual.
+
+### External bonuses (catch-all for untracked tree/cards)
+`src/utils/externalBonuses.js` + `itemStore.externalBonuses`. Character-wide
+per-stat bucket outside any item: `{ statId: { value, sourceName } }`, merged
+into aggregation by `useDerivedStats` (source label shows in tooltips), carried
+in character shares (`xb`), editable via `itemStore.setExternalBonus`. Seeded at
+load: the flat-health residual `savedHealth / (1 + gear health%) − gear flat`
+attributes the untracked levelup-tree/card health so `totalHealth` matches the
+save — this backs the 1%-of-max-Health monogram. As card/tree mappings land,
+parsed contributions shrink the seeded residual instead of changing totals.
 
 ## Testing
 
@@ -458,9 +475,14 @@ Options keys: `h`=minHitsPerPool, `c`=closeMinTotal, `w`=includeWeapons, `t`=min
     "wt": 0,                                       // weapon type (WEAPON_TYPE_DICT index)
     "ws": [[0, 1], [8, 5]],                        // weapon skills [[skillEnc, level], ...]
     "ks": [0, 2]                                   // keystones [keystoneEnc, ...]
-  }
+  },
+  "at": [[6, 535]],                                // allocated attributes [[statEnc, value], ...] (omitted if none)
+  "xb": [[44, 5908]]                               // external bonuses (untracked tree/cards) [[statEnc, value], ...] (omitted if none)
 }
 ```
+
+Legacy field: `hp` (raw max health) is no longer written; old links carrying it
+seed the health residual at decode instead.
 
 **Stat values:** Raw decimals from save file. Percentages are stored as decimals (0.316 = 31.6%). Flat stats as-is (Armor = 197.57). No conversion — `useDerivedStats` already handles the raw format.
 
@@ -481,7 +503,8 @@ Options keys: `h`=minHitsPerPool, `c`=closeMinTotal, `w`=includeWeapons, `t`=min
 | `src/utils/shareCodec.js` | String↔int dictionaries, `encodeIdOrString`/`decodeIdOrString` |
 | `src/models/CharacterShareModel.js` | `createItemShare`, `itemShareToItem`, `createMasteryShare`, `masteryShareToData`, `createCharacterSharePayload` |
 | `src/utils/shareUrl.js` | `encodeCharacterShare`, `decodeCharacterShare`, `buildCharacterShareUrl`, plus existing filter functions |
-| `src/hooks/useItemStore.js` | `loadFromShare(itemShares, masteryData)` — populates store from decoded share |
+| `src/hooks/useItemStore.js` | `loadFromShare(itemShares, masteryData, allocated, externalBonuses, legacyHp)` — populates store from decoded share |
+| `src/utils/externalBonuses.js` | `seedExternalBonuses`, `computeHealthResidual` — catch-all bucket seeding |
 
 ### Adding a new share type
 1. Add encode/decode functions to `src/utils/shareUrl.js`

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,7 @@ export default function App() {
       if (decoded) {
         const masteryData = masteryShareToData(decoded.sk ?? null);
         const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
-        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes);
+        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0);
         setActiveTab('character');
         log('Loaded shared character build');
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
 import { parseShareFromHash, decodeFilterShare, decodeCharacterShare } from './utils/shareUrl';
-import { masteryShareToData, allocatedAttributesShareToData } from './models/CharacterShareModel';
+import { masteryShareToData, allocatedAttributesShareToData, externalBonusesShareToData } from './models/CharacterShareModel';
 
 const TABS = [
   { id: 'upload', label: 'Upload', icon: '📂' },
@@ -75,7 +75,9 @@ export default function App() {
       if (decoded) {
         const masteryData = masteryShareToData(decoded.sk ?? null);
         const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
-        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0);
+        const externalBonuses = externalBonusesShareToData(decoded.xb ?? null);
+        // decoded.hp: legacy links carried raw max health; seeds the residual instead
+        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, externalBonuses, decoded.hp ?? 0);
         setActiveTab('character');
         log('Loaded shared character build');
       }

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -15,6 +15,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     timestamp: itemStore.metadata.loadedAt,
     stanceContext: itemStore.metadata.stanceContext,
     characterStats: itemStore.metadata.allocatedAttributes,
+    maxHealth: itemStore.metadata.maxHealth,
   } : saveData ? {
     filename: saveData.filename,
     equippedItems: saveData.equippedItems || [],
@@ -25,7 +26,8 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     const payload = createCharacterSharePayload(
       itemStore.equipped,
       characterData?.stanceContext ?? null,
-      itemStore.metadata?.allocatedAttributes ?? null
+      itemStore.metadata?.allocatedAttributes ?? null,
+      itemStore.metadata?.maxHealth ?? 0
     );
     const url = buildCharacterShareUrl(payload);
     try {

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -15,7 +15,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     timestamp: itemStore.metadata.loadedAt,
     stanceContext: itemStore.metadata.stanceContext,
     characterStats: itemStore.metadata.allocatedAttributes,
-    maxHealth: itemStore.metadata.maxHealth,
+    externalBonuses: itemStore.externalBonuses,
   } : saveData ? {
     filename: saveData.filename,
     equippedItems: saveData.equippedItems || [],
@@ -27,7 +27,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
       itemStore.equipped,
       characterData?.stanceContext ?? null,
       itemStore.metadata?.allocatedAttributes ?? null,
-      itemStore.metadata?.maxHealth ?? 0
+      itemStore.externalBonuses ?? null
     );
     const url = buildCharacterShareUrl(payload);
     try {
@@ -39,7 +39,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     }
     if (onLog) onLog('Share link copied to clipboard');
     setTimeout(() => setShareFeedback(null), 2000);
-  }, [itemStore.equipped, characterData?.stanceContext, onLog]);
+  }, [itemStore.equipped, itemStore.externalBonuses, itemStore.metadata?.allocatedAttributes, characterData?.stanceContext, onLog]);
 
   return (
     <div className="tab-content active">

--- a/src/components/character/ItemDetailTooltip.jsx
+++ b/src/components/character/ItemDetailTooltip.jsx
@@ -46,7 +46,7 @@ function getEffectSummary(statId, config) {
     critChanceFromEssence: '+1% crit per 20 essence',
     elementFromCritChance: `+3% ${config?.elementType || 'element'} per 1% crit>100`,
     lifeFromElement: '+2% life per 30% element',
-    damageFromLife: '+1% life as flat damage',
+    damageFromHealth: '+1% of max health as flat damage (both types)',
   };
 
   return summaryMap[statId] || null;

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -21,7 +21,7 @@ export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
  * @returns {Object} Aggregated and calculated stats
  */
 export function useDerivedStats(options = {}) {
-  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null } = options;
+  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, maxHealth = 0 } = options;
 
   // Aggregate base stats from all equipped items WITH source tracking
   // Returns { [statId]: { total: number, sources: [{ itemName, slot, value }] } }
@@ -234,19 +234,21 @@ export function useDerivedStats(options = {}) {
   // Post ele/phys split, stance feeds the single physical additive bucket
   // (SCHD is merged in — no separate standalone multiplier).
   const finalConfigOverrides = useMemo(() => {
-    if (!detectedStance) return configOverrides;
-    return {
-      ...configOverrides,
-      edpsPhysAdditive: {
-        ...(configOverrides.edpsPhysAdditive || {}),
-        stance: detectedStance,
-      },
-      edpsElemCrit: {
-        ...(configOverrides.edpsElemCrit || {}),
-        stance: detectedStance,
-      },
-    };
-  }, [configOverrides, detectedStance]);
+    const merged = { ...configOverrides };
+
+    if (detectedStance) {
+      merged.edpsPhysAdditive = { ...(configOverrides.edpsPhysAdditive || {}), stance: detectedStance };
+      merged.edpsElemCrit = { ...(configOverrides.edpsElemCrit || {}), stance: detectedStance };
+    }
+
+    // The 1%-of-max-Health monogram needs real max health (gear can't supply it).
+    // Inject it into the damageFromHealth override the monogram already created.
+    if (maxHealth > 0 && merged.damageFromHealth) {
+      merged.damageFromHealth = { ...merged.damageFromHealth, maxHealth };
+    }
+
+    return merged;
+  }, [configOverrides, detectedStance, maxHealth]);
 
   // Calculate all derived stats
   const calculatedStats = useMemo(() => {

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -21,7 +21,7 @@ export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
  * @returns {Object} Aggregated and calculated stats
  */
 export function useDerivedStats(options = {}) {
-  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, maxHealth = 0 } = options;
+  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, externalBonuses = {} } = options;
 
   // Aggregate base stats from all equipped items WITH source tracking
   // Returns { [statId]: { total: number, sources: [{ itemName, slot, value }] } }
@@ -36,6 +36,19 @@ export function useDerivedStats(options = {}) {
         total: value,
         sources: [{ itemName: sourceName, slot: 'base', value, sourceType: 'item' }],
       };
+    }
+
+    // External bonuses: catch-all character-wide stats outside any item
+    // (untracked tree/cards; seeded health residual). Additive with the above.
+    for (const [statId, rawValue] of Object.entries(externalBonuses || {})) {
+      const value = typeof rawValue === 'number' ? rawValue : Number(rawValue?.value || 0);
+      if (!value) continue;
+      const sourceName = rawValue?.sourceName || 'External';
+      if (!stats[statId]) {
+        stats[statId] = { total: 0, sources: [] };
+      }
+      stats[statId].total += value;
+      stats[statId].sources.push({ itemName: sourceName, slot: 'external', value, sourceType: 'item' });
     }
 
     // Active stance mastery defaults: +1% stance-specific damage per mastery level
@@ -106,7 +119,7 @@ export function useDerivedStats(options = {}) {
     }
 
     return stats;
-  }, [equippedItems, itemOverrides, characterStats, stanceContext]);
+  }, [equippedItems, itemOverrides, characterStats, stanceContext, externalBonuses]);
 
   // Flatten to simple { [statId]: total } for backward compatibility
   const aggregatedBaseStats = useMemo(() => {
@@ -233,22 +246,17 @@ export function useDerivedStats(options = {}) {
   // Merge stance detection into config overrides for eDPS.
   // Post ele/phys split, stance feeds the single physical additive bucket
   // (SCHD is merged in — no separate standalone multiplier).
+  // Merge stance detection into config overrides for eDPS. The health-based
+  // monogram reads totalHealth directly — accurate now that the external
+  // bonuses bucket carries the untracked (tree/cards) flat-health residual.
   const finalConfigOverrides = useMemo(() => {
-    const merged = { ...configOverrides };
-
-    if (detectedStance) {
-      merged.edpsPhysAdditive = { ...(configOverrides.edpsPhysAdditive || {}), stance: detectedStance };
-      merged.edpsElemCrit = { ...(configOverrides.edpsElemCrit || {}), stance: detectedStance };
-    }
-
-    // The 1%-of-max-Health monogram needs real max health (gear can't supply it).
-    // Inject it into the damageFromHealth override the monogram already created.
-    if (maxHealth > 0 && merged.damageFromHealth) {
-      merged.damageFromHealth = { ...merged.damageFromHealth, maxHealth };
-    }
-
-    return merged;
-  }, [configOverrides, detectedStance, maxHealth]);
+    if (!detectedStance) return configOverrides;
+    return {
+      ...configOverrides,
+      edpsPhysAdditive: { ...(configOverrides.edpsPhysAdditive || {}), stance: detectedStance },
+      edpsElemCrit: { ...(configOverrides.edpsElemCrit || {}), stance: detectedStance },
+    };
+  }, [configOverrides, detectedStance]);
 
   // Calculate all derived stats
   const calculatedStats = useMemo(() => {

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
-import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
+import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, parseStatusEffects, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -46,6 +46,7 @@ export function useItemStore() {
     const stanceContext = parseStanceContext(saveJson, equippedItems);
     const allocatedAttributes = parseAllocatedAttributes(saveJson);
     const maxHealth = parseMaxHealth(saveJson);
+    const statusEffects = parseStatusEffects(saveJson);
 
     // Extract all inventory items using unified Item model
     const { items: inventoryItems, totalCount } = transformAllItems(saveJson);
@@ -59,6 +60,7 @@ export function useItemStore() {
       stanceContext,
       allocatedAttributes,
       maxHealth,
+      statusEffects,
     });
   }, []);
 

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
-import { parseStanceContext, parseAllocatedAttributes, convertMasteryToStanceContext } from '../utils/stanceSkills';
+import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -45,6 +45,7 @@ export function useItemStore() {
     const equippedItems = extractEquippedItems(saveJson);
     const stanceContext = parseStanceContext(saveJson, equippedItems);
     const allocatedAttributes = parseAllocatedAttributes(saveJson);
+    const maxHealth = parseMaxHealth(saveJson);
 
     // Extract all inventory items using unified Item model
     const { items: inventoryItems, totalCount } = transformAllItems(saveJson);
@@ -57,6 +58,7 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       stanceContext,
       allocatedAttributes,
+      maxHealth,
     });
   }, []);
 
@@ -68,7 +70,7 @@ export function useItemStore() {
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
    * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
 
     setEquipped(equippedItems);
@@ -79,6 +81,7 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       stanceContext: convertMasteryToStanceContext(masteryData),
       allocatedAttributes: allocatedAttributes || {},
+      maxHealth: maxHealth || 0,
       sharedMastery: masteryData,
     });
   }, []);

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -60,7 +60,7 @@ export function useItemStore() {
     setEquipped(equippedItems);
     setInventory(inventoryItems);
     setTotalInventoryCount(totalCount);
-    setExternalBonuses(seedExternalBonuses(equippedItems, maxHealth));
+    setExternalBonuses(seedExternalBonuses(equippedItems, maxHealth, { allocatedAttributes, statusEffects }));
     setMetadata({
       filename,
       loadedAt: new Date().toISOString(),

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
 import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, parseStatusEffects, convertMasteryToStanceContext } from '../utils/stanceSkills';
+import { seedExternalBonuses, MANUAL_SOURCE } from '../utils/externalBonuses';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -33,6 +34,11 @@ export function useItemStore() {
     allocatedAttributes: {},
   });
 
+  // External bonuses: catch-all for character-wide stats outside any item
+  // (untracked tree/cards). Seeded at load (health residual), user-editable.
+  // Shape: { [statId]: { value, sourceName } }
+  const [externalBonuses, setExternalBonuses] = useState({});
+
   /**
    * Load items from parsed save data
    * Extracts equipped items and inventory from the save file JSON
@@ -54,6 +60,7 @@ export function useItemStore() {
     setEquipped(equippedItems);
     setInventory(inventoryItems);
     setTotalInventoryCount(totalCount);
+    setExternalBonuses(seedExternalBonuses(equippedItems, maxHealth));
     setMetadata({
       filename,
       loadedAt: new Date().toISOString(),
@@ -71,9 +78,17 @@ export function useItemStore() {
    * @param {import('../models/CharacterShareModel').EquippedItemShare[]} itemShares
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
    * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
+   * @param {Object<string, {value:number, sourceName:string}>} [sharedExternalBonuses] - Decoded external bonuses (xb)
+   * @param {number} [legacyMaxHealth] - `hp` from older share links; used to seed
+   *   the health residual when the share predates the external-bonuses field
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, sharedExternalBonuses = {}, legacyMaxHealth = 0) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
+
+    const hasShared = sharedExternalBonuses && Object.keys(sharedExternalBonuses).length > 0;
+    setExternalBonuses(hasShared
+      ? sharedExternalBonuses
+      : seedExternalBonuses(equippedItems, legacyMaxHealth));
 
     setEquipped(equippedItems);
     setInventory([]);
@@ -83,7 +98,6 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       stanceContext: convertMasteryToStanceContext(masteryData),
       allocatedAttributes: allocatedAttributes || {},
-      maxHealth: maxHealth || 0,
       sharedMastery: masteryData,
     });
   }, []);
@@ -95,10 +109,29 @@ export function useItemStore() {
     setEquipped([]);
     setInventory([]);
     setTotalInventoryCount(0);
+    setExternalBonuses({});
     setMetadata({
       filename: null,
       loadedAt: null,
       stanceContext: null,
+    });
+  }, []);
+
+  /**
+   * Set (or update) an external bonus entry. Value 0/null removes the entry.
+   * User edits are labeled MANUAL_SOURCE; the seeded residual keeps its label
+   * until edited.
+   *
+   * @param {string} statId - Registry stat ID
+   * @param {number|null} value - New value (falsy removes)
+   * @param {string} [sourceName] - Source label (defaults to Manual)
+   */
+  const setExternalBonus = useCallback((statId, value, sourceName = MANUAL_SOURCE) => {
+    setExternalBonuses(prev => {
+      const next = { ...prev };
+      if (!value) delete next[statId];
+      else next[statId] = { value, sourceName };
+      return next;
     });
   }, []);
 
@@ -232,6 +265,7 @@ export function useItemStore() {
     totalInventoryCount,
     metadata,
     hasItems,
+    externalBonuses,
 
     // Slot access
     equippedSlotMap,
@@ -242,6 +276,7 @@ export function useItemStore() {
     loadFromSave,
     loadFromShare,
     clear,
+    setExternalBonus,
   };
 }
 

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -59,6 +59,8 @@ export const CHARACTER_SHARE_VERSION = 1;
  *   attribute pool from the save's Attributes_21_* block — NOT on any item, so
  *   without this a shared build under-counts totals (e.g. luck) and every
  *   highestAttribute-driven derived stat.
+ * @property {number} [hp] - Character max health (omitted if 0). Not derivable
+ *   from gear; needed by the 1%-of-max-Health monogram.
  */
 
 // ---------------------------------------------------------------------------
@@ -170,7 +172,7 @@ export function allocatedAttributesShareToData(at) {
  * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -182,6 +184,10 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
 
   const at = createAllocatedAttributesShare(allocatedAttributes);
   if (at) payload.at = at;
+
+  // Character max health (for the 1%-of-max-Health monogram); not derivable
+  // from gear. Rounded to keep the URL short.
+  if (maxHealth > 0) payload.hp = Math.round(maxHealth);
 
   return payload;
 }

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -59,8 +59,12 @@ export const CHARACTER_SHARE_VERSION = 1;
  *   attribute pool from the save's Attributes_21_* block — NOT on any item, so
  *   without this a shared build under-counts totals (e.g. luck) and every
  *   highestAttribute-driven derived stat.
- * @property {number} [hp] - Character max health (omitted if 0). Not derivable
- *   from gear; needed by the 1%-of-max-Health monogram.
+ * @property {Array<[number|string, number]>} [xb] - External bonuses
+ *   [[statEnc, value], ...] (omitted if none). Catch-all for character-wide
+ *   stats outside any item (untracked tree/cards); includes the auto-seeded
+ *   flat-health residual so the 1%-of-max-Health monogram works from shares.
+ * @property {number} [hp] - LEGACY (no longer written): character max health
+ *   from older links; decoded into a seeded health residual.
  */
 
 // ---------------------------------------------------------------------------
@@ -164,15 +168,43 @@ export function allocatedAttributesShareToData(at) {
 }
 
 /**
+ * Convert the external-bonuses bucket to compact share form.
+ * Same wire format as allocated attributes: [[statEnc, value], ...].
+ *
+ * @param {Object<string, {value:number}|number>|null} externalBonuses
+ * @returns {Array<[number|string, number]>|null}
+ */
+export function createExternalBonusesShare(externalBonuses) {
+  return createAllocatedAttributesShare(externalBonuses);
+}
+
+/**
+ * Reconstruct the external-bonuses bucket from a decoded `xb` array.
+ *
+ * @param {Array<[number|string, number]>|null|undefined} xb
+ * @returns {Object<string, {value:number, sourceName:string}>}
+ */
+export function externalBonusesShareToData(xb) {
+  const result = {};
+  for (const [enc, value] of xb || []) {
+    const statId = decodeIdOrString(STAT_DICT, enc) || String(enc);
+    result[statId] = { value: value ?? 0, sourceName: 'Shared build' };
+  }
+  return result;
+}
+
+/**
  * Build a full character share payload from equipped items, optional
- * stanceContext, and the character's allocated attribute pool.
+ * stanceContext, the character's allocated attribute pool, and the
+ * external-bonuses bucket.
  *
  * @param {import('./Item').Item[]} equippedItems
  * @param {{ activeStance: object }|null} [stanceContext]
  * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
+ * @param {Object<string, {value:number}|number>|null} [externalBonuses]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, externalBonuses = null) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -185,9 +217,8 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
   const at = createAllocatedAttributesShare(allocatedAttributes);
   if (at) payload.at = at;
 
-  // Character max health (for the 1%-of-max-Health monogram); not derivable
-  // from gear. Rounded to keep the URL short.
-  if (maxHealth > 0) payload.hp = Math.round(maxHealth);
+  const xb = createExternalBonusesShare(externalBonuses);
+  if (xb) payload.xb = xb;
 
   return payload;
 }

--- a/src/models/itemTransformer.js
+++ b/src/models/itemTransformer.js
@@ -216,6 +216,29 @@ function extractTagFromGameplayTag(obj) {
 }
 
 /**
+ * Normalize stat values whose stored scale is inconsistent across sources.
+ *
+ * Attack speed is normally stored as a decimal fraction (0.01 = 1%, 0.10 = 10%),
+ * but some items (notably fossils) store it as already-multiplied percent-points
+ * (e.g. 454.12 = 454%). Left raw, the latter renders 100x too large (45412%) and
+ * blows past the 300% cap. Since a real attack-speed decimal never approaches the
+ * cap-region needed to exceed ~6, any value >= 10 is treated as percent-points
+ * and divided by 100 to bring it onto the decimal scale everything else expects.
+ *
+ * @param {string} rawTag - Full attribute tag path
+ * @param {number|null} value - Raw stored value
+ * @returns {number|null} Normalized value
+ */
+const ATTACK_SPEED_PERCENT_POINTS_THRESHOLD = 10;
+export function normalizeStatValue(rawTag, value) {
+  if (typeof value === 'number' && /AttackSpeed/i.test(rawTag || '') &&
+      Math.abs(value) >= ATTACK_SPEED_PERCENT_POINTS_THRESHOLD) {
+    return value / 100;
+  }
+  return value;
+}
+
+/**
  * Check if a tag is a monogram (modifier) rather than a regular stat
  * @param {string} rawTag - Full tag path
  * @returns {boolean}
@@ -281,7 +304,7 @@ function extractStatsAndMonograms(node) {
           // Regular stat
           stats.push({
             stat: tagInfo.stat,
-            value: value,
+            value: normalizeStatValue(tagInfo.rawTag, value),
             rawTag: tagInfo.rawTag,
           });
         }

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -225,11 +225,14 @@ export const DERIVED_STATS = {
       enabled: false, // gated by the "1% of max Health as damage" monogram
       sourceStat: 'totalHealth',
       percentage: 1,  // 1% of max health as flat damage (both types)
+      maxHealth: 0,   // real max health from save/share; preferred over totalHealth
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
       if (!config.enabled) return 0;
-      const source = stats[config.sourceStat] || 0;
+      // Prefer the character's real max health (from save/share) — the
+      // gear-summed totalHealth misses base/VIT-derived health entirely.
+      const source = config.maxHealth || stats[config.sourceStat] || 0;
       return Math.floor(source * (config.percentage / 100));
     },
     format: v => `+${v.toFixed(0)}`,

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -219,8 +219,11 @@ export const DERIVED_STATS = {
     id: 'damageFromHealth',
     name: 'Damage from Health',
     category: 'conversion',
-    layer: LAYERS.PRIMARY_DERIVED,
-    dependencies: ['totalHealth'],
+    // TERTIARY so the temporary life-bonus chain (life buffs, shroud, circle,
+    // overcrit, life-from-element) is computed before this reads it.
+    layer: LAYERS.TERTIARY_DERIVED,
+    dependencies: ['totalHealth', 'lifeBuffBonus', 'bloodlustLifeBonus', 'shroudLifeBonus',
+      'damageCircleLifeBonus', 'lifeBonusFromCritChance', 'lifeFromElement'],
     config: {
       enabled: false, // gated by the "1% of max Health as damage" monogram
       sourceStat: 'totalHealth',
@@ -230,13 +233,38 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
       if (!config.enabled) return 0;
-      // Prefer the character's real max health (from save/share) — the
-      // gear-summed totalHealth misses base/VIT-derived health entirely.
-      const source = config.maxHealth || stats[config.sourceStat] || 0;
-      return Math.floor(source * (config.percentage / 100));
+      // Base: the character's saved max health. It already bakes in permanent
+      // flat × health% from gear/tree/cards (which the tool can't reconstruct
+      // — tree and cards aren't tracked), so it's the right prior. Falls back
+      // to gear-summed totalHealth when no save/share health is available.
+      const base = config.maxHealth || stats[config.sourceStat] || 0;
+      // Temporary life bonuses are NOT in the saved health (buffs expire /
+      // aren't active at save time) — apply them on top. All are percent
+      // numbers (100 = +100%) and monogram-gated (0 unless equipped).
+      const tempLifePct = (stats.lifeBuffBonus || 0)
+        + (stats.bloodlustLifeBonus || 0)
+        + (stats.shroudLifeBonus || 0)
+        + (stats.damageCircleLifeBonus || 0)
+        + (stats.lifeBonusFromCritChance || 0)
+        + (stats.lifeFromElement || 0);
+      const effectiveMax = base * (1 + tempLifePct / 100);
+      return Math.floor(effectiveMax * (config.percentage / 100));
     },
     format: v => `+${v.toFixed(0)}`,
-    description: 'Flat damage from 1% of max health (both types; monogram-gated)',
+    description: 'Flat damage from 1% of max health × temp life buffs (both types; monogram-gated)',
+    breakdown: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.damageFromHealth.config;
+      const base = config.maxHealth || stats[config.sourceStat] || 0;
+      const tempLifePct = (stats.lifeBuffBonus || 0) + (stats.bloodlustLifeBonus || 0)
+        + (stats.shroudLifeBonus || 0) + (stats.damageCircleLifeBonus || 0)
+        + (stats.lifeBonusFromCritChance || 0) + (stats.lifeFromElement || 0);
+      return [
+        { label: 'maxHealth', fullName: config.maxHealth ? 'Max Health (save)' : 'Health (gear only — load a save for accuracy)', op: '=', value: base, fmt: 'int' },
+        { label: 'tempLife', fullName: 'Temp life bonuses (buff monograms)', op: '×', value: 1 + tempLifePct / 100, fmt: 'pct', isMonogram: true },
+        { label: 'pct', fullName: `${config.percentage}% of effective max health`, op: '×', value: config.percentage / 100, fmt: 'pct' },
+        { label: 'damageFromHealth', fullName: 'Flat damage (both types)', op: '=', value: stats.damageFromHealth, fmt: 'int', isSubtotal: true },
+      ];
+    },
   },
 
   /**
@@ -292,12 +320,13 @@ export const DERIVED_STATS = {
   /**
    * Final damage combining all flat damage sources
    * totalDamage + damageFromHealth + other conversion sources
+   * TERTIARY because damageFromHealth now waits on the temp life-buff chain.
    */
   finalDamage: {
     id: 'finalDamage',
     name: 'Final Damage',
     category: 'final',
-    layer: LAYERS.SECONDARY_DERIVED,
+    layer: LAYERS.TERTIARY_DERIVED,
     dependencies: ['totalDamage', 'damageFromHealth'],
     calculate: (stats) => {
       const baseDamage = stats.totalDamage || 0;
@@ -1394,34 +1423,9 @@ export const DERIVED_STATS = {
     description: 'Life bonus from elemental damage (2% per 30% element)',
   },
 
-  // ---------------------------------------------------------------------------
-  // GAIN DAMAGE FOR HP LOSE ARMOR (Bracer Monogram)
-  // 1% of total life added as Flat Damage
-  // ---------------------------------------------------------------------------
-  damageFromLife: {
-    id: 'damageFromLife',
-    name: 'Damage (Life)',
-    category: 'monogram-chain',
-    layer: LAYERS.TERTIARY_DERIVED,
-    dependencies: ['totalHealth', 'lifeBuffBonus', 'lifeFromElement'],
-    config: {
-      enabled: false,
-      lifePercent: 1, // 1% of total life
-    },
-    calculate: (stats, cfg) => {
-      const config = cfg || DERIVED_STATS.damageFromLife.config;
-      if (!config.enabled) return 0;
-      // Calculate total life with all bonuses
-      const baseHealth = stats.totalHealth || 0;
-      const lifeBuffPct = stats.lifeBuffBonus || 0;
-      const lifeFromElemPct = stats.lifeFromElement || 0;
-      const totalLifeBonus = lifeBuffPct + lifeFromElemPct;
-      const totalLife = Math.floor(baseHealth * (1 + totalLifeBonus / 100));
-      return Math.floor(totalLife * (config.lifePercent / 100));
-    },
-    format: v => `+${v.toFixed(0)}`,
-    description: 'Flat damage from total life (1% of life)',
-  },
+  // NOTE: the former `damageFromLife` stat (temp-life-aware 1%-of-life damage)
+  // was folded into `damageFromHealth`, which now applies the full temporary
+  // life-bonus chain on top of the character's saved max health.
 
   // ===========================================================================
   // BRACER MONOGRAM STATS

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -228,16 +228,13 @@ export const DERIVED_STATS = {
       enabled: false, // gated by the "1% of max Health as damage" monogram
       sourceStat: 'totalHealth',
       percentage: 1,  // 1% of max health as flat damage (both types)
-      maxHealth: 0,   // real max health from save/share; preferred over totalHealth
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
       if (!config.enabled) return 0;
-      // Base: the character's saved max health. It already bakes in permanent
-      // flat × health% from gear/tree/cards (which the tool can't reconstruct
-      // — tree and cards aren't tracked), so it's the right prior. Falls back
-      // to gear-summed totalHealth when no save/share health is available.
-      const base = config.maxHealth || stats[config.sourceStat] || 0;
+      // Base: totalHealth. Accurate when the external-bonuses bucket carries
+      // the untracked (tree/cards) flat-health residual seeded from the save.
+      const base = stats[config.sourceStat] || 0;
       // Temporary life bonuses are NOT in the saved health (buffs expire /
       // aren't active at save time) — apply them on top. All are percent
       // numbers (100 = +100%) and monogram-gated (0 unless equipped).
@@ -254,12 +251,12 @@ export const DERIVED_STATS = {
     description: 'Flat damage from 1% of max health × temp life buffs (both types; monogram-gated)',
     breakdown: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.damageFromHealth.config;
-      const base = config.maxHealth || stats[config.sourceStat] || 0;
+      const base = stats[config.sourceStat] || 0;
       const tempLifePct = (stats.lifeBuffBonus || 0) + (stats.bloodlustLifeBonus || 0)
         + (stats.shroudLifeBonus || 0) + (stats.damageCircleLifeBonus || 0)
         + (stats.lifeBonusFromCritChance || 0) + (stats.lifeFromElement || 0);
       return [
-        { label: 'maxHealth', fullName: config.maxHealth ? 'Max Health (save)' : 'Health (gear only — load a save for accuracy)', op: '=', value: base, fmt: 'int' },
+        term(stats, 'totalHealth', '=', 'int', { fullName: 'Total Health (incl. untracked residual)' }),
         { label: 'tempLife', fullName: 'Temp life bonuses (buff monograms)', op: '×', value: 1 + tempLifePct / 100, fmt: 'pct', isMonogram: true },
         { label: 'pct', fullName: `${config.percentage}% of effective max health`, op: '×', value: config.percentage / 100, fmt: 'pct' },
         { label: 'damageFromHealth', fullName: 'Flat damage (both types)', op: '=', value: stats.damageFromHealth, fmt: 'int', isSubtotal: true },

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -245,7 +245,8 @@ export const DERIVED_STATS = {
         + (stats.lifeBonusFromCritChance || 0)
         + (stats.lifeFromElement || 0);
       const effectiveMax = base * (1 + tempLifePct / 100);
-      return Math.floor(effectiveMax * (config.percentage / 100));
+      // Duplicate monogram instances stack additively (N × 1% of max health)
+      return Math.floor(effectiveMax * (config.percentage / 100) * (config.instanceCount || 1));
     },
     format: v => `+${v.toFixed(0)}`,
     description: 'Flat damage from 1% of max health × temp life buffs (both types; monogram-gated)',
@@ -304,10 +305,11 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.potionSlotsFromAttributes.config;
       const highest = stats.highestAttribute || 0;
-      return Math.floor(highest / config.ratio);
+      // Duplicate monogram instances stack additively
+      return Math.floor(highest / config.ratio) * (config.instanceCount || 1);
     },
     format: v => v.toFixed(0),
-    description: 'Additional potion slots from highest attribute (1 per 50)',
+    description: 'Additional potion slots from highest attribute (1 per 50, per instance)',
   },
 
   // ---------------------------------------------------------------------------
@@ -608,14 +610,16 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.essence.config;
       const stacks = stats.darkEssenceStacks || 0;
+      // Duplicate Dark Essence monograms stack additively: N instances = N × total essence
+      const instances = config.instanceCount || 1;
       if (stacks < config.thresholdStacks) {
         // Partial effect? Or none until max? Let's do proportional
-        return Math.floor((stacks / config.thresholdStacks) * (stats.highestAttribute || 0) * config.multiplier);
+        return Math.floor((stacks / config.thresholdStacks) * (stats.highestAttribute || 0) * config.multiplier * instances);
       }
-      return Math.floor((stats.highestAttribute || 0) * config.multiplier);
+      return Math.floor((stats.highestAttribute || 0) * config.multiplier * instances);
     },
     format: v => v.toFixed(0),
-    description: 'Essence value from Dark Essence (highestStat × 1.25 at 500 stacks)',
+    description: 'Essence value from Dark Essence (highestStat × 1.25 at 500 stacks; stacks per instance)',
   },
 
   // ---------------------------------------------------------------------------
@@ -679,11 +683,12 @@ export const DERIVED_STATS = {
       if (!config.enabled) return 0;
       const stacks = stats.lifeBuffStacks || 0;
       const highest = stats.highestAttribute || 0;
-      // Formula: stacks * lifePerStackPer50 * (highest / 50)
-      return stacks * config.lifePerStackPer50 * (highest / 50);
+      // Formula: stacks * lifePerStackPer50 * (highest / 50); duplicate rings
+      // stack additively (2 rings = 2×, up to 6× with 3× rolls on each)
+      return stacks * config.lifePerStackPer50 * (highest / 50) * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}%`,
-    description: 'Life bonus from Bloodlust stacks scaling with highest attribute',
+    description: 'Life bonus from Bloodlust stacks scaling with highest attribute (per instance)',
   },
 
   // ---------------------------------------------------------------------------
@@ -1325,16 +1330,96 @@ export const DERIVED_STATS = {
     dependencies: ['essence'],
     config: {
       enabled: false, // Enabled by monogram
-      essencePerCrit: 20, // 20 essence = 1% crit
+      essencePerCrit: 20,   // 20 essence per interval
+      critPerInterval: 1.5, // 1.5% crit chance per interval (pants monogram)
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.critChanceFromEssence.config;
       if (!config.enabled) return 0;
       const essence = stats.essence || 0;
-      return Math.floor(essence / config.essencePerCrit);
+      // Duplicate monogram instances stack additively
+      return Math.floor(essence / config.essencePerCrit) * (config.critPerInterval ?? 1.5) * (config.instanceCount || 1);
+    },
+    format: v => `+${v.toFixed(1)}%`,
+    description: 'Critical chance from Essence (1.5% per 20 essence, per instance)',
+  },
+
+  // ---------------------------------------------------------------------------
+  // CRIT DAMAGE FROM ESSENCE (Boots Monogram — BonusCritDamage%ForEssence)
+  // Crit DAMAGE per 20 essence; rolls multiple times (observed ×2 on one pair
+  // of boots) and stacks additively. Per-interval value unconfirmed — using
+  // 1.5% to match the crit-chance sibling until verified.
+  // ---------------------------------------------------------------------------
+  critDamageFromEssence: {
+    id: 'critDamageFromEssence',
+    name: 'Crit Damage (Essence)',
+    category: 'monogram-chain',
+    layer: LAYERS.TERTIARY_DERIVED,
+    dependencies: ['essence'],
+    config: {
+      enabled: false,
+      essencePerInterval: 20,
+      critDamagePerInterval: 1.5, // TODO: verify in-game value
+    },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.critDamageFromEssence.config;
+      if (!config.enabled) return 0;
+      const essence = stats.essence || 0;
+      return Math.floor(essence / config.essencePerInterval) * config.critDamagePerInterval * (config.instanceCount || 1);
+    },
+    format: v => `+${v.toFixed(1)}%`,
+    description: 'Critical damage from Essence (per 20 essence, per instance; value TBD)',
+  },
+
+  // ---------------------------------------------------------------------------
+  // STATIC CHARGE (Lightning offhand set — StaticCharge.Buff)
+  // +1% lightning damage per stack (100 stacks max). Feeds edpsED.
+  // Enabled via config until offhand-set detection is wired.
+  // ---------------------------------------------------------------------------
+  staticChargeLightningBonus: {
+    id: 'staticChargeLightningBonus',
+    name: 'Static Charge Lightning%',
+    category: 'monogram-buff',
+    layer: LAYERS.PRIMARY_DERIVED,
+    dependencies: [],
+    config: {
+      enabled: false,
+      lightningPerStack: 1,
+      maxStacks: 100,
+      currentStacks: 100,
+    },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.staticChargeLightningBonus.config;
+      if (!config.enabled) return 0;
+      return Math.min(config.currentStacks, config.maxStacks) * config.lightningPerStack;
     },
     format: v => `+${v.toFixed(0)}%`,
-    description: 'Critical chance from Essence (1% per 20 essence)',
+    description: 'Lightning damage from Static Charge stacks (1% per stack, 100 max)',
+  },
+
+  // ---------------------------------------------------------------------------
+  // JUGGERNAUT ELEMENTAL BUILDUP (Helm/Fist keystone)
+  // The buildup stacks grant instances of +3% elemental damage. Stack count at
+  // full buildup unconfirmed — defaults to 0 until configured. Feeds edpsED.
+  // ---------------------------------------------------------------------------
+  juggernautElementalBonus: {
+    id: 'juggernautElementalBonus',
+    name: 'Juggernaut Elem%',
+    category: 'monogram-buff',
+    layer: LAYERS.PRIMARY_DERIVED,
+    dependencies: [],
+    config: {
+      enabled: false,
+      elementalPerStack: 3,
+      currentStacks: 0, // TODO: buildup stack count unconfirmed
+    },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.juggernautElementalBonus.config;
+      if (!config.enabled) return 0;
+      return (config.currentStacks || 0) * config.elementalPerStack;
+    },
+    format: v => `+${v.toFixed(0)}%`,
+    description: 'Elemental damage from Juggernaut buildup stacks (3% per stack; count TBD)',
   },
 
   // ---------------------------------------------------------------------------
@@ -1361,10 +1446,11 @@ export const DERIVED_STATS = {
       const essenceCrit = stats.critChanceFromEssence || 0;
       const totalCrit = baseCrit + essenceCrit;
       const excessCrit = Math.max(0, totalCrit - config.critThreshold);
-      return excessCrit * config.elementPerCrit;
+      // Duplicate monogram instances stack additively
+      return excessCrit * config.elementPerCrit * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}%`,
-    description: 'Elemental damage from crit over 100% (3% per 1% crit)',
+    description: 'Elemental damage from crit over 100% (3% per 1% crit, per instance)',
   },
 
   // ---------------------------------------------------------------------------
@@ -1444,10 +1530,11 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.bloodlustDrawBloodBonus.config;
       const stacks = stats.bloodlustStacks || 0;
-      return stacks * config.damagePerStack;
+      // Bracer + blood ring instances stack additively
+      return stacks * config.damagePerStack * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}%`,
-    description: 'Damage bonus from Draw Blood (1% per bloodlust stack)',
+    description: 'Damage bonus from Draw Blood (1% per bloodlust stack, per instance)',
   },
 
   // ---------------------------------------------------------------------------
@@ -2256,6 +2343,7 @@ export const DERIVED_STATS = {
       // Stance-crit-merged sources (formerly the standalone SCHD multiplier)
       const bloodlustCrit = (stats.bloodlustCritDamageBonus || 0) / 100;
       const critFromArmor = (stats.critDamageFromArmor || 0) / 100;
+      const critFromEssence = (stats.critDamageFromEssence || 0) / 100;
       // Physical-only monogram damage%
       const drawBlood = (stats.bloodlustDrawBloodBonus || 0) / 100;
       const colossus = (stats.colossusDamageBonus || 0) / 100;
@@ -2264,7 +2352,7 @@ export const DERIVED_STATS = {
       // Converted elemental damage bonus (edpsED − 1) folded in as physical
       const elemConverted = (config.elemBonusToPhysRatio || 0) * Math.max(0, (stats.edpsED || 1) - 1);
       return critDmg + physBonus + stanceDmg + stanceCrit + bloodlustCrit + critFromArmor
-        + drawBlood + colossus + invSlot + bothTypes + elemConverted;
+        + critFromEssence + drawBlood + colossus + invSlot + bothTypes + elemConverted;
     },
     format: v => `${(v * 100).toFixed(0)}%`,
     description: 'Physical additive bucket: StanceCrit + Crit + PhysDmg% + StanceDmg% + both-types',
@@ -2297,6 +2385,7 @@ export const DERIVED_STATS = {
              : { label: 'stanceDamage', fullName: 'Stance Damage', op: '+', value: 0, fmt: 'pct' },
         { label: 'bloodlustCritDamageBonus', fullName: DERIVED_STATS.bloodlustCritDamageBonus.name, op: '+', value: (stats.bloodlustCritDamageBonus || 0) / 100, fmt: 'pct', isMonogram: true },
         { label: 'critDamageFromArmor', fullName: DERIVED_STATS.critDamageFromArmor.name, op: '+', value: (stats.critDamageFromArmor || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'critDamageFromEssence', fullName: DERIVED_STATS.critDamageFromEssence.name, op: '+', value: (stats.critDamageFromEssence || 0) / 100, fmt: 'pct', isMonogram: true },
         { label: 'bloodlustDrawBloodBonus', fullName: DERIVED_STATS.bloodlustDrawBloodBonus.name, op: '+', value: (stats.bloodlustDrawBloodBonus || 0) / 100, fmt: 'pct', isMonogram: true },
         { label: 'colossusDamageBonus', fullName: DERIVED_STATS.colossusDamageBonus.name, op: '+', value: (stats.colossusDamageBonus || 0) / 100, fmt: 'pct', isMonogram: true },
         { label: 'invSlotDamageBonus', fullName: DERIVED_STATS.invSlotDamageBonus.name, op: '+', value: (stats.invSlotDamageBonus || 0) / 100, fmt: 'pct', isMonogram: true },
@@ -2354,7 +2443,8 @@ export const DERIVED_STATS = {
     layer: LAYERS.EDPS,
     dependencies: ['elementFromCritChance', 'arcaneMineBonus', 'fireMineBonus', 'lightningMineBonus',
       'elementalFromEssence', 'elementalFromHighest', 'berserkerElementalFromHighest',
-      'shroudElementalBonus', 'shroudElementalFromHighest', 'phasingElementalBonus'],
+      'shroudElementalBonus', 'shroudElementalFromHighest', 'phasingElementalBonus',
+      'staticChargeLightningBonus', 'juggernautElementalBonus'],
     calculate: (stats) => {
       const fire = stats.fireDamageBonus || 0;
       const arcane = stats.arcaneDamageBonus || 0;
@@ -2371,8 +2461,11 @@ export const DERIVED_STATS = {
       const shroudElemHi = (stats.shroudElementalFromHighest || 0) / 100;
       const phasingElem = (stats.phasingElementalBonus || 0) / 100;
       const noPotionElem = (stats.damageNoPotionBonus || 0) / 100; // now elemental (15%/slot)
+      const staticCharge = (stats.staticChargeLightningBonus || 0) / 100;
+      const juggernautElem = (stats.juggernautElementalBonus || 0) / 100;
       return 1 + fire + arcane + lightning + elemFromCrit + arcMine + fireMine + ltngMine
-        + essenceElem + highestElem + berserkerElem + shroudElem + shroudElemHi + phasingElem + noPotionElem;
+        + essenceElem + highestElem + berserkerElem + shroudElem + shroudElemHi + phasingElem
+        + noPotionElem + staticCharge + juggernautElem;
     },
     format: v => `${(v * 100).toFixed(0)}%`,
     description: 'Elemental damage multiplier (Fire/Arcane/Lightning + elemental monograms, additive)',
@@ -2392,6 +2485,8 @@ export const DERIVED_STATS = {
       { label: 'shroudElementalFromHighest', fullName: DERIVED_STATS.shroudElementalFromHighest.name, op: '+', value: (stats.shroudElementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'phasingElementalBonus', fullName: DERIVED_STATS.phasingElementalBonus.name, op: '+', value: (stats.phasingElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'damageNoPotionBonus', fullName: DERIVED_STATS.damageNoPotionBonus.name, op: '+', value: (stats.damageNoPotionBonus || 0) / 100, fmt: 'pct', isMonogram: true },
+      { label: 'staticChargeLightningBonus', fullName: DERIVED_STATS.staticChargeLightningBonus.name, op: '+', value: (stats.staticChargeLightningBonus || 0) / 100, fmt: 'pct', isMonogram: true },
+      { label: 'juggernautElementalBonus', fullName: DERIVED_STATS.juggernautElementalBonus.name, op: '+', value: (stats.juggernautElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'ED', fullName: 'Elemental Damage', op: '=', value: stats.edpsED, fmt: 'pct', isSubtotal: true },
     ],
   },

--- a/src/utils/externalBonuses.js
+++ b/src/utils/externalBonuses.js
@@ -18,6 +18,8 @@
  */
 
 import { findStatForAttribute } from './statRegistry.js';
+import { calculateDerivedStats, DERIVED_STATS } from './derivedStats.js';
+import { MONOGRAM_CALC_CONFIGS, BUFF_STACK_MAP } from './monogramConfigs.js';
 
 export const RESIDUAL_SOURCE = 'Untracked (tree/cards) — auto';
 export const MANUAL_SOURCE = 'Manual';
@@ -41,13 +43,87 @@ function sumItemStat(items, statId) {
 }
 
 /**
+ * Compute the temporary life-bonus percentage that was ACTIVE at save time.
+ *
+ * The saved Health value includes contributions from buffs running when the
+ * game saved (verified on a fully-buffed save: Health_29 ≈ unbuffed ×
+ * (1 + DrawLife + MoreLife...)). To recover the unbuffed base, run the engine
+ * with the equipped monograms but with stack counts taken from the save's
+ * StatusEffects — a buff not present at save time contributes 0.
+ *
+ * @param {Array} items - Equipped item models (monograms drive the chains)
+ * @param {Object<string, {value:number}>} allocatedAttributes - Base attribute pool
+ * @param {Array<{id:string, stacks:number}>} statusEffects - Parsed save buffs
+ * @returns {number} Temp life bonus active at save, as a decimal (1.0 = +100%)
+ */
+export function computeSaveTimeTempLifePct(items, allocatedAttributes, statusEffects) {
+  if (!statusEffects || statusEffects.length === 0) return 0;
+
+  // Aggregate base stats the same way useDerivedStats does (gear + allocated)
+  const base = {};
+  for (const [statId, v] of Object.entries(allocatedAttributes || {})) {
+    const value = typeof v === 'number' ? v : Number(v?.value || 0);
+    base[statId] = (base[statId] || 0) + value;
+  }
+  for (const item of items || []) {
+    for (const s of item?.baseStats || []) {
+      const def = findStatForAttribute(s.rawTag || s.stat || '');
+      if (def?.id && typeof s.value === 'number') base[def.id] = (base[def.id] || 0) + s.value;
+    }
+  }
+
+  // Enable monogram-driven configs from equipped gear (theorycraft defaults)...
+  const overrides = {};
+  const seen = new Set();
+  for (const item of items || []) {
+    for (const m of item?.monograms || []) {
+      if (seen.has(m.id)) continue;
+      seen.add(m.id);
+      const mc = MONOGRAM_CALC_CONFIGS[m.id];
+      if (!mc?.effects) continue;
+      for (const e of mc.effects) {
+        if (e.derivedStatId && e.config) {
+          overrides[e.derivedStatId] = { ...DERIVED_STATS[e.derivedStatId]?.config, ...e.config };
+        }
+      }
+    }
+  }
+
+  // ...then pin stack counts to what was actually running at save time.
+  // Any stack-based buff NOT in StatusEffects was inactive → 0 stacks.
+  const savedStacks = {};
+  for (const buff of statusEffects) {
+    const stackStatId = BUFF_STACK_MAP[buff.id];
+    if (stackStatId) savedStacks[stackStatId] = buff.stacks || 0;
+  }
+  for (const stackStatId of Object.values(BUFF_STACK_MAP)) {
+    const current = savedStacks[stackStatId] ?? 0;
+    overrides[stackStatId] = {
+      ...DERIVED_STATS[stackStatId]?.config,
+      ...(overrides[stackStatId] || {}),
+      enabled: current > 0 ? true : (overrides[stackStatId]?.enabled ?? false),
+      currentStacks: current,
+    };
+  }
+
+  const r = calculateDerivedStats(base, overrides);
+  const tempPct = (r.lifeBuffBonus || 0)
+    + (r.bloodlustLifeBonus || 0)
+    + (r.shroudLifeBonus || 0)
+    + (r.damageCircleLifeBonus || 0)
+    + (r.lifeBonusFromCritChance || 0)
+    + (r.lifeFromElement || 0);
+  return tempPct / 100;
+}
+
+/**
  * Compute the untracked flat-health residual from the saved max health.
  *
  * Saved health bakes in permanent flat × health% from ALL sources (gear plus
- * untracked tree/cards/level). Removing the known gear contribution leaves the
- * untracked flat remainder:
+ * untracked tree/cards/level) AND any temp life buffs active at save time:
  *
- *   residual = savedMaxHealth / (1 + gear health%) − gear flat health
+ *   residual = savedMaxHealth / ((1 + gear health%) × (1 + save-time temp life%))
+ *              − gear flat health
  *
  * Known simplification: permanent monogram HP (e.g. paragon) currently lands
  * in the residual rather than its own line — totals stay correct, attribution
@@ -55,13 +131,17 @@ function sumItemStat(items, statId) {
  *
  * @param {Array} items - Equipped item models
  * @param {number} savedMaxHealth - Health value from save player data
+ * @param {Object} [opts]
+ * @param {Object} [opts.allocatedAttributes] - Base attribute pool (for buff scaling)
+ * @param {Array} [opts.statusEffects] - Parsed save buffs (divides out active temp life)
  * @returns {number} Residual flat health (0 if nothing to seed)
  */
-export function computeHealthResidual(items, savedMaxHealth) {
+export function computeHealthResidual(items, savedMaxHealth, opts = {}) {
   if (!savedMaxHealth || savedMaxHealth <= 0) return 0;
   const gearFlat = sumItemStat(items, 'health');
   const gearBonus = sumItemStat(items, 'healthBonus'); // decimal (0.10 = 10%)
-  const residual = savedMaxHealth / (1 + gearBonus) - gearFlat;
+  const tempLife = computeSaveTimeTempLifePct(items, opts.allocatedAttributes, opts.statusEffects);
+  const residual = savedMaxHealth / ((1 + gearBonus) * (1 + tempLife)) - gearFlat;
   return residual > 0 ? Math.round(residual) : 0;
 }
 
@@ -71,11 +151,12 @@ export function computeHealthResidual(items, savedMaxHealth) {
  *
  * @param {Array} items - Equipped item models
  * @param {number} savedMaxHealth - Health value from save player data
+ * @param {Object} [opts] - See computeHealthResidual
  * @returns {Object<string, {value: number, sourceName: string}>}
  */
-export function seedExternalBonuses(items, savedMaxHealth) {
+export function seedExternalBonuses(items, savedMaxHealth, opts = {}) {
   const bonuses = {};
-  const healthResidual = computeHealthResidual(items, savedMaxHealth);
+  const healthResidual = computeHealthResidual(items, savedMaxHealth, opts);
   if (healthResidual > 0) {
     bonuses.health = { value: healthResidual, sourceName: RESIDUAL_SOURCE };
   }

--- a/src/utils/externalBonuses.js
+++ b/src/utils/externalBonuses.js
@@ -72,19 +72,22 @@ export function computeSaveTimeTempLifePct(items, allocatedAttributes, statusEff
     }
   }
 
-  // Enable monogram-driven configs from equipped gear (theorycraft defaults)...
-  const overrides = {};
-  const seen = new Set();
+  // Enable monogram-driven configs from equipped gear (theorycraft defaults).
+  // Duplicate monograms stack additively — count instances first (mirrors
+  // useDerivedStats) so e.g. two MoreLife rings double the divisor too.
+  const instanceCounts = {};
   for (const item of items || []) {
     for (const m of item?.monograms || []) {
-      if (seen.has(m.id)) continue;
-      seen.add(m.id);
-      const mc = MONOGRAM_CALC_CONFIGS[m.id];
-      if (!mc?.effects) continue;
-      for (const e of mc.effects) {
-        if (e.derivedStatId && e.config) {
-          overrides[e.derivedStatId] = { ...DERIVED_STATS[e.derivedStatId]?.config, ...e.config };
-        }
+      instanceCounts[m.id] = (instanceCounts[m.id] || 0) + 1;
+    }
+  }
+  const overrides = {};
+  for (const [monoId, instanceCount] of Object.entries(instanceCounts)) {
+    const mc = MONOGRAM_CALC_CONFIGS[monoId];
+    if (!mc?.effects) continue;
+    for (const e of mc.effects) {
+      if (e.derivedStatId && e.config) {
+        overrides[e.derivedStatId] = { ...DERIVED_STATS[e.derivedStatId]?.config, ...e.config, instanceCount };
       }
     }
   }

--- a/src/utils/externalBonuses.js
+++ b/src/utils/externalBonuses.js
@@ -1,0 +1,83 @@
+/**
+ * External Bonuses — catch-all bucket for untracked character-wide stats.
+ *
+ * The save can't attribute every stat total to a source: the main levelup tree
+ * is ~200 opaque node IDs, crystal cards are unmapped, and seasonal changes
+ * shift values faster than they can be verified. Instead of pretending those
+ * sources don't exist, this bucket holds per-stat bonuses that sit outside any
+ * item — seeded from save data where an authoritative total exists (health),
+ * user-editable everywhere else.
+ *
+ * Shape matches allocatedAttributes for easy aggregation:
+ *   { [statId]: { value: number, sourceName: string } }
+ *
+ * As card/tree mappings land in the registries, their parsed contributions
+ * shrink the seeded residual instead of changing displayed totals.
+ *
+ * @module utils/externalBonuses
+ */
+
+import { findStatForAttribute } from './statRegistry.js';
+
+export const RESIDUAL_SOURCE = 'Untracked (tree/cards) — auto';
+export const MANUAL_SOURCE = 'Manual';
+
+/**
+ * Sum a stat across item baseStats, resolving tags through the registry.
+ *
+ * @param {Array<{baseStats?: Array}>} items - Item models (save- or share-derived)
+ * @param {string} statId - Registry stat ID to sum
+ * @returns {number}
+ */
+function sumItemStat(items, statId) {
+  let total = 0;
+  for (const item of items || []) {
+    for (const s of item?.baseStats || []) {
+      const def = findStatForAttribute(s.rawTag || s.stat || '');
+      if (def?.id === statId && typeof s.value === 'number') total += s.value;
+    }
+  }
+  return total;
+}
+
+/**
+ * Compute the untracked flat-health residual from the saved max health.
+ *
+ * Saved health bakes in permanent flat × health% from ALL sources (gear plus
+ * untracked tree/cards/level). Removing the known gear contribution leaves the
+ * untracked flat remainder:
+ *
+ *   residual = savedMaxHealth / (1 + gear health%) − gear flat health
+ *
+ * Known simplification: permanent monogram HP (e.g. paragon) currently lands
+ * in the residual rather than its own line — totals stay correct, attribution
+ * refines as more sources are subtracted here.
+ *
+ * @param {Array} items - Equipped item models
+ * @param {number} savedMaxHealth - Health value from save player data
+ * @returns {number} Residual flat health (0 if nothing to seed)
+ */
+export function computeHealthResidual(items, savedMaxHealth) {
+  if (!savedMaxHealth || savedMaxHealth <= 0) return 0;
+  const gearFlat = sumItemStat(items, 'health');
+  const gearBonus = sumItemStat(items, 'healthBonus'); // decimal (0.10 = 10%)
+  const residual = savedMaxHealth / (1 + gearBonus) - gearFlat;
+  return residual > 0 ? Math.round(residual) : 0;
+}
+
+/**
+ * Seed the external-bonuses bucket from save-derived data.
+ * Currently seeds only the health residual; other stats start manual/empty.
+ *
+ * @param {Array} items - Equipped item models
+ * @param {number} savedMaxHealth - Health value from save player data
+ * @returns {Object<string, {value: number, sourceName: string}>}
+ */
+export function seedExternalBonuses(items, savedMaxHealth) {
+  const bonuses = {};
+  const healthResidual = computeHealthResidual(items, savedMaxHealth);
+  if (healthResidual > 0) {
+    bonuses.health = { value: healthResidual, sourceName: RESIDUAL_SOURCE };
+  }
+  return bonuses;
+}

--- a/src/utils/monogramConfigs.js
+++ b/src/utils/monogramConfigs.js
@@ -13,6 +13,18 @@
  * @module utils/monogramConfigs
  */
 
+/**
+ * Save buff row (DT_StatusEffects RowName) → engine stack-stat ID.
+ * Used to reconstruct which stack-based buffs were ACTIVE at save time — the
+ * saved Health value includes their contributions, so residual seeding must
+ * divide them out. Only observed rows are listed; append as new ones show up.
+ */
+export const BUFF_STACK_MAP = {
+  'Buff_Bloodlust': 'bloodlustStacks',
+  'Buff_Life': 'lifeBuffStacks',        // Bloodlust.DrawLife life stacks
+  'Buff_DarkEssence': 'darkEssenceStacks',
+};
+
 export const MONOGRAM_CALC_CONFIGS = {
   // ===========================================================================
   // PHASING (Helmet Monogram - 50 stacks)

--- a/src/utils/monogramConfigs.js
+++ b/src/utils/monogramConfigs.js
@@ -93,13 +93,22 @@ export const MONOGRAM_CALC_CONFIGS = {
   },
 
   // ===========================================================================
-  // ESSENCE → CRIT CHAIN
-  // 1% crit per 20 essence
+  // ESSENCE → CRIT CHAINS (stack additively per instance)
+  // Pants: 1.5% crit CHANCE per 20 essence (incl. Dark Essence)
+  // Boots: crit DAMAGE per 20 essence (value TBD; rolls multiple times)
   // ===========================================================================
-  'BonusCritDamage%ForEssence': {
-    displayName: 'Crit from Essence',
+  'BonusCritChance%ForEssence': {
+    displayName: 'Crit Chance from Essence',
+    description: '+1.5% crit chance per 20 essence (per instance)',
     effects: [
-      { derivedStatId: 'critChanceFromEssence', config: { enabled: true, essencePerCrit: 20 } },
+      { derivedStatId: 'critChanceFromEssence', config: { enabled: true, essencePerCrit: 20, critPerInterval: 1.5 } },
+    ],
+  },
+  'BonusCritDamage%ForEssence': {
+    displayName: 'Crit Damage from Essence',
+    description: 'Crit damage per 20 essence (per instance; value TBD)',
+    effects: [
+      { derivedStatId: 'critDamageFromEssence', config: { enabled: true, essencePerInterval: 20, critDamagePerInterval: 1.5 } },
     ],
   },
   'GainCritChanceForHighest': {
@@ -336,11 +345,13 @@ export const MONOGRAM_CALC_CONFIGS = {
   // ===========================================================================
   'Juggernaut': {
     displayName: 'Juggernaut',
-    description: '+40% MS, +25% crit, 2x crit damage (fist pinnacle, single instance)',
+    description: '+40% MS, +25% crit, 2x crit damage; buildup stacks grant +3% elemental each (fist keystone)',
     effects: [
       { derivedStatId: 'juggernautMoveSpeed', config: { enabled: true, moveSpeedBonus: 40 } },
       { derivedStatId: 'juggernautCritChance', config: { enabled: true, critChanceBonus: 25 } },
       { derivedStatId: 'juggernautCritDamage', config: { enabled: true, critDamageMultiplier: 2 } },
+      // Buildup elemental: stack count at full buildup unconfirmed (default 0)
+      { derivedStatId: 'juggernautElementalBonus', config: { enabled: true, elementalPerStack: 3, currentStacks: 0 } },
     ],
   },
 
@@ -552,6 +563,18 @@ export const MONOGRAM_CALC_CONFIGS = {
     effects: [
       { derivedStatId: 'lightningMineBonus', config: { enabled: true, bonusPerStack: 5, maxStacks: 20, currentStacks: 20 } },
     ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // VEIL (Relic - defensive, no offense calc impact)
+  // 1% DR per second while moving, up to 50 stacks; 50% DR against a single
+  // hit. Some monograms key off losing veil stacks, but the mechanic isn't
+  // calc-relevant for eDPS.
+  // ---------------------------------------------------------------------------
+  'Veil': {
+    displayName: 'Veil',
+    description: '50% DR vs one hit at 50 stacks (1%/sec moving; defensive, no eDPS impact)',
+    effects: [],
   },
 
   // ---------------------------------------------------------------------------

--- a/src/utils/skillTreeRegistry.js
+++ b/src/utils/skillTreeRegistry.js
@@ -271,6 +271,74 @@ export const CARD_REGISTRY = {
   'CARD17_4': { rowName: 'CARD17_4', family: 17, variant: 4, name: 'Card 17-4', maxLevel: 6, effects: [] },
 };
 
+// =============================================================================
+// CARD ARCHETYPES — known in-game effect templates (values per level 1)
+// =============================================================================
+// The in-game card VALUES are known; which CARD{N}_{variant} ID maps to which
+// archetype is NOT yet — fill CARD_ID_TO_ARCHETYPE as mappings are verified.
+//
+// Level scaling: cards have discrete levels and each level adds the base again,
+// so effect = base × level. The final upgrade doubles L3 (saves observed so far
+// store it as level 6; if a format stores 4, treat ≥4 as the 6× tier).
+//
+// Value conventions match statRegistry (percents as decimals). "stat" means one
+// specific primary attribute per card (one card per attribute); "element" means
+// one of fire/arcane/lightning per card. The `param`/`paramBonus` placeholders
+// resolve against the mapping's concrete attribute/element statId.
+
+export const CARD_ARCHETYPES = {
+  // --- ATTRIBUTE CARDS (param: attribute statId, e.g. 'luck') ---
+  'stat+health':      { name: '+15 stat / +50 health', effects: [{ statId: 'param', value: 15 }, { statId: 'health', value: 50 }] },
+  'stat+physBonus':   { name: '+15 stat / +5% physical damage', effects: [{ statId: 'param', value: 15 }, { statId: 'damageBonus', value: 0.05 }] },
+  'stat+critChance':  { name: '+15 stat / +1% crit chance', effects: [{ statId: 'param', value: 15 }, { statId: 'critChance', value: 0.01 }] },
+  'stat+critDamage':  { name: '+15 stat / +5% crit damage', effects: [{ statId: 'param', value: 15 }, { statId: 'critDamage', value: 0.05 }] },
+  'stat+energy':      { name: '+15 stat / +5 max energy', effects: [{ statId: 'param', value: 15 }, { statId: 'maxEnergy', value: 5 }] },
+  'stat+attackSpeed': { name: '+15 stat / +75 attack speed', effects: [{ statId: 'param', value: 15 }, { statId: 'attackSpeed', value: 0.75 }] },
+  'statBonus+xp':     { name: '+10% stat / +1% experience', effects: [{ statId: 'paramBonus', value: 0.10 }, { statId: 'xpBonus', value: 0.01 }] },
+  'statBonus+health': { name: '+5% stat / +50 health', effects: [{ statId: 'paramBonus', value: 0.05 }, { statId: 'health', value: 50 }] },
+
+  // --- ELEMENTAL CARDS (param: fireDamageBonus / arcaneDamageBonus / lightningDamageBonus) ---
+  'element+physFlat': { name: '+10% element / +10 physical damage', effects: [{ statId: 'param', value: 0.10 }, { statId: 'damage', value: 10 }] },
+  'element+armor':    { name: '+5% element / +150 armor', effects: [{ statId: 'param', value: 0.05 }, { statId: 'armor', value: 150 }] },
+  'element+invSlots': { name: '+10% element / +4 inventory slots', effects: [{ statId: 'param', value: 0.10 }, { statId: 'inventorySlots', value: 4 }] },
+
+  // --- REMAINS ---
+  'triStat':          { name: '+15 STR/AGI/STA', effects: [{ statId: 'strength', value: 15 }, { statId: 'agility', value: 15 }, { statId: 'stamina', value: 15 }] },
+  'healthBonus':      { name: '+10% health', effects: [{ statId: 'healthBonus', value: 0.10 }] },
+  'physFlat':         { name: '+20 physical damage', effects: [{ statId: 'damage', value: 20 }] },
+  'dr+physFlat':      { name: '+1% DR / +10 physical damage', effects: [{ statId: 'damageReduction', value: 0.01 }, { statId: 'damage', value: 10 }] },
+  'dr+armor':         { name: '+1% DR / +150 armor', effects: [{ statId: 'damageReduction', value: 0.01 }, { statId: 'armor', value: 150 }] },
+  'boss+physFlat':    { name: '+10% boss / +10 physical damage', effects: [{ statId: 'bossBonus', value: 0.10 }, { statId: 'damage', value: 10 }] },
+  'physBonus+health': { name: '+10% physical damage / +75 health', effects: [{ statId: 'damageBonus', value: 0.10 }, { statId: 'health', value: 75 }] },
+};
+
+/**
+ * CARD ID → archetype mapping. TODO: verify in-game per season. Each entry:
+ * { archetype: keyof CARD_ARCHETYPES, param?: string } where param is the
+ * concrete attribute/element statId for parametric archetypes.
+ * Unmapped cards implicitly contribute via the external-bonuses residual.
+ */
+export const CARD_ID_TO_ARCHETYPE = {};
+
+/**
+ * Resolve a card's concrete effects at a given level, if its ID is mapped.
+ *
+ * @param {string} rowName - e.g. 'CARD3_2'
+ * @param {number} level - Stored card level (acts as the multiplier: L3 = 3×, L6 = 6×)
+ * @returns {Array<{statId: string, value: number}>|null} Scaled effects, or null if unmapped
+ */
+export function getCardEffects(rowName, level = 1) {
+  const mapping = CARD_ID_TO_ARCHETYPE[rowName];
+  if (!mapping) return null;
+  const archetype = CARD_ARCHETYPES[mapping.archetype];
+  if (!archetype) return null;
+  return archetype.effects.map(e => ({
+    statId: e.statId === 'param' ? mapping.param
+      : e.statId === 'paramBonus' ? `${mapping.param}Bonus`
+      : e.statId,
+    value: e.value * level,
+  }));
+}
 
 // =============================================================================
 // MAIN TREE KEYSTONES (manually curated checklist for user input)

--- a/src/utils/stanceSkills.js
+++ b/src/utils/stanceSkills.js
@@ -246,6 +246,48 @@ export function parseMaxHealth(saveData) {
 }
 
 /**
+ * Read active status effects (buffs) from save player data.
+ *
+ * Located at AbilitySystemSaveData_73 → StatusEffects_75: an array of
+ * DT_StatusEffects row handles with current Stack and TimeRemaining. This is
+ * where transient buffs live (e.g. Buff_Bloodlust with Stack 100) — their
+ * health/damage contributions are NOT baked into the saved Health value.
+ * Currently informational: stored in metadata for future buff-stack seeding.
+ *
+ * @param {Object} saveData
+ * @returns {Array<{id: string, stacks: number, timeRemaining: number}>}
+ */
+export function parseStatusEffects(saveData) {
+  const hostPlayerStruct = findHostPlayerStruct(saveData);
+  if (!hostPlayerStruct) return [];
+
+  const asKey = Object.keys(hostPlayerStruct).find(k => k.startsWith('AbilitySystemSaveData_'));
+  const asStruct = hostPlayerStruct[asKey]?.Struct?.Struct;
+  if (!asStruct) return [];
+
+  const seKey = Object.keys(asStruct).find(k => k.startsWith('StatusEffects_'));
+  const entries = asStruct[seKey]?.Array?.Struct?.value;
+  if (!Array.isArray(entries)) return [];
+
+  const result = [];
+  for (const entry of entries) {
+    const structData = entry?.Struct;
+    if (!structData) continue;
+    const handleKey = Object.keys(structData).find(k => k.startsWith('EffectHandle_'));
+    const stackKey = Object.keys(structData).find(k => k.startsWith('Stack_'));
+    const timeKey = Object.keys(structData).find(k => k.startsWith('TimeRemaining_'));
+    const id = structData[handleKey]?.Struct?.Struct?.RowName_0?.Name;
+    if (!id) continue;
+    result.push({
+      id,
+      stacks: structData[stackKey]?.Int ?? 0,
+      timeRemaining: structData[timeKey]?.Float ?? 0,
+    });
+  }
+  return result;
+}
+
+/**
  * Reconstruct a stanceContext from decoded share mastery data.
  * Used by loadFromShare so useDerivedStats gets proper stance/mastery effects
  * even when no save file is loaded.

--- a/src/utils/stanceSkills.js
+++ b/src/utils/stanceSkills.js
@@ -224,6 +224,28 @@ export function parseAllocatedAttributes(saveData) {
 }
 
 /**
+ * Read the character's max health from save player data.
+ *
+ * The 1%-of-max-Health monogram needs the real total health, which is NOT
+ * derivable from gear (it comes mostly from base/VIT). The save stores the
+ * player's health as a Double in `Health_29_*`. NOTE: this is current health,
+ * which equals max at full HP — there is no separate stored max, so this is the
+ * best available proxy.
+ *
+ * @param {Object} saveData
+ * @returns {number} Max health (0 if unavailable)
+ */
+export function parseMaxHealth(saveData) {
+  const hostPlayerStruct = findHostPlayerStruct(saveData);
+  if (!hostPlayerStruct) return 0;
+  const key = Object.keys(hostPlayerStruct).find(k => k.startsWith('Health_'));
+  if (!key) return 0;
+  const node = hostPlayerStruct[key];
+  const value = node?.Double ?? node?.Float ?? null;
+  return typeof value === 'number' ? value : 0;
+}
+
+/**
  * Reconstruct a stanceContext from decoded share mastery data.
  * Used by loadFromShare so useDerivedStats gets proper stance/mastery effects
  * even when no save file is loaded.

--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -825,7 +825,8 @@ export const STAT_REGISTRY = {
     isPercent: false,
     format: v => `+${v.toFixed(0)}`,
     description: 'Maximum health points',
-    regexPatterns: ['MaxHealth', 'Health$', '\\.Health$'],
+    // Anchored so a hypothetical MaxHealth% tag can't be claimed as flat health.
+    regexPatterns: ['MaxHealth$', '\\.MaxHealth$', 'Health$', '\\.Health$'],
   },
   healthBonus: {
     id: 'healthBonus',

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -586,6 +586,15 @@ describe('CharacterShareModel — allocated attributes', () => {
     expect(allocatedAttributesShareToData(undefined)).toEqual({});
   });
 
+  it('carries character max health (hp) for the 1%-health monogram', () => {
+    const payload = createCharacterSharePayload([], null, null, 5977.49);
+    expect(payload.hp).toBe(5977); // rounded
+    const decoded = decodeCharacterShare(encodeCharacterShare(payload));
+    expect(decoded.hp).toBe(5977);
+    // Omitted when 0 (backward compatible).
+    expect(createCharacterSharePayload([], null, null, 0).hp).toBeUndefined();
+  });
+
   it('feature parity: shared totals include the base pool (the luck-977 regression)', () => {
     // Before this fix the share carried only gear (~100 luck); the allocated
     // pool (~535) was dropped. Verify aggregating restored allocated + gear

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -10,6 +10,7 @@ import {
   createCharacterSharePayload,
   createAllocatedAttributesShare,
   allocatedAttributesShareToData,
+  externalBonusesShareToData,
   itemShareToItem,
   masteryShareToData,
   CHARACTER_SHARE_VERSION,
@@ -586,13 +587,20 @@ describe('CharacterShareModel — allocated attributes', () => {
     expect(allocatedAttributesShareToData(undefined)).toEqual({});
   });
 
-  it('carries character max health (hp) for the 1%-health monogram', () => {
-    const payload = createCharacterSharePayload([], null, null, 5977.49);
-    expect(payload.hp).toBe(5977); // rounded
+  it('carries external bonuses (xb) — e.g. the seeded health residual', () => {
+    const external = { health: { value: 5908, sourceName: 'Untracked (tree/cards) — auto' } };
+    const payload = createCharacterSharePayload([], null, null, external);
+    expect(payload.xb).toEqual([[encodeIdOrString(STAT_DICT, 'health'), 5908]]);
+    // hp is legacy — no longer written
+    expect(payload.hp).toBeUndefined();
+
     const decoded = decodeCharacterShare(encodeCharacterShare(payload));
-    expect(decoded.hp).toBe(5977);
-    // Omitted when 0 (backward compatible).
-    expect(createCharacterSharePayload([], null, null, 0).hp).toBeUndefined();
+    const restored = externalBonusesShareToData(decoded.xb);
+    expect(restored.health.value).toBe(5908);
+
+    // Omitted when empty (backward compatible); old links without xb decode to {}
+    expect(createCharacterSharePayload([], null, null, null).xb).toBeUndefined();
+    expect(externalBonusesShareToData(undefined)).toEqual({});
   });
 
   it('feature parity: shared totals include the base pool (the luck-977 regression)', () => {

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -587,6 +587,29 @@ describe('CharacterShareModel — allocated attributes', () => {
     expect(allocatedAttributesShareToData(undefined)).toEqual({});
   });
 
+  it('preserves duplicate monogram instances (additive stacking) through round-trip', () => {
+    // Within one item (boots roll the same monogram twice) and across items
+    // (two MoreLife rings) — instance counts drive additive stacking, so the
+    // share must keep every copy, not a deduped set.
+    const items = [
+      {
+        slot: 'boots', rowName: 'Boots_Test', baseStats: [],
+        monograms: [
+          { id: 'BonusCritDamage%ForEssence', value: 1 },
+          { id: 'BonusCritDamage%ForEssence', value: 1 },
+        ],
+      },
+      { slot: 'ring', rowName: 'Ring_A', baseStats: [], monograms: [{ id: 'Bloodlust.MoreLife.Highest', value: 1 }] },
+      { slot: 'ring', rowName: 'Ring_B', baseStats: [], monograms: [{ id: 'Bloodlust.MoreLife.Highest', value: 1 }] },
+    ];
+    const decoded = decodeCharacterShare(encodeCharacterShare(createCharacterSharePayload(items)));
+    const restored = (decoded.e || []).map((s, i) => itemShareToItem(s, i));
+    const counts = {};
+    for (const it of restored) for (const m of it.monograms || []) counts[m.id] = (counts[m.id] || 0) + 1;
+    expect(counts['BonusCritDamage%ForEssence']).toBe(2);
+    expect(counts['Bloodlust.MoreLife.Highest']).toBe(2);
+  });
+
   it('carries external bonuses (xb) — e.g. the seeded health residual', () => {
     const external = { health: { value: 5908, sourceName: 'Untracked (tree/cards) — auto' } };
     const payload = createCharacterSharePayload([], null, null, external);

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -554,6 +554,22 @@ describe('derivedStats', () => {
       expect(r.edpsPhysFlat).toBe(159);
       expect(r.edpsElemFlat).toBe(109);
     });
+
+    it('health monogram applies temporary life bonuses on top of saved max health', () => {
+      // Saved max health bakes in permanent flat×% (gear/tree/cards) but NOT
+      // temporary buffs. With Bloodlust DrawLife (+1% life/stack, 100 stacks)
+      // and MoreLife.Highest (0.1%/stack per 50 highest) active:
+      const r = calculateDerivedStats({ strength: 1000 }, {
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1, maxHealth: 5977 },
+        lifeBuffStacks: { enabled: true, maxStacks: 100, currentStacks: 100 },
+        bloodlustLifeBonus: { enabled: true, lifePerStackPer50: 0.1 },
+      });
+      // lifeBuffBonus = 100%; bloodlustLifeBonus = 100 × 0.1 × (1000/50) = 200%
+      expect(r.lifeBuffBonus).toBe(100);
+      expect(r.bloodlustLifeBonus).toBeCloseTo(200, 1);
+      // damageFromHealth = floor(5977 × (1 + 3.0) × 1%) = floor(239.08) = 239
+      expect(r.damageFromHealth).toBe(239);
+    });
   });
 });
 

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -542,6 +542,18 @@ describe('derivedStats', () => {
       expect(on.edpsPhysFlat).toBe(200);
       expect(on.edpsElemFlat).toBe(150);
     });
+
+    it('health monogram prefers real max health (from save/share) over gear-summed totalHealth', () => {
+      // Gear health is only 69 here; the character's real max health is 5977.
+      const base = { damage: 100, elementalDamage: 50, health: 69 };
+      const r = calculateDerivedStats(base, {
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1, maxHealth: 5977 },
+      });
+      // 1% of 5977 = 59 (not 1% of gear 69 = 0)
+      expect(r.damageFromHealth).toBe(59);
+      expect(r.edpsPhysFlat).toBe(159);
+      expect(r.edpsElemFlat).toBe(109);
+    });
   });
 });
 

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -204,8 +204,8 @@ describe('derivedStats', () => {
       // essence = highestAttribute * 1.25 at 500 stacks
       expect(result.essence).toBe(1250);
 
-      // critChanceFromEssence = essence / 20 = 62%
-      expect(result.critChanceFromEssence).toBe(62);
+      // critChanceFromEssence = floor(essence / 20) × 1.5%/interval = 93%
+      expect(result.critChanceFromEssence).toBe(93);
     });
 
     it('should return 0 for disabled monograms', () => {

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -543,24 +543,26 @@ describe('derivedStats', () => {
       expect(on.edpsElemFlat).toBe(150);
     });
 
-    it('health monogram prefers real max health (from save/share) over gear-summed totalHealth', () => {
-      // Gear health is only 69 here; the character's real max health is 5977.
-      const base = { damage: 100, elementalDamage: 50, health: 69 };
+    it('health monogram reads totalHealth including the untracked residual', () => {
+      // Gear health is only 69; the external-bonuses bucket carries the
+      // untracked (tree/cards) residual of 5908 seeded from the save, so
+      // totalHealth = 69 + 5908 = 5977 (the hook aggregates both into `health`).
+      const base = { damage: 100, elementalDamage: 50, health: 69 + 5908 };
       const r = calculateDerivedStats(base, {
-        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1, maxHealth: 5977 },
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1 },
       });
-      // 1% of 5977 = 59 (not 1% of gear 69 = 0)
+      // 1% of 5977 = 59
       expect(r.damageFromHealth).toBe(59);
       expect(r.edpsPhysFlat).toBe(159);
       expect(r.edpsElemFlat).toBe(109);
     });
 
-    it('health monogram applies temporary life bonuses on top of saved max health', () => {
-      // Saved max health bakes in permanent flat×% (gear/tree/cards) but NOT
+    it('health monogram applies temporary life bonuses on top of total health', () => {
+      // Total health (gear + residual) bakes in permanent flat×% but NOT
       // temporary buffs. With Bloodlust DrawLife (+1% life/stack, 100 stacks)
       // and MoreLife.Highest (0.1%/stack per 50 highest) active:
-      const r = calculateDerivedStats({ strength: 1000 }, {
-        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1, maxHealth: 5977 },
+      const r = calculateDerivedStats({ strength: 1000, health: 5977 }, {
+        damageFromHealth: { enabled: true, sourceStat: 'totalHealth', percentage: 1 },
         lifeBuffStacks: { enabled: true, maxStacks: 100, currentStacks: 100 },
         bloodlustLifeBonus: { enabled: true, lifePerStackPer50: 0.1 },
       });

--- a/test/externalBonuses.test.js
+++ b/test/externalBonuses.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   computeHealthResidual,
+  computeSaveTimeTempLifePct,
   seedExternalBonuses,
   RESIDUAL_SOURCE,
 } from '../src/utils/externalBonuses.js';
@@ -45,6 +46,42 @@ describe('external bonuses — health residual', () => {
     const seeded = seedExternalBonuses(gearItems, 5977.49);
     expect(seeded.health).toEqual({ value: 5908, sourceName: RESIDUAL_SOURCE });
     expect(seedExternalBonuses(gearItems, 0)).toEqual({});
+  });
+});
+
+describe('external bonuses — buff-aware residual (saved health includes active buffs)', () => {
+  // Amulet with the DrawLife monogram (life buff chain equipped)
+  const buffGear = [
+    {
+      baseStats: [{ rawTag: 'EasyRPG.Attributes.Base.MaxHealth', value: 100 }],
+      monograms: [{ id: 'Bloodlust.DrawLife', value: 1 }],
+    },
+  ];
+
+  it('computes save-time temp life% from StatusEffects stacks', () => {
+    // Buff_Life at 50 stacks → DrawLife +1%/stack = +50%
+    const pct = computeSaveTimeTempLifePct(buffGear, {}, [{ id: 'Buff_Life', stacks: 50 }]);
+    expect(pct).toBeCloseTo(0.5, 3);
+    // No buffs at save → 0 even though the monogram is equipped
+    expect(computeSaveTimeTempLifePct(buffGear, {}, [])).toBe(0);
+  });
+
+  it('divides active temp life buffs out of the saved health', () => {
+    // Unbuffed base 2000 (100 gear + 1900 untracked); saved at full Buff_Life
+    // (100 stacks → ×2.0): saved = 4000
+    const residual = computeHealthResidual(buffGear, 4000, {
+      allocatedAttributes: {},
+      statusEffects: [{ id: 'Buff_Life', stacks: 100 }],
+    });
+    expect(residual).toBe(1900);
+  });
+
+  it('unbuffed saves are unaffected (no life buff in StatusEffects)', () => {
+    const residual = computeHealthResidual(buffGear, 2000, {
+      allocatedAttributes: {},
+      statusEffects: [{ id: 'Buff_Bloodlust', stacks: 100 }], // bloodlust ≠ life
+    });
+    expect(residual).toBe(1900);
   });
 });
 

--- a/test/externalBonuses.test.js
+++ b/test/externalBonuses.test.js
@@ -83,6 +83,23 @@ describe('external bonuses — buff-aware residual (saved health includes active
     });
     expect(residual).toBe(1900);
   });
+
+  it('duplicate monogram instances stack additively in the save-time divisor', () => {
+    // Two MoreLife rings: 0.1%/stack per 50 highest, ×2 instances.
+    // With 1000 highest and Buff_Life at 100 stacks: 2 × (100 × 0.1 × 20) = 400%.
+    const twoRings = [
+      { baseStats: [], monograms: [{ id: 'Bloodlust.MoreLife.Highest', value: 1 }] },
+      { baseStats: [], monograms: [{ id: 'Bloodlust.MoreLife.Highest', value: 1 }] },
+      { baseStats: [], monograms: [{ id: 'Bloodlust.DrawLife', value: 1 }] },
+    ];
+    const pct = computeSaveTimeTempLifePct(
+      twoRings,
+      { strength: { value: 1000 } },
+      [{ id: 'Buff_Life', stacks: 100 }]
+    );
+    // DrawLife 100% + MoreLife ×2 400% = 500%
+    expect(pct).toBeCloseTo(5.0, 2);
+  });
 });
 
 describe('card archetypes', () => {

--- a/test/externalBonuses.test.js
+++ b/test/externalBonuses.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeHealthResidual,
+  seedExternalBonuses,
+  RESIDUAL_SOURCE,
+} from '../src/utils/externalBonuses.js';
+import { CARD_ARCHETYPES, CARD_ID_TO_ARCHETYPE, getCardEffects } from '../src/utils/skillTreeRegistry.js';
+import { getStatById } from '../src/utils/statRegistry.js';
+
+const gearItems = [
+  {
+    baseStats: [
+      { rawTag: 'EasyRPG.Attributes.Base.MaxHealth', value: 69.14 },
+      { rawTag: 'EasyRPG.Attributes.Base.Damage', value: 100 },
+    ],
+  },
+];
+
+describe('external bonuses — health residual', () => {
+  it('computes residual = savedMaxHealth / (1 + gear health%) − gear flat', () => {
+    // No health% on gear: residual = 5977 − 69.14 ≈ 5908
+    expect(computeHealthResidual(gearItems, 5977.49)).toBe(5908);
+  });
+
+  it('divides out gear health% before subtracting flat', () => {
+    const items = [
+      {
+        baseStats: [
+          { rawTag: 'EasyRPG.Attributes.Base.MaxHealth', value: 100 },
+          // Real bonus tag family: Health%6 / Health% → healthBonus
+          { rawTag: 'EasyRPG.Attributes.Characteristics.Health%6', value: 0.5 },
+        ],
+      },
+    ];
+    // saved 3000 / 1.5 = 2000; − 100 flat = 1900
+    expect(computeHealthResidual(items, 3000)).toBe(1900);
+  });
+
+  it('returns 0 when no saved health or a negative residual', () => {
+    expect(computeHealthResidual(gearItems, 0)).toBe(0);
+    expect(computeHealthResidual(gearItems, 50)).toBe(0); // gear alone exceeds saved
+  });
+
+  it('seedExternalBonuses labels the residual as auto-seeded', () => {
+    const seeded = seedExternalBonuses(gearItems, 5977.49);
+    expect(seeded.health).toEqual({ value: 5908, sourceName: RESIDUAL_SOURCE });
+    expect(seedExternalBonuses(gearItems, 0)).toEqual({});
+  });
+});
+
+describe('card archetypes', () => {
+  it('every archetype effect references a real registry stat (or documented meta-stat)', () => {
+    const META_STATS = new Set(['param', 'paramBonus', 'inventorySlots']);
+    for (const [key, def] of Object.entries(CARD_ARCHETYPES)) {
+      for (const effect of def.effects) {
+        if (META_STATS.has(effect.statId)) continue;
+        expect(getStatById(effect.statId), `${key} → ${effect.statId}`).toBeTruthy();
+      }
+    }
+  });
+
+  it('getCardEffects returns null for unmapped card IDs', () => {
+    expect(getCardEffects('CARD3_2', 3)).toBeNull();
+  });
+
+  it('scales effects by level and resolves param placeholders', () => {
+    // Temporarily map a card to verify resolution + scaling
+    CARD_ID_TO_ARCHETYPE.CARD_TEST = { archetype: 'stat+critChance', param: 'luck' };
+    try {
+      expect(getCardEffects('CARD_TEST', 1)).toEqual([
+        { statId: 'luck', value: 15 },
+        { statId: 'critChance', value: 0.01 },
+      ]);
+      // L6 (final upgrade) = 6× base
+      expect(getCardEffects('CARD_TEST', 6)).toEqual([
+        { statId: 'luck', value: 90 },
+        { statId: 'critChance', value: 0.06 },
+      ]);
+    } finally {
+      delete CARD_ID_TO_ARCHETYPE.CARD_TEST;
+    }
+  });
+
+  it('resolves paramBonus placeholders to the attribute bonus stat', () => {
+    CARD_ID_TO_ARCHETYPE.CARD_TEST2 = { archetype: 'statBonus+xp', param: 'luck' };
+    try {
+      expect(getCardEffects('CARD_TEST2', 2)).toEqual([
+        { statId: 'luckBonus', value: 0.2 },
+        { statId: 'xpBonus', value: 0.02 },
+      ]);
+    } finally {
+      delete CARD_ID_TO_ARCHETYPE.CARD_TEST2;
+    }
+  });
+});

--- a/test/itemTransformer.test.js
+++ b/test/itemTransformer.test.js
@@ -5,6 +5,7 @@ import {
   isItemStruct,
   isWeaponType,
   WEAPON_PATTERNS,
+  normalizeStatValue,
 } from '../src/models/itemTransformer.js';
 import { Rarity } from '../src/models/Item.js';
 
@@ -427,6 +428,27 @@ describe('itemTransformer', () => {
 
       expect(result.totalCount).toBe(1);
       expect(result.items[0].displayName).toBe('Chest Piece');
+    });
+  });
+
+  describe('normalizeStatValue (attack speed scale)', () => {
+    const TAG = 'EasyRPG.Attributes.Base.AttackSpeed';
+
+    it('divides percent-points attack speed (>=10) onto the decimal scale', () => {
+      // Fossil stores 454.12 (game shows +454.12) — must become 4.5412 so the
+      // x100 display formatting yields ~454%, not 45412%.
+      expect(normalizeStatValue(TAG, 454.12)).toBeCloseTo(4.5412, 4);
+    });
+
+    it('leaves normal decimal attack speed untouched', () => {
+      expect(normalizeStatValue(TAG, 0.01)).toBe(0.01); // stones = 1%
+      expect(normalizeStatValue(TAG, 0.1)).toBe(0.1);   // = 10%
+      expect(normalizeStatValue(TAG, 3.0)).toBe(3.0);   // 300% cap region, still decimal
+    });
+
+    it('never touches non-attack-speed stats or non-numbers', () => {
+      expect(normalizeStatValue('EasyRPG.Attributes.Base.Armor%', 434)).toBe(434);
+      expect(normalizeStatValue(TAG, null)).toBe(null);
     });
   });
 });

--- a/test/stanceSkills.test.js
+++ b/test/stanceSkills.test.js
@@ -5,6 +5,7 @@ import {
   parseStanceContext,
   inferWeaponStance,
   parseAllocatedAttributes,
+  parseStatusEffects,
   STANCE_KEYSTONE_BREAKPOINT,
   STANCE_MASTERY_STEP,
 } from '../src/utils/stanceSkills.js';
@@ -156,5 +157,59 @@ describe('allocated attributes parsing', () => {
     const attrs = parseAllocatedAttributes(save);
     expect(attrs.strength).toEqual({ value: 200, sourceName: 'Allocated Points' });
     expect(attrs.dexterity).toEqual({ value: 100, sourceName: 'Allocated Points' });
+  });
+});
+
+describe('status effects (buffs) parsing', () => {
+  it('extracts buff row names with stacks and time remaining', () => {
+    const save = {
+      root: {
+        properties: {
+          HostPlayerData_0: {
+            Struct: {
+              Struct: {
+                'AbilitySystemSaveData_73_TEST_0': {
+                  Struct: {
+                    Struct: {
+                      'StatusEffects_75_TEST_0': {
+                        Array: {
+                          Struct: {
+                            value: [
+                              {
+                                Struct: {
+                                  'EffectHandle_34_TEST_0': {
+                                    Struct: {
+                                      Struct: {
+                                        RowName_0: { Name: 'Buff_Bloodlust' },
+                                      },
+                                    },
+                                  },
+                                  'Stack_32_TEST_0': { Int: 100 },
+                                  'TimeRemaining_33_TEST_0': { Float: 1 },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(parseStatusEffects(save)).toEqual([
+      { id: 'Buff_Bloodlust', stacks: 100, timeRemaining: 1 },
+    ]);
+  });
+
+  it('returns empty array when save data or block is missing', () => {
+    expect(parseStatusEffects(null)).toEqual([]);
+    expect(parseStatusEffects({})).toEqual([]);
+    expect(parseStatusEffects(fixtureData)).toBeInstanceOf(Array);
   });
 });


### PR DESCRIPTION
Support package for the primary monogram of the season (1% of max Health as damage, both types), replacing the saved-health formula bypass with proper modeling. Validated against three real saves including a fully-buffed endgame spear build.

## External-bonuses catch-all bucket

Untracked character-wide sources (levelup tree ≈200 opaque `UI_SkillTreeNode_*` IDs, unmapped crystal cards) get an explicit per-stat bucket (`src/utils/externalBonuses.js` + `itemStore.externalBonuses`): merged into aggregation as a labeled source, editable via `setExternalBonus`, carried in shares (new `xb` field). Seeded at load with the flat-health residual so unbuffed `totalHealth` matches the save. As card/tree mappings land, they shrink the residual instead of moving totals.

## Buff-aware residual (key finding)

**`Health_29` includes buffs active at save time** — verified on the fully-buffed save (334,314 saved vs ~13k unbuffed). Seeding divides them out:

```
residual = saved / ((1 + gear health%) × (1 + save-time temp life%)) − gear flat
```

`computeSaveTimeTempLifePct` reruns the engine with stack counts pinned from the save's `StatusEffects` (`BUFF_STACK_MAP`: Buff_Bloodlust / Buff_Life / Buff_DarkEssence); a buff absent at save contributes 0. At full buff the monogram value equals exactly 1% × saved health (division and re-multiplication cancel).

## Additive monogram instance stacking (verified in-game)

Duplicate monogram copies stack additively. Instance-scaled stats: `bloodlustLifeBonus` (×2 rings observed), `damageFromHealth` (N × 1%), `essence` (N × Dark Essence), `potionSlotsFromAttributes`, `elementFromCritChance`, `critChanceFromEssence`, `critDamageFromEssence`, `bloodlustDrawBloodBonus`. Residual divisor mirrors the counting.

## Mapping fixes/additions (endgame save lineup)

- `BonusCritChance%ForEssence` (pants): +1.5% crit chance per 20 essence (was unmapped)
- `BonusCritDamage%ForEssence` (boots ×2): was mis-mapped to crit chance → new `critDamageFromEssence` feeding the physical additive bucket (per-interval value TBD, 1.5% placeholder)
- `Veil` (relic): display stub, no eDPS impact
- `StaticCharge`: +1% lightning/stack → `edpsED` (config-enabled; offhand-set detection TODO)
- `Juggernaut`: buildup elemental (+3%/stack) → `edpsED` (stack count TBD, defaults 0)

## Card archetype catalog

All known card effect templates (attribute / elemental / remains) in `CARD_ARCHETYPES` with values in registry conventions; level scaling = base × stored level (L6 = 6×). `CARD_ID_TO_ARCHETYPE` is the per-season fill-in; `getCardEffects()` resolves param placeholders. Unmapped cards flow through the residual.

## Share parity

Full round-trip verified on the endgame save: duplicate monogram instances (within-item ×2 and cross-item ×2), `xb` residual, allocated attributes — every derived stat identical between save-load and share-load (5.2 KB URL). Legacy `hp` links decode into a seeded residual.

## Tests

264 pass; build clean. New coverage: residual math (buffed + unbuffed + health% division), save-time temp-life from StatusEffects stacks, instance-stacking divisor, card archetype validity + level scaling, duplicate-monogram share preservation, xb round-trip.

## Known TBDs (documented in code)

- `critDamageFromEssence` per-interval % (placeholder 1.5)
- Juggernaut buildup stack count
- Blood ring monogram tag ID (stacks with bracer DrawBlood when observed)
- Static Charge auto-detection from the Lightning offhand set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwZ4FDJhXooQk7xUyKw8WB)_