### PR TITLE
Live watch: single-file handle instead of folder (Chrome AppData bloc…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,18 +169,24 @@ The save file is an "import shortcut" - all UI components work from the internal
 |---------|----------------------|----------------|
 | Drag & drop | Yes | Yes |
 | File picker | Yes | Yes |
-| Folder picker | Yes (`showDirectoryPicker`) | No |
-| Live watch (save-folder polling) | Yes (Upload tab checkbox, 10s poll) | No (snapshot `File` semantics — re-reading a changed file throws; UI shows a re-drop note) |
+| Live watch (single-file polling) | Yes (Upload tab checkbox → `showOpenFilePicker`, 10s poll) | No (snapshot `File` semantics — re-reading a changed file throws; UI shows a re-drop note) |
 
-Detection in `src/utils/platform.js`.
+Detection in `src/utils/platform.js` (`hasFilePicker()`).
 
 **Live watch architecture:** file acquisition is consolidated on the Upload
 tab. `useSaveWatcher` (instantiated in `App.jsx` so polling survives tab
-switches) holds a `FileSystemDirectoryHandle`, polls for the newest `.sav` by
-name+lastModified, and re-processes it through the normal load path WITHOUT
-switching tabs (initial start lands on Filter). Character stats and Filter
-results update reactively from the item store — the Filter tab has no file
-inputs of its own.
+switches) holds a `FileSystemFileHandle` for ONE user-picked `.sav`, polls
+`getFile()` for lastModified changes, and re-processes it through the normal
+load path WITHOUT switching tabs (initial start lands on Filter). Character
+stats and Filter results update reactively from the item store — the Filter
+tab has no file inputs of its own.
+
+**Why a FILE handle, not a directory:** Chrome's File System Access blocklist
+forbids DIRECTORY handles anywhere under AppData — which is where UE saves
+live (`%LOCALAPPDATA%\...\Saved\SaveGames`) — but individual FILE handles
+inside AppData are allowed. A folder-watching variant was tried and removed
+(commit history: PR #67 → fixed here); `showDirectoryPicker` on the real save
+location is blocked by policy, full stop.
 
 ## Patterns & Conventions
 

--- a/src/components/upload/UploadTab.jsx
+++ b/src/components/upload/UploadTab.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { Button, DropZone } from '../common';
 import { useFileProcessor } from '../../hooks/useFileProcessor';
-import { hasDirPicker } from '../../utils/platform';
 
 export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare, saveWatcher }) {
   const [recentFiles, setRecentFiles] = useState([]);
@@ -15,14 +14,20 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare, 
     if (ok) setImportText('');
   }, [onImportShare, importText]);
 
-  // Live watch toggle: checking it opens the save-folder picker and starts
-  // polling; the checkbox stays unchecked if the picker is cancelled because
-  // `watching` is the source of truth.
+  // Live watch toggle: checking it opens a FILE picker (pick the character's
+  // .sav) and starts polling; the checkbox stays unchecked if the picker is
+  // cancelled or blocked because `watching` is the source of truth.
   const handleWatchToggle = useCallback(async (e) => {
     if (!saveWatcher) return;
     if (e.target.checked) {
-      const ok = await saveWatcher.start();
-      if (!ok) onLog('Live watch not started (folder picker cancelled)');
+      const result = await saveWatcher.start();
+      if (!result.ok) {
+        if (result.reason === 'cancelled') {
+          onLog('Live watch not started (file picker cancelled)');
+        } else {
+          onLog(`❌ Live watch failed: ${result.reason}`);
+        }
+      }
     } else {
       saveWatcher.stop();
     }
@@ -77,39 +82,6 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare, 
     e.target.value = '';
   }, [handleFileSelect]);
 
-  const handlePickDir = useCallback(async () => {
-    if (!hasDirPicker()) return;
-
-    try {
-      const handle = await window.showDirectoryPicker({ mode: 'read' });
-      onLog('📁 Folder access granted');
-      onStatusChange('Scanning folder...', 'scanning');
-
-      const files = [];
-      for await (const [name, h] of handle.entries()) {
-        if (/\.sav$/i.test(name)) {
-          const file = await h.getFile();
-          files.push(file);
-        }
-      }
-
-      if (files.length > 0) {
-        files.sort((a, b) => b.lastModified - a.lastModified);
-        onLog(`📄 Found ${files.length} save file(s), loading most recent`);
-        setRecentFiles(files);
-        await handleFileSelect(files[0]);
-      } else {
-        onLog('⚠️ No .sav files found in folder');
-        onStatusChange('No files found', 'ready');
-      }
-    } catch (e) {
-      if (e?.name !== 'AbortError') {
-        onLog(`❌ Folder access failed: ${e?.message || e}`);
-      }
-      onStatusChange('Ready', 'ready');
-    }
-  }, [handleFileSelect, onLog, onStatusChange]);
-
   return (
     <div className="tab-content active">
       <input
@@ -133,25 +105,31 @@ export function UploadTab({ onFileLoaded, onLog, onStatusChange, onImportShare, 
           <Button icon="📄" variant="primary" onClick={handlePickFile} disabled={isProcessing}>
             Pick .sav File
           </Button>
-          <Button icon="📁" onClick={handlePickDir} hidden={!hasDirPicker()} disabled={isProcessing}>
-            Pick Save Folder
-          </Button>
         </div>
         {saveWatcher?.supported ? (
-          <div className="control-row" style={{ justifyContent: 'center', marginTop: '0.5rem' }}>
-            <label
-              className="live-watch-toggle"
-              title="Pick your save folder once — the app re-scans automatically whenever the game writes a new save (polls every 10s)"
-            >
-              <input
-                type="checkbox"
-                checked={saveWatcher.watching}
-                onChange={handleWatchToggle}
-              />
-              <span>Live watch for item filter</span>
-              {saveWatcher.watching && <span className="live-watch-indicator">👁️ watching…</span>}
-            </label>
-          </div>
+          <>
+            <div className="control-row" style={{ justifyContent: 'center', marginTop: '0.5rem' }}>
+              <label
+                className="live-watch-toggle"
+                title="Opens a file picker: choose your character's .sav once, and the app re-scans automatically whenever the game saves (checked every 10s)"
+              >
+                <input
+                  type="checkbox"
+                  checked={saveWatcher.watching}
+                  onChange={handleWatchToggle}
+                />
+                <span>Live watch a save file (pick it once, auto re-scan while you play)</span>
+              </label>
+            </div>
+            {saveWatcher.watching && (
+              <div className="live-watch-status">
+                👁️ Watching <strong>{saveWatcher.watchedName}</strong> — checks every 10s
+                {saveWatcher.lastChangeAt && (
+                  <> · last change {new Date(saveWatcher.lastChangeAt).toLocaleTimeString()}</>
+                )}
+              </div>
+            )}
+          </>
         ) : (
           <div className="live-watch-note">
             Live watch (auto re-scan while you play) needs Chrome or Edge — re-drop your save here to refresh on this browser.

--- a/src/hooks/useSaveWatcher.js
+++ b/src/hooks/useSaveWatcher.js
@@ -1,95 +1,126 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { hasDirPicker } from '../utils/platform';
+import { hasFilePicker } from '../utils/platform';
+
+// Give up after this many consecutive failed polls (file deleted/moved,
+// permission revoked) instead of erroring every 10s forever.
+const MAX_CONSECUTIVE_FAILURES = 6;
 
 /**
- * Live save-folder watcher (Chromium only).
+ * Live single-file save watcher (Chromium only).
  *
- * Uses the File System Access API (`showDirectoryPicker`) to poll the game's
- * save folder and re-deliver the newest `.sav` whenever the game writes a new
- * one. Firefox/Safari can't do this: a `File` from an input or drag is a
- * snapshot — re-reading after the file changes on disk throws — and neither
- * ships the handle-based API, so callers should feature-gate on `supported`.
+ * Uses `showOpenFilePicker()` to take a persistent handle on ONE `.sav` file
+ * and polls `handle.getFile()` for lastModified changes, re-delivering the
+ * file when the game writes it.
+ *
+ * Why a FILE handle and not a directory: Chrome's File System Access
+ * blocklist forbids DIRECTORY handles anywhere under AppData — which is where
+ * UE save games live (`%LOCALAPPDATA%\...\Saved\SaveGames`) — but individual
+ * file handles inside AppData are allowed. Firefox/Safari support neither
+ * (their `File` objects are snapshots; re-reading a changed file throws), so
+ * callers feature-gate on `supported`.
  *
  * Instantiate at App level so polling survives tab switches.
  *
  * @param {Object} options
  * @param {(file: File, info: {isInitial: boolean}) => Promise<void>|void} options.onSaveChanged
- *   Called with the newest .sav on start and whenever name/lastModified changes.
+ *   Called with the file on start and whenever lastModified changes.
  * @param {(msg: string) => void} [options.onLog]
  * @param {number} [options.intervalMs=10000] - Poll interval
- * @returns {{ watching: boolean, supported: boolean, start: () => Promise<boolean>, stop: () => void }}
+ * @returns {{
+ *   watching: boolean,
+ *   supported: boolean,
+ *   watchedName: string|null,
+ *   lastChangeAt: number|null,
+ *   start: () => Promise<{ok: boolean, reason?: 'cancelled'|'unsupported'|string}>,
+ *   stop: () => void,
+ * }}
  */
 export function useSaveWatcher({ onSaveChanged, onLog, intervalMs = 10000 }) {
   const [watching, setWatching] = useState(false);
-  const dirHandleRef = useRef(null);
+  const [watchedName, setWatchedName] = useState(null);
+  const [lastChangeAt, setLastChangeAt] = useState(null);
+  const fileHandleRef = useRef(null);
   const timerRef = useRef(null);
-  const lastSeenRef = useRef(null); // `${name}:${lastModified}` of newest .sav
+  const lastModifiedRef = useRef(0);
   const busyRef = useRef(false);
+  const failureCountRef = useRef(0);
 
-  const scanOnce = useCallback(async (isInitial = false) => {
-    const handle = dirHandleRef.current;
-    if (!handle || busyRef.current) return;
-    busyRef.current = true;
-    try {
-      let newest = null;
-      for await (const [name, entry] of handle.entries()) {
-        if (!/\.sav$/i.test(name)) continue;
-        const file = await entry.getFile();
-        if (!newest || file.lastModified > newest.lastModified) newest = file;
-      }
-      if (!newest) {
-        if (isInitial) onLog?.('⚠️ No .sav files found in folder');
-        return;
-      }
-      const stamp = `${newest.name}:${newest.lastModified}`;
-      if (stamp !== lastSeenRef.current) {
-        lastSeenRef.current = stamp;
-        await onSaveChanged?.(newest, { isInitial });
-      }
-    } catch (e) {
-      onLog?.(`⚠️ Watch scan failed: ${e?.message || e}`);
-    } finally {
-      busyRef.current = false;
-    }
-  }, [onSaveChanged, onLog]);
-
-  const stop = useCallback(() => {
+  const stop = useCallback((reasonMsg) => {
     if (timerRef.current) {
       clearInterval(timerRef.current);
       timerRef.current = null;
     }
-    dirHandleRef.current = null;
-    lastSeenRef.current = null;
+    fileHandleRef.current = null;
+    lastModifiedRef.current = 0;
+    failureCountRef.current = 0;
     setWatching(false);
-    onLog?.('👁️ Live watch stopped');
+    setWatchedName(null);
+    onLog?.(reasonMsg || '👁️ Live watch stopped');
   }, [onLog]);
 
+  const pollOnce = useCallback(async (isInitial = false) => {
+    const handle = fileHandleRef.current;
+    if (!handle || busyRef.current) return;
+    busyRef.current = true;
+    try {
+      const file = await handle.getFile();
+      failureCountRef.current = 0;
+      if (file.lastModified !== lastModifiedRef.current) {
+        lastModifiedRef.current = file.lastModified;
+        setLastChangeAt(Date.now());
+        await onSaveChanged?.(file, { isInitial });
+      }
+    } catch (e) {
+      failureCountRef.current += 1;
+      if (failureCountRef.current === 1) {
+        onLog?.(`⚠️ Watch poll failed: ${e?.message || e}`);
+      }
+      if (failureCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+        stop(`⚠️ Live watch stopped — the file couldn't be read ${MAX_CONSECUTIVE_FAILURES} times in a row (moved/deleted?)`);
+      }
+    } finally {
+      busyRef.current = false;
+    }
+  }, [onSaveChanged, onLog, stop]);
+
   /**
-   * Prompt for the save folder and begin watching.
-   * @returns {Promise<boolean>} false if unsupported or the picker was cancelled
+   * Prompt for a .sav file and begin watching it.
+   * @returns {Promise<{ok: boolean, reason?: string}>} `reason` is
+   *   'cancelled' when the user dismissed the picker; otherwise the browser's
+   *   error message (e.g. a policy block).
    */
   const start = useCallback(async () => {
-    if (!hasDirPicker()) return false;
+    if (!hasFilePicker()) return { ok: false, reason: 'unsupported' };
     let handle;
     try {
-      handle = await window.showDirectoryPicker({ mode: 'read' });
-    } catch {
-      return false; // user cancelled the picker
+      [handle] = await window.showOpenFilePicker({
+        multiple: false,
+        types: [{
+          description: 'Unreal save files',
+          accept: { 'application/octet-stream': ['.sav'] },
+        }],
+      });
+    } catch (e) {
+      if (e?.name === 'AbortError') return { ok: false, reason: 'cancelled' };
+      return { ok: false, reason: e?.message || String(e) };
     }
-    dirHandleRef.current = handle;
+
+    fileHandleRef.current = handle;
+    failureCountRef.current = 0;
     setWatching(true);
-    onLog?.(`👁️ Live watch started (polling every ${Math.round(intervalMs / 1000)}s)`);
-    await scanOnce(true);
-    timerRef.current = setInterval(() => scanOnce(false), intervalMs);
-    return true;
-  }, [scanOnce, intervalMs, onLog]);
+    setWatchedName(handle.name);
+    onLog?.(`👁️ Live watching ${handle.name} (checking every ${Math.round(intervalMs / 1000)}s)`);
+    await pollOnce(true);
+    timerRef.current = setInterval(() => pollOnce(false), intervalMs);
+    return { ok: true };
+  }, [pollOnce, intervalMs, onLog]);
 
   // Clean up the timer on unmount
   useEffect(() => () => {
     if (timerRef.current) clearInterval(timerRef.current);
   }, []);
 
-  return { watching, supported: hasDirPicker(), start, stop };
+  return { watching, supported: hasFilePicker(), watchedName, lastChangeAt, start, stop };
 }
 
 export default useSaveWatcher;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1577,6 +1577,13 @@ h1::before {
   font-style: italic;
 }
 
+.live-watch-status {
+  text-align: center;
+  margin-top: 0.4rem;
+  font-size: 0.82rem;
+  color: var(--success);
+}
+
 /* Share code paste-import (Upload tab) */
 .share-import-input {
   background: var(--bg-secondary);

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -18,3 +18,11 @@ export function detectPlatform() {
 export function hasDirPicker() {
   return 'showDirectoryPicker' in window;
 }
+
+// Single-file handle picker (Chromium). Unlike DIRECTORY handles — which
+// Chrome's File System Access blocklist forbids anywhere under AppData, where
+// UE save games actually live — FILE handles inside AppData are allowed, so
+// live watch uses this instead of showDirectoryPicker.
+export function hasFilePicker() {
+  return 'showOpenFilePicker' in window;
+}


### PR DESCRIPTION
…klist)

Chrome's File System Access blocklist forbids DIRECTORY handles anywhere under AppData — exactly where UE saves live — so the folder-based watcher could never reach the real save location. FILE handles inside AppData ARE allowed, so useSaveWatcher now takes a showOpenFilePicker handle on one user-picked .sav and polls getFile() for lastModified changes.

UX fixes from field testing:
- Checkbox label now says what happens: "Live watch a save file (pick it once, auto re-scan while you play)", and while watching a status line shows the watched filename, the 10s cadence, and the last change time — no more guessing whether it's a file or folder or live.
- Picker cancellation and policy blocks are reported distinctly (start() returns {ok, reason} instead of a bare boolean that conflated them).
- Poller stops itself with a message after 6 consecutive read failures (file moved/deleted) instead of erroring every 10s forever.
- Removed the vestigial "Pick Save Folder" button: blocked by policy for the real save location, and its useful behavior (load newest save) is subsumed by the watcher's initial scan. File picker + drag/drop remain.


Claude-Session: https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g