### PR TITLE
Vitals display, source-bucket chips, and compressed v2 shares with sk…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,13 +504,22 @@ Options keys: `h`=minHitsPerPool, `c`=closeMinTotal, `w`=includeWeapons, `t`=min
 
 **Stat values:** Raw decimals from save file. Percentages are stored as decimals (0.316 = 31.6%). Flat stats as-is (Armor = 197.57). No conversion — `useDerivedStats` already handles the raw format.
 
-**URL size:** Full 17-item build ≈ 5,800 chars. Well within browser URL limits (~8KB safe, 2KB+ for older systems).
+**v2 (current):** payload gains `st` — skill tree section
+`{ cd: [[cardRowName, level]], ws: [[weaponSkillEnc, level]] }` — so shared
+builds compute real card/skill/buff effects via `skillTreeShareToData()` →
+`metadata.skillTree` (the `sk` mastery snapshot stays as fallback for old
+links). v2 travels **compressed**: `"2." + base64url(deflate-raw(JSON))` via
+native `CompressionStream` (encode/decode async). Legacy v1 bare-base64url
+links still decode (`decodeCharacterShareAny` handles both).
+
+**URL size:** Full 17-item build + full skill tree ≈ 2,400 chars compressed
+(was ≈ 5,800 gear-only uncompressed). Well within browser URL limits.
 
 ### Flow
 - **Filter Share**: FilterConfig "Share" button → `encodeFilterShare()` → `buildShareUrl('filter', ...)` → clipboard
 - **Filter Load**: App mount → `parseShareFromHash()` → `decodeFilterShare()` → passed to FilterTab as `sharedFilterModel` prop → consumed once, config panel auto-opens
-- **Character Share**: (UI button TBD) → `createCharacterSharePayload()` → `encodeCharacterShare()` → `buildCharacterShareUrl()` → clipboard
-- **Character Load**: App mount → `parseShareFromHash()` → `decodeCharacterShare()` → `itemStore.loadFromShare()` → navigates to Character tab
+- **Character Share**: CharacterTab "Share Build" → `createCharacterSharePayload(..., skillTree)` → `buildCharacterShareUrlCompressed()` → clipboard. "Copy Code" copies the bare `2.…` code (no URL) for platforms that mangle long links
+- **Character Load**: App mount hash OR Upload tab paste-import (accepts full URL or bare code) → `decodeCharacterShareAny()` → `itemStore.loadFromShare(..., skillTree)` → navigates to Character tab
 - When a shared filter is loaded without save data, the Filter tab is enabled so users can see the configuration before uploading a save
 - When a shared character is loaded, only Character and Stats tabs are enabled (no inventory/filter data)
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,8 +9,8 @@ import { initWasm } from './utils/wasm';
 import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
-import { parseShareFromHash, decodeFilterShare, decodeCharacterShare } from './utils/shareUrl';
-import { masteryShareToData, allocatedAttributesShareToData } from './models/CharacterShareModel';
+import { parseShareFromHash, decodeFilterShare, decodeCharacterShareAny } from './utils/shareUrl';
+import { masteryShareToData, allocatedAttributesShareToData, skillTreeShareToData } from './models/CharacterShareModel';
 
 const TABS = [
   { id: 'upload', label: 'Upload', icon: '📂' },
@@ -54,6 +54,33 @@ export default function App() {
     init();
   }, [log]);
 
+  // Decode a character share code (compressed v2 or legacy v1) and load it
+  // into the item store. Returns true if a build was loaded.
+  const loadCharacterShareCode = useCallback(async (code) => {
+    const decoded = await decodeCharacterShareAny(code);
+    if (!decoded) return false;
+    const masteryData = masteryShareToData(decoded.sk ?? null);
+    const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
+    const skillTree = skillTreeShareToData(decoded.st ?? null);
+    itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0, skillTree);
+    setActiveTab('character');
+    log('Loaded shared character build');
+    return true;
+  }, [itemStore, log]);
+
+  // Paste-import: accepts a full share URL or a bare share code
+  const handleImportShare = useCallback(async (text) => {
+    const trimmed = (text || '').trim();
+    if (!trimmed) return false;
+    const hashIdx = trimmed.indexOf('#');
+    const parsed = hashIdx >= 0 ? parseShareFromHash(trimmed.slice(hashIdx)) : null;
+    const code = parsed?.type === 'character' ? parsed.data : (hashIdx >= 0 ? null : trimmed);
+    if (!code) return false;
+    const ok = await loadCharacterShareCode(code);
+    if (!ok) log('⚠️ Could not decode share code');
+    return ok;
+  }, [loadCharacterShareCode, log]);
+
   // Read share URL hash on mount
   useEffect(() => {
     const hash = window.location.hash;
@@ -71,14 +98,7 @@ export default function App() {
         log(`Loaded shared filter: "${decoded.name}"`);
       }
     } else if (parsed.type === 'character') {
-      const decoded = decodeCharacterShare(parsed.data);
-      if (decoded) {
-        const masteryData = masteryShareToData(decoded.sk ?? null);
-        const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
-        itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0);
-        setActiveTab('character');
-        log('Loaded shared character build');
-      }
+      loadCharacterShareCode(parsed.data);
     }
 
     // Clean the hash from the URL
@@ -131,7 +151,7 @@ export default function App() {
       {wasmReady && (
         <>
           {activeTab === 'upload' && (
-            <UploadTab onFileLoaded={handleFileLoaded} onLog={log} onStatusChange={handleStatusChange} />
+            <UploadTab onFileLoaded={handleFileLoaded} onLog={log} onStatusChange={handleStatusChange} onImportShare={handleImportShare} />
           )}
           {activeTab === 'character' && (saveData || itemStore.hasItems) && (
             <CharacterTab

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -2,10 +2,11 @@ import React, { useState, useCallback } from 'react';
 import { Button } from '../common';
 import { CharacterPanel } from './CharacterPanel';
 import { createCharacterSharePayload } from '../../models/CharacterShareModel';
-import { encodeCharacterShare, buildCharacterShareUrl } from '../../utils/shareUrl';
+import { encodeCharacterShareCompressed, buildCharacterShareUrlCompressed } from '../../utils/shareUrl';
 
 export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
   const [shareFeedback, setShareFeedback] = useState(null);
+  const [codeFeedback, setCodeFeedback] = useState(null);
 
   // Build characterData from itemStore (central source of truth)
   // Falls back to saveData for backward compatibility
@@ -23,14 +24,16 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     timestamp: saveData.timestamp,
   } : null;
 
+  const buildPayload = useCallback(() => createCharacterSharePayload(
+    itemStore.equipped,
+    characterData?.stanceContext ?? null,
+    itemStore.metadata?.allocatedAttributes ?? null,
+    itemStore.metadata?.maxHealth ?? 0,
+    itemStore.metadata?.skillTree ?? null,
+  ), [itemStore.equipped, itemStore.metadata, characterData?.stanceContext]);
+
   const handleShare = useCallback(async () => {
-    const payload = createCharacterSharePayload(
-      itemStore.equipped,
-      characterData?.stanceContext ?? null,
-      itemStore.metadata?.allocatedAttributes ?? null,
-      itemStore.metadata?.maxHealth ?? 0
-    );
-    const url = buildCharacterShareUrl(payload);
+    const url = await buildCharacterShareUrlCompressed(buildPayload());
     try {
       await navigator.clipboard.writeText(url);
       setShareFeedback('Copied!');
@@ -40,7 +43,22 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     }
     if (onLog) onLog('Share link copied to clipboard');
     setTimeout(() => setShareFeedback(null), 2000);
-  }, [itemStore.equipped, characterData?.stanceContext, onLog]);
+  }, [buildPayload, onLog]);
+
+  // Bare share code (same payload, no URL) — for platforms that mangle long
+  // links. Paste into the Upload tab's import box to load.
+  const handleCopyCode = useCallback(async () => {
+    const code = await encodeCharacterShareCompressed(buildPayload());
+    try {
+      await navigator.clipboard.writeText(code);
+      setCodeFeedback('Copied!');
+    } catch {
+      window.prompt('Copy this share code:', code);
+      setCodeFeedback('Ready');
+    }
+    if (onLog) onLog('Share code copied to clipboard');
+    setTimeout(() => setCodeFeedback(null), 2000);
+  }, [buildPayload, onLog]);
 
   return (
     <div className="tab-content active">
@@ -53,6 +71,9 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
           <div style={{ display: 'flex', gap: '0.5rem' }}>
             <Button icon="🔗" onClick={handleShare} hidden={!itemStore?.hasItems}>
               {shareFeedback || 'Share Build'}
+            </Button>
+            <Button icon="📋" onClick={handleCopyCode} hidden={!itemStore?.hasItems}>
+              {codeFeedback || 'Copy Code'}
             </Button>
             <Button icon="📂" onClick={onClearSave}>
               Load Different File

--- a/src/components/character/StatTooltip.jsx
+++ b/src/components/character/StatTooltip.jsx
@@ -7,6 +7,24 @@ const formatBreakdownTerm = ({ value, fmt }) => {
   return Math.floor(value).toLocaleString();
 };
 
+/**
+ * Map a source entry to its system-bucket chip (label + CSS suffix) so the
+ * tooltip shows where each contribution comes from.
+ */
+const sourceChip = (source) => {
+  switch (source.sourceType) {
+    case 'skill':
+      if (source.kind === 'card') return { label: 'Card', cls: 'card' };
+      if (source.kind === 'buff') return { label: 'Buff', cls: 'buff' };
+      return { label: 'Skill', cls: 'skill' };
+    case 'monogram': return { label: 'Mono', cls: 'monogram' };
+    case 'allocated': return { label: 'Base', cls: 'base' };
+    case 'stance': return { label: 'Stance', cls: 'stance' };
+    case 'save': return { label: 'Save', cls: 'base' };
+    default: return { label: 'Item', cls: 'item' };
+  }
+};
+
 export function StatTooltip({
   stat,
   visible,
@@ -149,12 +167,16 @@ export function StatTooltip({
       {hasSources && (
         <div className="stat-tooltip-breakdown">
           <div className="stat-tooltip-section-title">Sources</div>
-          {stat.sources.map((source, i) => (
-            <div key={i} className={`stat-tooltip-source${source.sourceType === 'monogram' ? ' is-monogram' : ''}`}>
-              <span className="source-item">{source.itemName}</span>
-              <span className="source-value">{formatSourceValue(source.value, source.isPercent)}</span>
-            </div>
-          ))}
+          {stat.sources.map((source, i) => {
+            const chip = sourceChip(source);
+            return (
+              <div key={i} className={`stat-tooltip-source${source.sourceType === 'monogram' ? ' is-monogram' : ''}`}>
+                <span className={`source-chip source-chip-${chip.cls}`}>{chip.label}</span>
+                <span className="source-item">{source.itemName}</span>
+                <span className="source-value">{formatSourceValue(source.value, source.isPercent)}</span>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/src/components/character/StatsPanel.jsx
+++ b/src/components/character/StatsPanel.jsx
@@ -3,6 +3,7 @@ import { StatLine } from './StatLine';
 import { useDerivedStats } from '../../hooks/useDerivedStats';
 
 const categoryLabels = {
+  vitals: 'Vitals',
   attributes: 'Attributes',
   offense: 'Offense',
   stance: 'Stance/Weapon',
@@ -15,8 +16,9 @@ const categoryLabels = {
   unmapped: 'Unmapped (Debug)',
 };
 
-// eDPS first so the damage headline is the user's landing spot; monograms last.
-const categoryOrder = ['edps', 'attributes', 'offense', 'stance', 'elemental', 'defense', 'monograms', 'abilities', 'utility', 'unmapped'];
+// Vitals (in-game max health) and eDPS first — the progress-indicator numbers
+// belong above the fold; monograms last.
+const categoryOrder = ['vitals', 'edps', 'attributes', 'offense', 'stance', 'elemental', 'defense', 'monograms', 'abilities', 'utility', 'unmapped'];
 
 /**
  * @param {Object} props

--- a/src/components/upload/UploadTab.jsx
+++ b/src/components/upload/UploadTab.jsx
@@ -3,10 +3,17 @@ import { Button, DropZone } from '../common';
 import { useFileProcessor } from '../../hooks/useFileProcessor';
 import { hasDirPicker } from '../../utils/platform';
 
-export function UploadTab({ onFileLoaded, onLog, onStatusChange }) {
+export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare }) {
   const [recentFiles, setRecentFiles] = useState([]);
+  const [importText, setImportText] = useState('');
   const fileInputRef = useRef(null);
   const { processFile, isProcessing } = useFileProcessor();
+
+  const handleImport = useCallback(async () => {
+    if (!onImportShare) return;
+    const ok = await onImportShare(importText);
+    if (ok) setImportText('');
+  }, [onImportShare, importText]);
 
   const handleFileSelect = useCallback(async (file) => {
     try {
@@ -124,6 +131,25 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange }) {
         text="Drop your .sav file here to begin"
         onFileDrop={handleFileDrop}
       />
+
+      {onImportShare && (
+        <div className="controls" style={{ marginTop: '0.75rem' }}>
+          <div className="control-row" style={{ justifyContent: 'center', gap: '0.5rem' }}>
+            <input
+              type="text"
+              className="share-import-input"
+              placeholder="Paste a share link or code…"
+              value={importText}
+              onChange={e => setImportText(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') handleImport(); }}
+              style={{ minWidth: '20rem' }}
+            />
+            <Button icon="📥" onClick={handleImport} disabled={!importText.trim()}>
+              Import Build
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="upload-info">
         <div className="upload-info-item">

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -35,7 +35,7 @@ export function useDerivedStats(options = {}) {
       const sourceName = rawValue?.sourceName || 'Character';
       stats[statId] = {
         total: value,
-        sources: [{ itemName: sourceName, slot: 'base', value, sourceType: 'item' }],
+        sources: [{ itemName: sourceName, slot: 'base', value, sourceType: 'allocated' }],
       };
     }
 
@@ -55,6 +55,7 @@ export function useDerivedStats(options = {}) {
           slot: 'skill',
           value: contrib.value,
           sourceType: 'skill',
+          kind: contrib.kind, // 'card' | 'weaponSkill' | 'buff'
         });
       }
     }
@@ -73,7 +74,7 @@ export function useDerivedStats(options = {}) {
         itemName: `${activeStance.id}.level.1`,
         slot: 'stance',
         value,
-        sourceType: 'item',
+        sourceType: 'stance',
       });
     }
 
@@ -386,6 +387,7 @@ export function useDerivedStats(options = {}) {
     };
 
     const result = {
+      vitals: [],
       attributes: [],
       offense: [],
       stance: [],
@@ -527,6 +529,23 @@ export function useDerivedStats(options = {}) {
     }
 
 
+    // Vitals: the save-reported max health is the real in-game number — the
+    // gear-only calculation misses the character's base health pool (level /
+    // class scaling), so surface both up top instead of burying Health in
+    // Defense below the fold.
+    if (maxHealth > 0) {
+      const gearCalc = values.totalHealth || 0;
+      result.vitals.push({
+        id: 'saveMaxHealth',
+        name: 'Max Health (in-game)',
+        value: maxHealth,
+        formattedValue: Math.round(maxHealth).toLocaleString(),
+        description: `Read from the save file — includes the character's base health pool plus gear and buffs active at save time. Gear-calculated health: ${Math.round(gearCalc).toLocaleString()} (difference ≈ base pool).`,
+        sources: [{ itemName: 'Save file (Health_29)', value: maxHealth, sourceType: 'save' }],
+        layer: LAYERS.BASE,
+      });
+    }
+
     // Add stance context debug/info rows
     if (stanceContext?.activeStance) {
       const active = stanceContext.activeStance;
@@ -593,7 +612,7 @@ export function useDerivedStats(options = {}) {
     }
 
     return result;
-  }, [calculatedStats, aggregatedWithSources, stanceContext, finalConfigOverrides]);
+  }, [calculatedStats, aggregatedWithSources, stanceContext, finalConfigOverrides, maxHealth]);
 
   return {
     // For StatsPanel compatibility

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -75,7 +75,7 @@ export function useItemStore() {
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
    * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0, skillTree = null) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
 
     setEquipped(equippedItems);
@@ -88,6 +88,9 @@ export function useItemStore() {
       allocatedAttributes: allocatedAttributes || {},
       maxHealth: maxHealth || 0,
       sharedMastery: masteryData,
+      // v2 shares carry the skill tree; when present, useDerivedStats computes
+      // real card/skill/buff effects instead of the mastery approximation
+      skillTree,
     });
   }, []);
 

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -15,13 +15,19 @@
 
 import {
   STAT_DICT, MONOGRAM_DICT,
-  SLOT_DICT, WEAPON_TYPE_DICT,
+  SLOT_DICT, WEAPON_TYPE_DICT, WEAPON_SKILL_DICT,
   encodeIdOrString, decodeIdOrString,
 } from '../utils/shareCodec.js';
 import { findStatForAttribute, getStatById } from '../utils/statRegistry.js';
+import { getWeaponSkillDef } from '../utils/skillTreeRegistry.js';
+import { createEmptySkillTreeData } from './SkillTree.js';
 import { createEmptyItem } from './Item.js';
 
-export const CHARACTER_SHARE_VERSION = 1;
+// v2: adds the `st` skill tree section (cards + weapon skill levels) so shared
+// builds compute real skill effects instead of the mastery approximation.
+// v2 payloads travel compressed ("2." prefix, see shareUrl.js); v1 decode is
+// unchanged for old links.
+export const CHARACTER_SHARE_VERSION = 2;
 
 // ---------------------------------------------------------------------------
 // Type Definitions
@@ -61,6 +67,9 @@ export const CHARACTER_SHARE_VERSION = 1;
  *   highestAttribute-driven derived stat.
  * @property {number} [hp] - Character max health (omitted if 0). Not derivable
  *   from gear; needed by the 1%-of-max-Health monogram.
+ * @property {{ cd?: Array<[string, number]>, ws?: Array<[number|string, number]> }} [st] -
+ *   Skill tree section (v2+): cards [[rowName, level]] and weapon skills
+ *   [[skillEnc, level]]. Lets shared builds compute real skill effects.
  */
 
 // ---------------------------------------------------------------------------
@@ -125,6 +134,61 @@ export function createMasteryShare(stanceContext) {
 }
 
 /**
+ * Convert a parsed skill tree (extractSkillTree) to compact share form.
+ * Cards keep string row names (already short: "CARD3_2"); weapon skills use
+ * WEAPON_SKILL_DICT indices with string fallback for unknown rows.
+ *
+ * @param {Object|null} skillTree
+ * @returns {{ cd?: Array<[string, number]>, ws?: Array<[number|string, number]> }|null}
+ */
+export function createSkillTreeShare(skillTree) {
+  if (!skillTree) return null;
+  const st = {};
+
+  const cards = (skillTree.cards ?? [])
+    .filter(c => c.rowName && c.level > 0)
+    .map(c => [c.rowName, c.level]);
+  if (cards.length > 0) st.cd = cards;
+
+  const ws = [];
+  for (const stance of Object.values(skillTree.weaponStances ?? {})) {
+    for (const skill of stance.skills ?? []) {
+      if (!skill.rowName) continue;
+      ws.push([encodeIdOrString(WEAPON_SKILL_DICT, skill.rowName), skill.level || 1]);
+    }
+  }
+  if (ws.length > 0) st.ws = ws;
+
+  return Object.keys(st).length > 0 ? st : null;
+}
+
+/**
+ * Reconstruct a skill-tree-shaped object from a decoded `st` section —
+ * enough for skillEffectAggregator (cards + weaponStances with rowName/level).
+ * Weapon skills are bucketed by their registry/game-data weapon type.
+ *
+ * @param {{ cd?: Array<[string, number]>, ws?: Array<[number|string, number]> }|null|undefined} st
+ * @returns {Object|null} SkillTreeData-shaped object, or null if empty
+ */
+export function skillTreeShareToData(st) {
+  if (!st || (!st.cd?.length && !st.ws?.length)) return null;
+  const tree = createEmptySkillTreeData();
+
+  for (const [rowName, level] of st.cd || []) {
+    tree.cards.push({ rowName, level: level ?? 1 });
+  }
+
+  for (const [enc, level] of st.ws || []) {
+    const rowName = decodeIdOrString(WEAPON_SKILL_DICT, enc) || String(enc);
+    const weapon = getWeaponSkillDef(rowName)?.weapon;
+    const stance = tree.weaponStances[weapon] ?? tree.weaponStances.spear;
+    stance.skills.push({ rowName, level: level ?? 1 });
+  }
+
+  return tree;
+}
+
+/**
  * Convert the character's allocated attribute pool to compact share form.
  * Input shape matches parseAllocatedAttributes(): { statId: { value, sourceName } }.
  * Plain numeric values are also accepted.
@@ -172,7 +236,7 @@ export function allocatedAttributesShareToData(at) {
  * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0, skillTree = null) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -188,6 +252,11 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
   // Character max health (for the 1%-of-max-Health monogram); not derivable
   // from gear. Rounded to keep the URL short.
   if (maxHealth > 0) payload.hp = Math.round(maxHealth);
+
+  // Skill tree (cards + weapon skill levels) so the receiving side computes
+  // real skill effects; the mastery snapshot above stays as the fallback.
+  const st = createSkillTreeShare(skillTree);
+  if (st) payload.st = st;
 
   return payload;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1523,6 +1523,45 @@ h1::before {
   margin-right: 0.5rem;
 }
 
+/* System-bucket chips: which subsystem a stat contribution comes from */
+.source-chip {
+  flex: 0 0 auto;
+  display: inline-block;
+  min-width: 2.6rem;
+  margin-right: 0.45rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  text-align: center;
+  color: #fff;
+}
+
+.source-chip-item { background: #5a7d9e; }
+.source-chip-card { background: #8e5aa8; }
+.source-chip-skill { background: #4a8f5c; }
+.source-chip-buff { background: #b3823a; }
+.source-chip-monogram { background: #a85a5a; }
+.source-chip-base { background: #6f7a86; }
+.source-chip-stance { background: #3f8f8f; }
+
+/* Share code paste-import (Upload tab) */
+.share-import-input {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.85rem;
+}
+
+.share-import-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 .stat-tooltip-source .source-value {
   color: var(--success);
   font-weight: 600;

--- a/src/utils/shareUrl.js
+++ b/src/utils/shareUrl.js
@@ -174,7 +174,8 @@ export function decodeCharacterShare(encoded) {
   try {
     const json = fromBase64Url(encoded);
     const payload = JSON.parse(json);
-    if (!payload || typeof payload.v !== 'number' || payload.v > 1) return null;
+    // v2 fields are additive, so uncompressed v2 payloads decode fine here too
+    if (!payload || typeof payload.v !== 'number' || payload.v > 2) return null;
     return payload;
   } catch {
     return null;
@@ -190,4 +191,83 @@ export function decodeCharacterShare(encoded) {
  */
 export function buildCharacterShareUrl(payload, baseUrl) {
   return buildShareUrl('character', encodeCharacterShare(payload), baseUrl);
+}
+
+// ---------------------------------------------------------------------------
+// Compressed (v2) character shares
+//
+// Format: "2." + base64url(deflate-raw(JSON)). The prefix distinguishes
+// compressed payloads from legacy v1 (bare base64url JSON, which never starts
+// with "2." because base64 of '{' is 'ey...'). Compression uses the native
+// CompressionStream API (browsers + Node 18+), so encode/decode are async.
+// ---------------------------------------------------------------------------
+
+const COMPRESSED_PREFIX = '2.';
+const MAX_SHARE_VERSION = 2;
+
+function bytesToBase64Url(bytes) {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(b64url) {
+  let b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+  while (b64.length % 4 !== 0) b64 += '=';
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function pipeThrough(bytes, TransformCtor, mode) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new TransformCtor(mode));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Encode a CharacterSharePayload to a compressed "2."-prefixed share code.
+ * @param {import('../models/CharacterShareModel').CharacterSharePayload} payload
+ * @returns {Promise<string>}
+ */
+export async function encodeCharacterShareCompressed(payload) {
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  const deflated = await pipeThrough(bytes, CompressionStream, 'deflate-raw');
+  return COMPRESSED_PREFIX + bytesToBase64Url(deflated);
+}
+
+/**
+ * Decode any character share string — compressed v2 ("2." prefix) or legacy
+ * v1 (bare base64url JSON).
+ * @param {string} encoded
+ * @returns {Promise<import('../models/CharacterShareModel').CharacterSharePayload|null>}
+ */
+export async function decodeCharacterShareAny(encoded) {
+  if (typeof encoded !== 'string' || !encoded) return null;
+  if (!encoded.startsWith(COMPRESSED_PREFIX)) {
+    return decodeCharacterShare(encoded);
+  }
+  try {
+    const deflated = base64UrlToBytes(encoded.slice(COMPRESSED_PREFIX.length));
+    const bytes = await pipeThrough(deflated, DecompressionStream, 'deflate-raw');
+    const payload = JSON.parse(new TextDecoder().decode(bytes));
+    if (!payload || typeof payload.v !== 'number' || payload.v > MAX_SHARE_VERSION) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a full shareable URL using the compressed v2 encoding.
+ * @param {import('../models/CharacterShareModel').CharacterSharePayload} payload
+ * @param {string} [baseUrl]
+ * @returns {Promise<string>}
+ */
+export async function buildCharacterShareUrlCompressed(payload, baseUrl) {
+  return buildShareUrl('character', await encodeCharacterShareCompressed(payload), baseUrl);
 }

--- a/test/shareV2.test.js
+++ b/test/shareV2.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { extractSkillTree } from '../src/utils/skillTreeParser.js';
+import { aggregateSkillEffects, hasWeaponSkillData } from '../src/utils/skillEffectAggregator.js';
+import {
+  createCharacterSharePayload,
+  createSkillTreeShare,
+  skillTreeShareToData,
+  CHARACTER_SHARE_VERSION,
+} from '../src/models/CharacterShareModel.js';
+import {
+  encodeCharacterShare,
+  encodeCharacterShareCompressed,
+  decodeCharacterShareAny,
+  buildCharacterShareUrlCompressed,
+} from '../src/utils/shareUrl.js';
+
+let skillTree;
+
+beforeAll(() => {
+  const fixturePath = path.join(import.meta.dirname, 'fixtures', 'dr-character-skills.json');
+  skillTree = extractSkillTree(JSON.parse(fs.readFileSync(fixturePath, 'utf8')));
+});
+
+describe('skill tree share section', () => {
+  it('round-trips cards and weapon skills', () => {
+    const st = createSkillTreeShare(skillTree);
+    expect(st.cd.length).toBeGreaterThan(0);
+    expect(st.ws.length).toBeGreaterThan(0);
+
+    const restored = skillTreeShareToData(st);
+    expect(hasWeaponSkillData(restored)).toBe(true);
+    expect(restored.cards.length).toBe(skillTree.cards.length);
+
+    // Paragon level survives (PolearmDamage L732, bucketed under mauls)
+    const mauls = restored.weaponStances.mauls.skills.find(s => s.rowName === 'PolearmDamage');
+    expect(mauls?.level).toBe(732);
+  });
+
+  it('restored tree produces identical aggregated skill effects', () => {
+    const original = aggregateSkillEffects(skillTree);
+    const restored = aggregateSkillEffects(skillTreeShareToData(createSkillTreeShare(skillTree)));
+
+    const total = (contribs) => {
+      const sums = {};
+      for (const c of contribs) sums[c.tag] = (sums[c.tag] || 0) + c.value;
+      return sums;
+    };
+    expect(total(restored)).toEqual(total(original));
+  });
+
+  it('returns null for empty trees', () => {
+    expect(createSkillTreeShare(null)).toBeNull();
+    expect(skillTreeShareToData(null)).toBeNull();
+    expect(skillTreeShareToData({})).toBeNull();
+  });
+});
+
+describe('compressed (v2) share encoding', () => {
+  it('round-trips a full payload with skill tree', async () => {
+    const payload = createCharacterSharePayload([], null, { luck: { value: 361 } }, 3731, skillTree);
+    expect(payload.v).toBe(CHARACTER_SHARE_VERSION);
+    expect(payload.st).toBeDefined();
+
+    const code = await encodeCharacterShareCompressed(payload);
+    expect(code.startsWith('2.')).toBe(true);
+
+    const decoded = await decodeCharacterShareAny(code);
+    expect(decoded).toEqual(payload);
+  });
+
+  it('still decodes legacy v1 uncompressed codes', async () => {
+    const legacy = { v: 1, e: [], hp: 1000 };
+    const code = encodeCharacterShare(legacy);
+    const decoded = await decodeCharacterShareAny(code);
+    expect(decoded).toEqual(legacy);
+  });
+
+  it('rejects garbage input', async () => {
+    expect(await decodeCharacterShareAny('2.not-valid-deflate!!')).toBeNull();
+    expect(await decodeCharacterShareAny('')).toBeNull();
+    expect(await decodeCharacterShareAny(null)).toBeNull();
+  });
+
+  it('compression keeps the URL under the practical limit', async () => {
+    const payload = createCharacterSharePayload([], null, null, 0, skillTree);
+    const url = await buildCharacterShareUrlCompressed(payload, 'https://example.com/');
+    console.log(`Skill-tree-only compressed URL: ${url.length} chars (${skillTree.cards.length} cards, ${
+      Object.values(skillTree.weaponStances).reduce((n, s) => n + s.skills.length, 0)} weapon skills)`);
+    expect(url.length).toBeLessThan(8000);
+  });
+});


### PR DESCRIPTION
…ill tree

Display (Character tab):
- New Vitals category pinned above the fold showing the save-reported max health (Health_29) — the real in-game number. Gear-only calculation misses the character base health pool (e.g. 3,731 in-game vs 1,238 from gear on a real save); the tooltip explains the difference.
- Stat tooltips prefix each source with a colored system-bucket chip: Item / Card / Skill / Buff / Mono / Base / Stance. Skill contributions carry their aggregator kind through to the tooltip.

Share v2:
- Character shares now include the skill tree (st: cards + weapon skill levels, WEAPON_SKILL_DICT-compressed), so shared builds compute real card/skill/buff effects instead of the mastery approximation.
- Payloads are deflate-compressed via native CompressionStream with a "2." prefix; decodeCharacterShareAny() handles both v2 and legacy v1. Full 17-item build + full tree ≈ 2.4KB (was ≈ 5.8KB gear-only).
- "Copy Code" button shares the bare code; Upload tab gains a paste-import box accepting either a full URL or a bare code.


Claude-Session: https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g