### PR TITLE
Consolidate file acquisition: live-watch checkbox on Upload, Filter a…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,9 +170,17 @@ The save file is an "import shortcut" - all UI components work from the internal
 | Drag & drop | Yes | Yes |
 | File picker | Yes | Yes |
 | Folder picker | Yes (`showDirectoryPicker`) | No |
-| Directory watching | Yes (10s polling) | No |
+| Live watch (save-folder polling) | Yes (Upload tab checkbox, 10s poll) | No (snapshot `File` semantics — re-reading a changed file throws; UI shows a re-drop note) |
 
 Detection in `src/utils/platform.js`.
+
+**Live watch architecture:** file acquisition is consolidated on the Upload
+tab. `useSaveWatcher` (instantiated in `App.jsx` so polling survives tab
+switches) holds a `FileSystemDirectoryHandle`, polls for the newest `.sav` by
+name+lastModified, and re-processes it through the normal load path WITHOUT
+switching tabs (initial start lands on Filter). Character stats and Filter
+results update reactively from the item store — the Filter tab has no file
+inputs of its own.
 
 ## Patterns & Conventions
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import { initWasm } from './utils/wasm';
 import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
+import { useSaveWatcher } from './hooks/useSaveWatcher';
+import { useFileProcessor } from './hooks/useFileProcessor';
 import { parseShareFromHash, decodeFilterShare, decodeCharacterShareAny } from './utils/shareUrl';
 import { masteryShareToData, allocatedAttributesShareToData, skillTreeShareToData } from './models/CharacterShareModel';
 
@@ -126,6 +128,33 @@ export default function App() {
     log(`🎮 Save loaded: ${data.filename}`);
   }, [log, itemStore]);
 
+  // Live watch (Chromium): re-process the newest .sav whenever the game
+  // writes one. Reloads the store in place — Character stats and Filter
+  // results are store-reactive — without yanking the user off their tab.
+  const { processFile } = useFileProcessor();
+  const handleWatchedSave = useCallback(async (file, { isInitial } = {}) => {
+    try {
+      log(`${isInitial ? '👁️ Watching' : '🔄 Save updated'}: ${file.name} (${(file.size / 1024).toFixed(1)} KB)`);
+      const result = await processFile(file);
+      setSaveData({
+        file,
+        filename: result.filename,
+        raw: result.parsed,
+        json: result.json,
+        equippedItems: result.equippedItems || [],
+        items: result.items || [],
+        totalItems: result.totalItems || 0,
+        timestamp: Date.now(),
+      });
+      itemStore.loadFromSave(result.parsed, result.filename);
+      // The checkbox is "live watch for item filter" — land there on start
+      if (isInitial) setActiveTab('filter');
+    } catch (e) {
+      log(`❌ Watch reload failed: ${e.message}`);
+    }
+  }, [processFile, itemStore, log]);
+  const saveWatcher = useSaveWatcher({ onSaveChanged: handleWatchedSave, onLog: log });
+
   const handleClearSave = useCallback(() => {
     setSaveData(null);
     itemStore.clear();
@@ -151,7 +180,7 @@ export default function App() {
       {wasmReady && (
         <>
           {activeTab === 'upload' && (
-            <UploadTab onFileLoaded={handleFileLoaded} onLog={log} onStatusChange={handleStatusChange} onImportShare={handleImportShare} />
+            <UploadTab onFileLoaded={handleFileLoaded} onLog={log} onStatusChange={handleStatusChange} onImportShare={handleImportShare} saveWatcher={saveWatcher} />
           )}
           {activeTab === 'character' && (saveData || itemStore.hasItems) && (
             <CharacterTab

--- a/src/components/filter/FilterTab.jsx
+++ b/src/components/filter/FilterTab.jsx
@@ -1,26 +1,21 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Button, DropZone } from '../common';
+import { Button } from '../common';
 import { FilterConfig } from './FilterConfig';
 import { ResultsSection, EmptyResultsSection } from './ResultsSection';
-import { useFileProcessor } from '../../hooks/useFileProcessor';
-import { hasDirPicker } from '../../utils/platform';
 import { playNotificationSound } from '../../utils/sound';
 import { filterByModel } from '../../utils/itemFilter';
 import { transformAllItems } from '../../models/itemTransformer';
 import { createFilterModel } from '../../models/FilterModel';
 import { useFilterProfiles } from '../../hooks/useFilterProfiles';
 
+// File acquisition (drop/pick/live-watch) is consolidated on the Upload tab —
+// this tab is a pure view over the item store: results re-filter reactively
+// when the filter model changes or the store reloads (including live watch).
 export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, sharedFilterModel, onSharedFilterConsumed }) {
   const [results, setResults] = useState(new Map());
   const [filterModel, setFilterModel] = useState(() => createFilterModel('Default'));
   const [configVisible, setConfigVisible] = useState(false);
-  const [lastFiles, setLastFiles] = useState([]);
-  const [dirHandle, setDirHandle] = useState(null);
-  const [watching, setWatching] = useState(false);
-  const watchTimerRef = useRef(null);
   const seenFilesRef = useRef(new Set());
-  const fileInputRef = useRef(null);
-  const { processFile, isProcessing } = useFileProcessor();
   const { profiles, saveProfile, deleteProfile } = useFilterProfiles();
 
   /**
@@ -30,46 +25,9 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
     return filterByModel(items, model);
   }, []);
 
-  /**
-   * Process .sav files: parse via WASM, transform to Item models, then filter.
-   */
-  const processFiles = useCallback(async (files, model = filterModel) => {
-    for (const file of files) {
-      try {
-        onLog(`Converting: ${file.name} (${(file.size / 1024).toFixed(1)} KB)`);
-        const result = await processFile(file);
-
-        // Transform raw JSON into Item models (equipment arrays are
-        // automatically excluded by the transformer)
-        const { items: searchableItems } = transformAllItems(result.json);
-        const { hits, close, totalItems } = runFilter(searchableItems, model);
-
-        setResults(prev => {
-          const next = new Map(prev);
-          next.set(file.name, {
-            hits,
-            close,
-            totalItems,
-            timestamp: Date.now(),
-            filterModel: model,
-          });
-          return next;
-        });
-
-        onLog(`Found ${hits.length} matches, ${close.length} near-misses from ${totalItems} items`);
-
-        if (hits.length > 0) {
-          playNotificationSound();
-        }
-      } catch (e) {
-        onLog(`Error: ${e.message}`);
-      }
-    }
-  }, [filterModel, processFile, onLog, runFilter]);
-
   // Keep the loaded save's results live: re-filter the in-memory inventory
-  // whenever the filter model changes or a new save is loaded. (Results from
-  // manually dropped files are snapshots — use Re-run to refresh those.)
+  // whenever the filter model changes or a new save is loaded (uploads and
+  // live-watch reloads both land in the item store).
   useEffect(() => {
     if (!itemStore?.hasItems && !initialSaveData) return;
 
@@ -105,9 +63,6 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
       return next;
     });
 
-    if (initialSaveData?.file) {
-      setLastFiles(prev => (prev.length === 0 ? [initialSaveData.file] : prev));
-    }
   }, [initialSaveData, itemStore?.inventory, itemStore?.metadata?.filename, filterModel, runFilter]);
 
   // Load shared filter model from URL and auto-save to profiles
@@ -124,120 +79,10 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
     if (onSharedFilterConsumed) onSharedFilterConsumed();
   }, [sharedFilterModel, onLog, onSharedFilterConsumed, saveProfile]);
 
-  const handleFileDrop = useCallback(async (files) => {
-    setLastFiles(files);
-    onStatusChange('Processing...', 'scanning');
-    await processFiles(files);
-    onStatusChange('Ready', 'ready');
-  }, [processFiles, onStatusChange]);
-
-  const handlePickFile = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
-
-  const handleFileInputChange = useCallback(async (e) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setLastFiles([file]);
-      onStatusChange('Processing...', 'scanning');
-      await processFiles([file]);
-      onStatusChange('Ready', 'ready');
-    }
-    e.target.value = '';
-  }, [processFiles, onStatusChange]);
-
-  const handlePickDir = useCallback(async () => {
-    if (!hasDirPicker()) return;
-
-    try {
-      const handle = await window.showDirectoryPicker({ mode: 'read' });
-      setDirHandle(handle);
-      onLog('Folder granted (Chromium)');
-      onStatusChange('Folder selected', 'active');
-
-      const files = [];
-      for await (const [name, h] of handle.entries()) {
-        if (/\.sav$/i.test(name)) {
-          const file = await h.getFile();
-          files.push(file);
-        }
-      }
-
-      if (files.length > 0) {
-        setLastFiles(files);
-        await processFiles(files);
-      }
-      onStatusChange('Ready', 'ready');
-    } catch (e) {
-      onLog(`Pick canceled: ${e?.message || e}`);
-    }
-  }, [processFiles, onLog, onStatusChange]);
-
-  const handleStartWatch = useCallback(async () => {
-    if (!hasDirPicker()) {
-      alert('Directory watching requires Chrome/Edge/Brave.');
-      return;
-    }
-
-    if (watching) {
-      if (watchTimerRef.current) {
-        clearInterval(watchTimerRef.current);
-        watchTimerRef.current = null;
-      }
-      setWatching(false);
-      onLog('Stopped watching');
-      onStatusChange('Ready', 'ready');
-      return;
-    }
-
-    let handle = dirHandle;
-    if (!handle) {
-      try {
-        handle = await window.showDirectoryPicker({ mode: 'read' });
-        setDirHandle(handle);
-      } catch {
-        return;
-      }
-    }
-
-    onLog('Watching... (poll every 10s)');
-    onStatusChange('Watching', 'active');
-    setWatching(true);
-
-    const scanOnce = async () => {
-      const files = [];
-      for await (const [name, h] of handle.entries()) {
-        if (/\.sav$/i.test(name)) {
-          const file = await h.getFile();
-          files.push(file);
-        }
-      }
-      if (files.length > 0) {
-        setLastFiles(files);
-        await processFiles(files);
-      }
-    };
-
-    await scanOnce();
-    watchTimerRef.current = setInterval(scanOnce, 10000);
-  }, [watching, dirHandle, processFiles, onLog, onStatusChange]);
-
-  const handleRerun = useCallback(async () => {
-    if (lastFiles.length === 0) {
-      onLog('No files to re-run');
-      return;
-    }
-    onLog(`Re-running ${lastFiles.length} file(s)`);
-    onStatusChange('Re-running...', 'scanning');
-    await processFiles(lastFiles);
-    onStatusChange('Ready', 'ready');
-  }, [lastFiles, processFiles, onLog, onStatusChange]);
-
   const handleClear = useCallback(() => {
     setResults(new Map());
-    setLastFiles([]);
     seenFilesRef.current.clear();
-    onLog('Results and file history cleared');
+    onLog('Results cleared');
   }, [onLog]);
 
   // --- Filter model updates from the config panel ---
@@ -288,48 +133,22 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
     onLog(`Profile "${name}" deleted`);
   }, [deleteProfile, onLog]);
 
-  const handleApplyConfig = useCallback(async () => {
+  // The reactive effect above re-filters on every model change; Apply/Reset
+  // just close the panel and log.
+  const handleApplyConfig = useCallback(() => {
     if (filterModel.affixes.length === 0 && filterModel.monograms.length === 0) {
       onLog('No filter criteria selected');
       return;
     }
     setConfigVisible(false);
     onLog(`Filters updated: ${filterModel.affixes.length} affixes, ${filterModel.monograms.length} monograms`);
+  }, [filterModel, onLog]);
 
-    if (lastFiles.length > 0) {
-      onLog('Re-scanning with new filters...');
-      onStatusChange('Applying filters...', 'scanning');
-      setResults(new Map());
-      await processFiles(lastFiles, filterModel);
-      onStatusChange('Ready', 'ready');
-    } else if (itemStore?.inventory?.length) {
-      // Re-filter existing inventory (already excludes equipped items)
-      const filename = itemStore?.metadata?.filename || 'loaded.sav';
-      const { hits, close, totalItems } = runFilter(itemStore.inventory, filterModel);
-      setResults(new Map([[filename, {
-        hits, close, totalItems,
-        timestamp: Date.now(),
-        filterModel,
-      }]]));
-      onLog(`Found ${hits.length} matches, ${close.length} near-misses from ${totalItems} items`);
-      if (hits.length > 0) playNotificationSound();
-    }
-  }, [filterModel, lastFiles, processFiles, onLog, onStatusChange, itemStore, runFilter]);
-
-  const handleResetConfig = useCallback(async () => {
-    const newModel = createFilterModel('Default');
-    setFilterModel(newModel);
+  const handleResetConfig = useCallback(() => {
+    setFilterModel(createFilterModel('Default'));
     setConfigVisible(false);
     onLog('Filters reset');
-
-    if (lastFiles.length > 0) {
-      onLog('Re-scanning with cleared filters...');
-      onStatusChange('Applying filters...', 'scanning');
-      setResults(new Map());
-      await processFiles(lastFiles, newModel);
-      onStatusChange('Ready', 'ready');
-    }
-  }, [lastFiles, processFiles, onLog, onStatusChange]);
+  }, [onLog]);
 
   const sortedResults = Array.from(results.entries()).sort((a, b) => b[1].timestamp - a[1].timestamp);
 
@@ -354,39 +173,13 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
 
   return (
     <div className="tab-content active">
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".sav"
-        hidden
-        onChange={handleFileInputChange}
-      />
-
       <div className="controls">
         <div className="control-row">
-          <Button icon="📄" variant="primary" onClick={handlePickFile} disabled={isProcessing}>
-            Pick .sav File
+          <Button icon="⚙️" variant="primary" onClick={() => setConfigVisible(!configVisible)}>
+            Configure Filters
           </Button>
-          <Button icon="📁" onClick={handlePickDir} hidden={!hasDirPicker()} disabled={isProcessing}>
-            Pick Folder
-          </Button>
-          <Button
-            icon={watching ? '⏹️' : '👁️'}
-            onClick={handleStartWatch}
-            hidden={!hasDirPicker()}
-          >
-            {watching ? 'Stop Watching' : 'Start Watching'}
-          </Button>
-          <Button icon="🔄" onClick={handleRerun} disabled={lastFiles.length === 0}>
-            Re-run Last
-          </Button>
-        </div>
-        <div className="control-row">
           <Button icon="🗑️" onClick={handleClear} disabled={results.size === 0}>
             Clear Results
-          </Button>
-          <Button icon="⚙️" onClick={() => setConfigVisible(!configVisible)}>
-            Configure Filters
           </Button>
         </div>
       </div>
@@ -411,12 +204,6 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
         onLog={onLog}
       />
 
-      <DropZone
-        icon="📦"
-        text="Drop .sav files here or use the Pick button above"
-        onFileDrop={handleFileDrop}
-      />
-
       <div className="results-container">
         {results.size === 0 ? (
           <div className="empty-state">
@@ -428,13 +215,13 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
                   <strong>Filter Ready:</strong> {filterSummary}
                 </div>
                 <div style={{ marginTop: '1rem', color: 'var(--text-secondary)' }}>
-                  Drop a <code>.sav</code> file above or use <strong>Pick .sav File</strong> to apply this filter.
+                  Load a save on the <strong>Upload</strong> tab (or enable <strong>Live watch</strong> there) to apply this filter.
                 </div>
               </>
             ) : (
               <>
                 <div className="empty-state-icon">🔭</div>
-                <div>No results yet. Select a .sav file or drop one here to begin.</div>
+                <div>No results yet. Load a save on the <strong>Upload</strong> tab, then configure filters here.</div>
               </>
             )}
           </div>
@@ -444,7 +231,7 @@ export function FilterTab({ initialSaveData, itemStore, onLog, onStatusChange, s
               {profileLabel && <div className="filter-profile-name">{profileLabel}</div>}
               <strong>Active Filters:</strong> {filterSummary}
               <div style={{ marginTop: '0.5rem', fontSize: '0.9em', color: 'var(--text-secondary)' }}>
-                {results.size} file(s) processed | {lastFiles.length} file(s) in memory
+                {results.size} save(s) scanned — results update live as filters change or the save reloads
               </div>
             </div>
 

--- a/src/components/upload/UploadTab.jsx
+++ b/src/components/upload/UploadTab.jsx
@@ -3,7 +3,7 @@ import { Button, DropZone } from '../common';
 import { useFileProcessor } from '../../hooks/useFileProcessor';
 import { hasDirPicker } from '../../utils/platform';
 
-export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare }) {
+export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare, saveWatcher }) {
   const [recentFiles, setRecentFiles] = useState([]);
   const [importText, setImportText] = useState('');
   const fileInputRef = useRef(null);
@@ -14,6 +14,19 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare }
     const ok = await onImportShare(importText);
     if (ok) setImportText('');
   }, [onImportShare, importText]);
+
+  // Live watch toggle: checking it opens the save-folder picker and starts
+  // polling; the checkbox stays unchecked if the picker is cancelled because
+  // `watching` is the source of truth.
+  const handleWatchToggle = useCallback(async (e) => {
+    if (!saveWatcher) return;
+    if (e.target.checked) {
+      const ok = await saveWatcher.start();
+      if (!ok) onLog('Live watch not started (folder picker cancelled)');
+    } else {
+      saveWatcher.stop();
+    }
+  }, [saveWatcher, onLog]);
 
   const handleFileSelect = useCallback(async (file) => {
     try {
@@ -124,6 +137,26 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare }
             Pick Save Folder
           </Button>
         </div>
+        {saveWatcher?.supported ? (
+          <div className="control-row" style={{ justifyContent: 'center', marginTop: '0.5rem' }}>
+            <label
+              className="live-watch-toggle"
+              title="Pick your save folder once — the app re-scans automatically whenever the game writes a new save (polls every 10s)"
+            >
+              <input
+                type="checkbox"
+                checked={saveWatcher.watching}
+                onChange={handleWatchToggle}
+              />
+              <span>Live watch for item filter</span>
+              {saveWatcher.watching && <span className="live-watch-indicator">👁️ watching…</span>}
+            </label>
+          </div>
+        ) : (
+          <div className="live-watch-note">
+            Live watch (auto re-scan while you play) needs Chrome or Edge — re-drop your save here to refresh on this browser.
+          </div>
+        )}
       </div>
 
       <DropZone

--- a/src/hooks/useSaveWatcher.js
+++ b/src/hooks/useSaveWatcher.js
@@ -1,0 +1,95 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { hasDirPicker } from '../utils/platform';
+
+/**
+ * Live save-folder watcher (Chromium only).
+ *
+ * Uses the File System Access API (`showDirectoryPicker`) to poll the game's
+ * save folder and re-deliver the newest `.sav` whenever the game writes a new
+ * one. Firefox/Safari can't do this: a `File` from an input or drag is a
+ * snapshot — re-reading after the file changes on disk throws — and neither
+ * ships the handle-based API, so callers should feature-gate on `supported`.
+ *
+ * Instantiate at App level so polling survives tab switches.
+ *
+ * @param {Object} options
+ * @param {(file: File, info: {isInitial: boolean}) => Promise<void>|void} options.onSaveChanged
+ *   Called with the newest .sav on start and whenever name/lastModified changes.
+ * @param {(msg: string) => void} [options.onLog]
+ * @param {number} [options.intervalMs=10000] - Poll interval
+ * @returns {{ watching: boolean, supported: boolean, start: () => Promise<boolean>, stop: () => void }}
+ */
+export function useSaveWatcher({ onSaveChanged, onLog, intervalMs = 10000 }) {
+  const [watching, setWatching] = useState(false);
+  const dirHandleRef = useRef(null);
+  const timerRef = useRef(null);
+  const lastSeenRef = useRef(null); // `${name}:${lastModified}` of newest .sav
+  const busyRef = useRef(false);
+
+  const scanOnce = useCallback(async (isInitial = false) => {
+    const handle = dirHandleRef.current;
+    if (!handle || busyRef.current) return;
+    busyRef.current = true;
+    try {
+      let newest = null;
+      for await (const [name, entry] of handle.entries()) {
+        if (!/\.sav$/i.test(name)) continue;
+        const file = await entry.getFile();
+        if (!newest || file.lastModified > newest.lastModified) newest = file;
+      }
+      if (!newest) {
+        if (isInitial) onLog?.('⚠️ No .sav files found in folder');
+        return;
+      }
+      const stamp = `${newest.name}:${newest.lastModified}`;
+      if (stamp !== lastSeenRef.current) {
+        lastSeenRef.current = stamp;
+        await onSaveChanged?.(newest, { isInitial });
+      }
+    } catch (e) {
+      onLog?.(`⚠️ Watch scan failed: ${e?.message || e}`);
+    } finally {
+      busyRef.current = false;
+    }
+  }, [onSaveChanged, onLog]);
+
+  const stop = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    dirHandleRef.current = null;
+    lastSeenRef.current = null;
+    setWatching(false);
+    onLog?.('👁️ Live watch stopped');
+  }, [onLog]);
+
+  /**
+   * Prompt for the save folder and begin watching.
+   * @returns {Promise<boolean>} false if unsupported or the picker was cancelled
+   */
+  const start = useCallback(async () => {
+    if (!hasDirPicker()) return false;
+    let handle;
+    try {
+      handle = await window.showDirectoryPicker({ mode: 'read' });
+    } catch {
+      return false; // user cancelled the picker
+    }
+    dirHandleRef.current = handle;
+    setWatching(true);
+    onLog?.(`👁️ Live watch started (polling every ${Math.round(intervalMs / 1000)}s)`);
+    await scanOnce(true);
+    timerRef.current = setInterval(() => scanOnce(false), intervalMs);
+    return true;
+  }, [scanOnce, intervalMs, onLog]);
+
+  // Clean up the timer on unmount
+  useEffect(() => () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+  }, []);
+
+  return { watching, supported: hasDirPicker(), start, stop };
+}
+
+export default useSaveWatcher;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1547,6 +1547,36 @@ h1::before {
 .source-chip-base { background: #6f7a86; }
 .source-chip-stance { background: #3f8f8f; }
 
+/* Live watch toggle (Upload tab, Chromium only) */
+.live-watch-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.live-watch-toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.live-watch-indicator {
+  color: var(--success);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.live-watch-note {
+  text-align: center;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 /* Share code paste-import (Upload tab) */
 .share-import-input {
   background: var(--bg-secondary);


### PR DESCRIPTION
…s pure view

New useSaveWatcher hook (App-level, so polling survives tab switches): holds a FileSystemDirectoryHandle, polls the save folder every 10s, and re-processes the newest .sav when its name/lastModified changes. Reloads flow through the normal item-store path without switching tabs, so Character stats and Filter results update reactively in place.

Upload tab gains a "Live watch for item filter" checkbox behind agent detect (hasDirPicker): checking it opens the folder picker and starts watching (initial load lands on the Filter tab); the checkbox is controlled by watcher state so a cancelled picker leaves it unchecked. Firefox/Safari see a note that live watch needs Chrome/Edge (File snapshot semantics make re-reading a changed file impossible there) with re-drop as the fallback.

Filter tab drops its duplicated acquisition UI (file input, drop zone, pick file/folder, watch, re-run) and becomes a pure view over the item store — the reactive re-filter effect added previously covers all reload paths including live watch. Apply/Reset no longer reprocess files; they just close the config panel and let the effect re-score.


Claude-Session: https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g