### PR TITLE
Fix health% misclassification, distance proc exclusivity, monogram he…

### DIFF
--- a/src/components/character/ItemDetailTooltip.jsx
+++ b/src/components/character/ItemDetailTooltip.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useLayoutEffect, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getDisplayName, formatAttributeValue } from '../../utils/attributeDisplay';
-import { getMonogramName, isKnownMonogram, MONOGRAM_REGISTRY } from '../../utils/monogramRegistry';
+import { getMonogramName, getMonogramById, isKnownMonogram, MONOGRAM_REGISTRY } from '../../utils/monogramRegistry';
 import { MONOGRAM_CALC_CONFIGS, getMonogramEffectSummary as getConfigEffectSummary } from '../../utils/monogramConfigs';
 
 /**
@@ -211,7 +211,11 @@ export function ItemDetailTooltip({
           {itemData.monograms.map((mono, i) => {
             const monoName = getMonogramName(mono.id);
             const hasCalcEffect = !!MONOGRAM_CALC_CONFIGS[mono.id];
-            const effectSummary = getMonogramEffectSummary(mono.id);
+            // Prefer calc-config summary; fall back to the registry/game-data
+            // description so monograms without calc wiring still get helper text
+            const effectSummary = getMonogramEffectSummary(mono.id)
+              ?? getMonogramById(mono.id)?.description
+              ?? null;
 
             return (
               <div key={i} className={`tooltip-monogram ${hasCalcEffect ? 'has-calc-effect' : ''}`}>

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { calculateDerivedStats, calculateDerivedStatsDetailed, DERIVED_STATS, LAYERS } from '../utils/derivedStats.js';
 import { getStatType } from '../utils/statBuckets.js';
 import { STAT_REGISTRY } from '../utils/statRegistry.js';
-import { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
+import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
 import { inferWeaponStance } from '../utils/equipmentParser.js';
 import { aggregateSkillEffects, hasWeaponSkillData } from '../utils/skillEffectAggregator.js';
 
@@ -237,6 +237,10 @@ export function useDerivedStats(options = {}) {
         level: activeStance.mastery,
       };
     }
+
+    // Enforce mutually exclusive monogram effects (e.g. near/far distance
+    // procs can never be active together)
+    applyExclusiveMonogramRules(overrides);
 
     return overrides;
   }, [appliedMonograms, monogramInstanceCounts, stanceContext]);

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -634,6 +634,33 @@ export const DERIVED_STATS = {
   },
 
   // ---------------------------------------------------------------------------
+  // HEALTH% FROM HIGHEST STAT (Health%ForHighest / MaxHp%ForStat.Highest)
+  // Game text: "Gain 1% maximum Health for every 50 of your highest stat."
+  // Percent bonus — formerly misrouted through chainedHealthBonus, which
+  // computed and displayed it as FLAT health.
+  // ---------------------------------------------------------------------------
+  healthPercentFromHighest: {
+    id: 'healthPercentFromHighest',
+    name: 'Health% (Highest Stat)',
+    category: 'monogram-buff',
+    layer: LAYERS.PRIMARY_DERIVED,
+    dependencies: ['highestAttribute'],
+    config: {
+      enabled: false,
+      percentPerInterval: 1, // 1% max health
+      statInterval: 50,      // per 50 highest stat
+    },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.healthPercentFromHighest.config;
+      if (!config.enabled) return 0;
+      const highest = stats.highestAttribute || 0;
+      return Math.floor(highest / config.statInterval) * config.percentPerInterval;
+    },
+    format: v => `+${v.toFixed(0)}%`,
+    description: 'Max health bonus from highest stat (1% per 50)',
+  },
+
+  // ---------------------------------------------------------------------------
   // BLOODLUST LIFE (Ring Monogram - Bloodlust.MoreLife.Highest)
   // 0.1% life bonus per life stack per 50 of highest attribute
   // At 100 stacks: 10% life per 50 highest attribute
@@ -1403,7 +1430,7 @@ export const DERIVED_STATS = {
     name: 'Damage (Life)',
     category: 'monogram-chain',
     layer: LAYERS.TERTIARY_DERIVED,
-    dependencies: ['totalHealth', 'lifeBuffBonus', 'lifeFromElement'],
+    dependencies: ['totalHealth', 'lifeBuffBonus', 'lifeFromElement', 'healthPercentFromHighest'],
     config: {
       enabled: false,
       lifePercent: 1, // 1% of total life
@@ -1415,7 +1442,8 @@ export const DERIVED_STATS = {
       const baseHealth = stats.totalHealth || 0;
       const lifeBuffPct = stats.lifeBuffBonus || 0;
       const lifeFromElemPct = stats.lifeFromElement || 0;
-      const totalLifeBonus = lifeBuffPct + lifeFromElemPct;
+      const healthFromHighestPct = stats.healthPercentFromHighest || 0;
+      const totalLifeBonus = lifeBuffPct + lifeFromElemPct + healthFromHighestPct;
       const totalLife = Math.floor(baseHealth * (1 + totalLifeBonus / 100));
       return Math.floor(totalLife * (config.lifePercent / 100));
     },

--- a/src/utils/monogramConfigs.js
+++ b/src/utils/monogramConfigs.js
@@ -174,14 +174,14 @@ export const MONOGRAM_CALC_CONFIGS = {
   // ===========================================================================
   'DistanceProcsDamage': {
     displayName: 'Distance Procs',
-    description: '+50% damage (own additive bucket, exclusive with Near)',
+    description: 'Attacks hitting further than 6m gain +50% damage (exclusive with Near)',
     effects: [
       { derivedStatId: 'distanceProcsDamageBonus', config: { enabled: true, bonusPercent: 50 } },
     ],
   },
   'DistanceProcsDamage_Near': {
     displayName: 'Distance Procs (Near)',
-    description: '+50% damage (own additive bucket, exclusive with Far)',
+    description: 'Attacks hitting within 5m gain +50% damage (exclusive with Far)',
     effects: [
       { derivedStatId: 'distanceProcsNearDamageBonus', config: { enabled: true, bonusPercent: 50 } },
     ],
@@ -699,9 +699,13 @@ export const MONOGRAM_CALC_CONFIGS = {
       { derivedStatId: 'elementalFlatFromEssence', config: { enabled: true, flatPerInterval: 1.5, essenceInterval: 20 } },
     ],
   },
+  // Same effect text as Health%ForHighest (game data duplicate)
   'MaxHp%ForStat.Highest': {
     displayName: 'HP from Stats',
-    effects: [],
+    description: '+1% max health per 50 of highest stat',
+    effects: [
+      { derivedStatId: 'healthPercentFromHighest', config: { enabled: true, percentPerInterval: 1, statInterval: 50 } },
+    ],
   },
   'DamageReduction%ForStat.Highest': {
     displayName: 'DR from Stats',
@@ -734,14 +738,13 @@ export const MONOGRAM_CALC_CONFIGS = {
   // ===========================================================================
   // OTHER MONOGRAM CONFIGS
   // ===========================================================================
+  // "Gain 1% maximum Health for every 50 your highest stat." — percent bonus
   'Health%ForHighest': {
     displayName: 'Health from Stats',
-    derivedStatId: 'chainedHealthBonus',
-    config: {
-      sourceStat: 'highestAttribute',
-      ratio: 50,
-      baseValue: 1,
-    },
+    description: '+1% max health per 50 of highest stat',
+    effects: [
+      { derivedStatId: 'healthPercentFromHighest', config: { enabled: true, percentPerInterval: 1, statInterval: 50 } },
+    ],
   },
   // Game text: "gain 2% damage reduction each time you're hit. Upon reaching
   // maximum damage reduction, gain +100 Physical damage."
@@ -845,6 +848,34 @@ export const MONOGRAM_CALC_CONFIGS = {
     ],
   },
 };
+
+/**
+ * Mutually exclusive derived-stat pairs from monogram effects.
+ * Each entry is [winner, loser]: when both are enabled by equipped monograms,
+ * the loser's override is dropped so only one applies. The winner choice
+ * matches the eDPS EMulti breakdown tie-break (Near preferred).
+ *
+ * Distance procs: you attack from ONE distance at a time — near (≤5m) and far
+ * (>6m) bonuses can never be active together.
+ */
+export const EXCLUSIVE_MONOGRAM_STATS = [
+  ['distanceProcsNearDamageBonus', 'distanceProcsDamageBonus'],
+];
+
+/**
+ * Enforce monogram exclusivity on a config-overrides map (mutates and
+ * returns it). Called by useDerivedStats after collecting monogram effects.
+ * @param {Object} overrides - { [derivedStatId]: config }
+ * @returns {Object} The same overrides object
+ */
+export function applyExclusiveMonogramRules(overrides) {
+  for (const [winner, loser] of EXCLUSIVE_MONOGRAM_STATS) {
+    if (overrides[winner]?.enabled && overrides[loser]?.enabled) {
+      delete overrides[loser];
+    }
+  }
+  return overrides;
+}
 
 /**
  * Get effect summary text for a monogram

--- a/src/utils/monogramRegistry.js
+++ b/src/utils/monogramRegistry.js
@@ -702,19 +702,19 @@ export const MONOGRAM_REGISTRY = {
     id: 'GainDamageForHPLoseArmor',
     name: 'Glass Cannon',
     category: 'damage',
-    description: 'Trade armor for damage and HP',
+    description: 'Gain base damage equal to 1% of your maximum Health',
   },
   'DistanceProcsDamage': {
     id: 'DistanceProcsDamage',
     name: 'Distance Damage',
     category: 'damage',
-    description: '+50% damage proc (own additive bucket, exclusive with Near)',
+    description: 'Attacks hitting further than 6m gain +50% damage (exclusive with Close Range)',
   },
   'DistanceProcsDamage_Near': {
     id: 'DistanceProcsDamage_Near',
     name: 'Close Range Damage',
     category: 'damage',
-    description: '+50% damage proc (own additive bucket, exclusive with Far)',
+    description: 'Attacks hitting within 5m gain +50% damage (exclusive with Distance)',
   },
   'ProcsTake100EnergyHighDamage': {
     id: 'ProcsTake100EnergyHighDamage',

--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -829,7 +829,8 @@ export const STAT_REGISTRY = {
     isPercent: false,
     format: v => `+${v.toFixed(0)}`,
     description: 'Maximum health points',
-    regexPatterns: ['MaxHealth', 'Health$', '\\.Health$'],
+    // Anchored so the % variants (MaxHealth%) fall through to healthBonus
+    regexPatterns: ['MaxHealth$', 'Health$', '\\.Health$'],
   },
   healthBonus: {
     id: 'healthBonus',
@@ -840,12 +841,18 @@ export const STAT_REGISTRY = {
       'Health%',
       'Life%6',
       'Life%',
+      // Cards grant EasyRPG.Attributes.Base.MaxHealth% (e.g. CARD3_2) — must
+      // resolve as percent, not flat health
+      'Base.MaxHealth%6',
+      'Base.MaxHealth%',
+      'MaxHealth%6',
+      'MaxHealth%',
     ],
     canonical: 'Health%6',
     isPercent: true,
     format: v => `+${(v * 100).toFixed(0)}%`,
     description: 'Maximum health bonus',
-    regexPatterns: ['Health%6', 'Health%', '\\.Health%6', '\\.Health%', 'Life%6', 'Life%'],
+    regexPatterns: ['MaxHealth%6', 'MaxHealth%', 'Health%6', 'Health%', '\\.Health%6', '\\.Health%', 'Life%6', 'Life%'],
   },
   healthRegen: {
     id: 'healthRegen',

--- a/test/monogramStragglers.test.js
+++ b/test/monogramStragglers.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { findStatForAttribute } from '../src/utils/statRegistry.js';
+import { calculateDerivedStats } from '../src/utils/derivedStats.js';
+import {
+  MONOGRAM_CALC_CONFIGS,
+  applyExclusiveMonogramRules,
+  getMonogramEffectSummary,
+} from '../src/utils/monogramConfigs.js';
+import { getMonogramById } from '../src/utils/monogramRegistry.js';
+
+describe('MaxHealth% classification (health % lost as flat)', () => {
+  it('resolves MaxHealth% variants to healthBonus (percent), not flat health', () => {
+    expect(findStatForAttribute('EasyRPG.Attributes.Base.MaxHealth%').id).toBe('healthBonus');
+    expect(findStatForAttribute('EasyRPG.Attributes.Base.MaxHealth%6').id).toBe('healthBonus');
+    expect(findStatForAttribute('MaxHealth%').id).toBe('healthBonus');
+  });
+
+  it('still resolves flat MaxHealth to health', () => {
+    expect(findStatForAttribute('EasyRPG.Attributes.Base.MaxHealth').id).toBe('health');
+    expect(findStatForAttribute('MaxHealth').id).toBe('health');
+  });
+
+  it('percent health flows through totalHealth as a multiplier', () => {
+    // e.g. CARD3_2 at L2 grants MaxHealth% 0.2 (decimal) → healthBonus
+    const result = calculateDerivedStats({ health: 1000, healthBonus: 0.2 });
+    expect(result.totalHealth).toBe(1200);
+  });
+});
+
+describe('Health%ForHighest → percent stat (was flat chain)', () => {
+  it('computes a percent from highest attribute', () => {
+    const result = calculateDerivedStats(
+      { strength: 250 },
+      { healthPercentFromHighest: { enabled: true, percentPerInterval: 1, statInterval: 50 } },
+    );
+    expect(result.healthPercentFromHighest).toBe(5); // 250 / 50 × 1%
+  });
+
+  it('is disabled by default', () => {
+    const result = calculateDerivedStats({ strength: 250 });
+    expect(result.healthPercentFromHighest).toBe(0);
+  });
+
+  it('monogram configs route both game tags to the percent stat', () => {
+    for (const key of ['Health%ForHighest', 'MaxHp%ForStat.Highest']) {
+      const effects = MONOGRAM_CALC_CONFIGS[key].effects;
+      expect(effects?.[0]?.derivedStatId, key).toBe('healthPercentFromHighest');
+    }
+  });
+
+  it('feeds the glass-cannon damage-from-life total', () => {
+    const withHealthPct = calculateDerivedStats(
+      { health: 1000, strength: 500 },
+      {
+        damageFromLife: { enabled: true, lifePercent: 1 },
+        healthPercentFromHighest: { enabled: true, percentPerInterval: 1, statInterval: 50 },
+      },
+    );
+    // 500/50 = 10% life bonus → totalLife 1100 → 1% = 11
+    expect(withHealthPct.damageFromLife).toBe(11);
+  });
+});
+
+describe('distance monogram exclusivity', () => {
+  it('drops the far bonus when both near and far are enabled', () => {
+    const overrides = {
+      distanceProcsDamageBonus: { enabled: true, bonusPercent: 50 },
+      distanceProcsNearDamageBonus: { enabled: true, bonusPercent: 50 },
+    };
+    applyExclusiveMonogramRules(overrides);
+    expect(overrides.distanceProcsNearDamageBonus).toBeDefined();
+    expect(overrides.distanceProcsDamageBonus).toBeUndefined();
+  });
+
+  it('leaves a single distance bonus untouched', () => {
+    const farOnly = { distanceProcsDamageBonus: { enabled: true, bonusPercent: 50 } };
+    applyExclusiveMonogramRules(farOnly);
+    expect(farOnly.distanceProcsDamageBonus).toBeDefined();
+
+    const nearOnly = { distanceProcsNearDamageBonus: { enabled: true, bonusPercent: 50 } };
+    applyExclusiveMonogramRules(nearOnly);
+    expect(nearOnly.distanceProcsNearDamageBonus).toBeDefined();
+  });
+
+  it('only one distance bonus reaches the calc when both monograms are equipped', () => {
+    const overrides = applyExclusiveMonogramRules({
+      distanceProcsDamageBonus: { enabled: true, bonusPercent: 50 },
+      distanceProcsNearDamageBonus: { enabled: true, bonusPercent: 50 },
+    });
+    const result = calculateDerivedStats({}, overrides);
+    expect(result.distanceProcsNearDamageBonus).toBe(50);
+    expect(result.distanceProcsDamageBonus).toBe(0);
+    // EMulti applies the single surviving bonus once: ×1.5
+    expect(result.edpsEMulti).toBeCloseTo(1.5);
+  });
+});
+
+describe('monogram helper text fallback', () => {
+  it('calc-config monograms provide a summary', () => {
+    expect(getMonogramEffectSummary('DistanceProcsDamage')).toMatch(/6m/);
+  });
+
+  it('uncurated monograms fall back to game-data descriptions', () => {
+    // No calc config, no curated entry — description comes from generated data
+    expect(MONOGRAM_CALC_CONFIGS['EnergyNoHPRegen']).toBeUndefined();
+    const def = getMonogramById('EnergyNoHPRegen');
+    expect(def?.description).toMatch(/energy regeneration/i);
+  });
+
+  it('Glass Cannon description states the actual effect', () => {
+    expect(getMonogramById('GainDamageForHPLoseArmor').description).toMatch(/1% of your maximum Health/i);
+  });
+});

--- a/test/skillEffectAggregator.test.js
+++ b/test/skillEffectAggregator.test.js
@@ -32,7 +32,7 @@ describe('skillEffectAggregator', () => {
       expect(card).toBeDefined();
       expect(card.tag).toBe('EasyRPG.Attributes.Base.MaxHealth%');
       expect(card.value).toBeCloseTo(0.2);
-      expect(card.statId).toBeTruthy();
+      expect(card.statId).toBe('healthBonus'); // percent — not flat health
     });
 
     it('handles max-level (L6) cards', () => {


### PR DESCRIPTION
…lper text

Three display/calc stragglers:

- MaxHealth% resolved to flat health: the health entry's unanchored 'MaxHealth' regex swallowed the percent variant, so card/skill health% (e.g. CARD3_2's Base.MaxHealth%) aggregated as flat HP. healthBonus now owns the MaxHealth%/%6 patterns and health's regex is anchored.

- Health%ForHighest ("1% max health per 50 highest") was wired to chainedHealthBonus, a placeholder that computes and displays FLAT health. New healthPercentFromHighest percent stat (also wired to the duplicate MaxHp%ForStat.Highest tag) formats as % and feeds the glass-cannon damage-from-life total.

- Distance procs (near ≤5m / far >6m) can never be active together: applyExclusiveMonogramRules() in monogramConfigs drops the far bonus when both monograms are equipped, so only one shows in the stats panel (eDPS EMulti already took the max; the panel showed both).

- Monogram tooltips now fall back to registry/game-data descriptions when no calc-config summary exists, so all ~470 known monograms get helper text. Glass Cannon and the distance pair use the actual game effect text ("Gain base Damage equal to 1% of your maximum Health").


Claude-Session: https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g