### PR TITLE
Max health formula, live-watch removal, character header cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,9 +511,17 @@ Options keys: `h`=minHitsPerPool, `c`=closeMinTotal, `w`=includeWeapons, `t`=min
     "wt": 0,                                       // weapon type (WEAPON_TYPE_DICT index)
     "ws": [[0, 1], [8, 5]],                        // weapon skills [[skillEnc, level], ...]
     "ks": [0, 2]                                   // keystones [keystoneEnc, ...]
-  }
+  },
+  "cn": "NesPasJeter",                             // character name (omitted if unknown)
+  "lv": 560,                                       // character level (omitted if unknown)
+  "cb": 6                                          // campaign bosses defeated 0-6 (omitted if 0)
 }
 ```
+
+**Identity fields (`cn`/`lv`/`cb`):** name/level drive the Character header;
+level + campaign-boss count rebuild the progression health pool on load
+(`calculateLevelHealth(lv) + cb × 100`), so shared builds compute the same max
+health as a direct save load.
 
 **Stat values:** Raw decimals from save file. Percentages are stored as decimals (0.316 = 31.6%). Flat stats as-is (Armor = 197.57). No conversion — `useDerivedStats` already handles the raw format.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,9 +62,14 @@ export default function App() {
     const masteryData = masteryShareToData(decoded.sk ?? null);
     const allocatedAttributes = allocatedAttributesShareToData(decoded.at ?? null);
     const skillTree = skillTreeShareToData(decoded.st ?? null);
-    itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0, skillTree);
+    const identity = {
+      name: decoded.cn ?? '',
+      level: decoded.lv ?? 0,
+      campaignBossCount: decoded.cb ?? 0,
+    };
+    itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0, skillTree, identity);
     setActiveTab('character');
-    log('Loaded shared character build');
+    log(`Loaded shared character build${identity.name ? `: ${identity.name}` : ''}`);
     return true;
   }, [itemStore, log]);
 

--- a/src/components/character/CharacterPanel.jsx
+++ b/src/components/character/CharacterPanel.jsx
@@ -13,7 +13,11 @@ export function CharacterPanel({ characterData }) {
 
   if (!characterData) return null;
 
-  const baseName = characterData.filename.replace(/\.sav$/i, '');
+  // Prefer the character's real name (HostPlayerData.PlayerName) — save
+  // filenames are character-id hashes. Shares fall back to the filename stub.
+  const displayName = characterData.characterName
+    || characterData.filename?.replace(/\.sav$/i, '')
+    || 'Character';
 
   // Map equipped items to their slots
   const equippedItems = characterData.equippedItems || [];
@@ -151,8 +155,10 @@ export function CharacterPanel({ characterData }) {
   return (
     <div className="character-panel">
       <div className="character-header">
-        <span className="character-name">{baseName}</span>
-        <span className="character-class">Unknown Class</span>
+        <span className="character-name">{displayName}</span>
+        {characterData.characterLevel > 0 && (
+          <span className="character-class">Level {characterData.characterLevel}</span>
+        )}
       </div>
 
       <div className="character-content">

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -12,6 +12,8 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
   // Falls back to saveData for backward compatibility
   const characterData = itemStore?.hasItems ? {
     filename: itemStore.metadata.filename || saveData?.filename,
+    characterName: itemStore.metadata.characterName,
+    characterLevel: itemStore.metadata.characterLevel,
     equippedItems: itemStore.equipped,
     timestamp: itemStore.metadata.loadedAt,
     stanceContext: itemStore.metadata.stanceContext,

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -32,6 +32,11 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     itemStore.metadata?.allocatedAttributes ?? null,
     itemStore.metadata?.maxHealth ?? 0,
     itemStore.metadata?.skillTree ?? null,
+    {
+      name: itemStore.metadata?.characterName || '',
+      level: itemStore.metadata?.characterLevel || 0,
+      campaignBossCount: itemStore.metadata?.healthProgression?.campaignBosses?.length || 0,
+    },
   ), [itemStore.equipped, itemStore.metadata, characterData?.stanceContext]);
 
   const handleShare = useCallback(async () => {

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -3,7 +3,7 @@ import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
 import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { extractSkillTree } from '../utils/skillTreeParser';
-import { parseHealthProgression } from '../utils/healthParser';
+import { parseHealthProgression, parseCharacterName } from '../utils/healthParser';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -72,6 +72,10 @@ export function useItemStore() {
     setMetadata({
       filename,
       loadedAt: new Date().toISOString(),
+      // Save filenames are character-id hashes; the real name lives in
+      // HostPlayerData.PlayerName
+      characterName: parseCharacterName(saveJson),
+      characterLevel: healthProgression.level,
       stanceContext,
       allocatedAttributes,
       characterStats,

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -3,7 +3,7 @@ import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
 import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { extractSkillTree } from '../utils/skillTreeParser';
-import { parseHealthProgression, parseCharacterName } from '../utils/healthParser';
+import { parseHealthProgression, parseCharacterName, calculateLevelHealth, CAMPAIGN_BOSS_HEALTH } from '../utils/healthParser';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -92,9 +92,27 @@ export function useItemStore() {
    * @param {import('../models/CharacterShareModel').EquippedItemShare[]} itemShares
    * @param {Object|null} [masteryData] - Decoded mastery data (stored in metadata for downstream use)
    * @param {Object<string, {value:number}>} [allocatedAttributes] - Decoded base attribute pool
+   * @param {number} [maxHealth]
+   * @param {Object|null} [skillTree]
+   * @param {{name?: string, level?: number, campaignBossCount?: number}|null} [identity]
+   *   Character name/level/boss-count from the share — level + boss count
+   *   rebuild the progression health pool so shared max health matches a
+   *   direct save load.
    */
-  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0, skillTree = null) => {
+  const loadFromShare = useCallback((itemShares, masteryData = null, allocatedAttributes = {}, maxHealth = 0, skillTree = null, identity = null) => {
     const equippedItems = (itemShares || []).map((share, i) => itemShareToItem(share, i));
+
+    const characterStats = { ...(allocatedAttributes || {}) };
+    const level = identity?.level || 0;
+    const bossCount = identity?.campaignBossCount || 0;
+    const progressionHealth = calculateLevelHealth(level) + bossCount * CAMPAIGN_BOSS_HEALTH;
+    if (progressionHealth > 0) {
+      characterStats.health = {
+        value: progressionHealth,
+        sourceName: `Base + level ${level} + ${bossCount} campaign bosses`,
+        sourceType: 'progression',
+      };
+    }
 
     setEquipped(equippedItems);
     setInventory([]);
@@ -102,9 +120,11 @@ export function useItemStore() {
     setMetadata({
       filename: 'Shared Build',
       loadedAt: new Date().toISOString(),
+      characterName: identity?.name || '',
+      characterLevel: level,
       stanceContext: convertMasteryToStanceContext(masteryData),
       allocatedAttributes: allocatedAttributes || {},
-      characterStats: allocatedAttributes || {},
+      characterStats,
       maxHealth: maxHealth || 0,
       sharedMastery: masteryData,
       // v2 shares carry the skill tree; when present, useDerivedStats computes

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -72,6 +72,11 @@ export const CHARACTER_SHARE_VERSION = 2;
  * @property {{ cd?: Array<[string, number]>, ws?: Array<[number|string, number]>, mh?: string[] }} [st] -
  *   Skill tree section (v2+): cards [[rowName, level]], weapon skills
  *   [[skillEnc, level]], and known main-tree health node row names.
+ * @property {string} [cn] - Character name (display; omitted if unknown)
+ * @property {number} [lv] - Character level (drives the progression health
+ *   pool on the receiving side; omitted if unknown)
+ * @property {number} [cb] - Campaign bosses defeated (0-6; each grants +100
+ *   flat health; omitted if 0)
  */
 
 // ---------------------------------------------------------------------------
@@ -251,7 +256,7 @@ export function allocatedAttributesShareToData(at) {
  * @param {Object<string, {value:number}|number>|null} [allocatedAttributes]
  * @returns {CharacterSharePayload}
  */
-export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0, skillTree = null) {
+export function createCharacterSharePayload(equippedItems, stanceContext = null, allocatedAttributes = null, maxHealth = 0, skillTree = null, identity = null) {
   const payload = { v: CHARACTER_SHARE_VERSION };
 
   if (equippedItems && equippedItems.length > 0) {
@@ -272,6 +277,14 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
   // real skill effects; the mastery snapshot above stays as the fallback.
   const st = createSkillTreeShare(skillTree);
   if (st) payload.st = st;
+
+  // Character identity + progression inputs. Name/level for display; level
+  // plus campaign-boss count let the receiving side rebuild the exact
+  // progression health pool (base + per-level + boss bonuses), so shared
+  // builds compute the same max health as a direct save load.
+  if (identity?.name) payload.cn = identity.name;
+  if (identity?.level > 0) payload.lv = identity.level;
+  if (identity?.campaignBossCount > 0) payload.cb = identity.campaignBossCount;
 
   return payload;
 }

--- a/src/utils/healthParser.js
+++ b/src/utils/healthParser.js
@@ -25,6 +25,19 @@ export function parseCharacterLevel(saveData) {
   return Number.isFinite(level) && level > 0 ? level : 0;
 }
 
+/**
+ * Character name from HostPlayerData (PlayerName_*). The save FILENAME is a
+ * character-id hash — useless as a display name — so the UI prefers this.
+ * @returns {string} Character name, or '' when unavailable.
+ */
+export function parseCharacterName(saveData) {
+  const hostPlayerStruct = findHostPlayerStruct(saveData);
+  if (!hostPlayerStruct) return '';
+  const key = Object.keys(hostPlayerStruct).find(k => k.startsWith('PlayerName_'));
+  const name = key ? hostPlayerStruct[key]?.Str : '';
+  return typeof name === 'string' ? name : '';
+}
+
 /** @returns {number[]} Completed rupture numbers from the map-select save data. */
 export function parseCompletedRuptures(saveData) {
   const props = saveData?.root?.properties || saveData?.properties;

--- a/test/healthParser.test.js
+++ b/test/healthParser.test.js
@@ -3,6 +3,7 @@ import {
   calculateCampaignHealth,
   calculateLevelHealth,
   parseCharacterLevel,
+  parseCharacterName,
   parseCompletedRuptures,
   parseHealthProgression,
 } from '../src/utils/healthParser.js';
@@ -15,6 +16,7 @@ function makeSave(level, completedRuptures = []) {
           Struct: {
             Struct: {
               Level_11_TEST_0: { Int: level },
+              PlayerName_2_TEST_0: { Str: 'NesPasJeter' },
             },
           },
         },
@@ -39,6 +41,11 @@ describe('health progression parsing', () => {
     const save = makeSave(560, [1, 6, 12, 18, 24, 30, 36, 160]);
     expect(parseCharacterLevel(save)).toBe(560);
     expect(parseCompletedRuptures(save)).toEqual([1, 6, 12, 18, 24, 30, 36, 160]);
+  });
+
+  it('reads the character name from HostPlayerData', () => {
+    expect(parseCharacterName(makeSave(560))).toBe('NesPasJeter');
+    expect(parseCharacterName({})).toBe('');
   });
 
   it('awards 100 flat health for each of the six campaign bosses', () => {

--- a/test/shareV2.test.js
+++ b/test/shareV2.test.js
@@ -15,6 +15,7 @@ import {
   decodeCharacterShareAny,
   buildCharacterShareUrlCompressed,
 } from '../src/utils/shareUrl.js';
+import { calculateLevelHealth, CAMPAIGN_BOSS_HEALTH } from '../src/utils/healthParser.js';
 
 let skillTree;
 
@@ -70,6 +71,41 @@ describe('compressed (v2) share encoding', () => {
 
     const decoded = await decodeCharacterShareAny(code);
     expect(decoded).toEqual(payload);
+  });
+
+  it('carries character identity (name, level, campaign bosses)', async () => {
+    const payload = createCharacterSharePayload([], null, null, 5360, skillTree, {
+      name: 'NesPasJeter',
+      level: 560,
+      campaignBossCount: 6,
+    });
+    expect(payload.cn).toBe('NesPasJeter');
+    expect(payload.lv).toBe(560);
+    expect(payload.cb).toBe(6);
+
+    const decoded = await decodeCharacterShareAny(await encodeCharacterShareCompressed(payload));
+    expect(decoded.cn).toBe('NesPasJeter');
+    expect(decoded.lv).toBe(560);
+    expect(decoded.cb).toBe(6);
+  });
+
+  it('omits identity fields when unknown (and old payloads stay valid)', async () => {
+    const noIdentity = createCharacterSharePayload([], null, null, 0, null, { name: '', level: 0, campaignBossCount: 0 });
+    expect(noIdentity.cn).toBeUndefined();
+    expect(noIdentity.lv).toBeUndefined();
+    expect(noIdentity.cb).toBeUndefined();
+
+    // Payloads created before the identity fields existed decode unchanged
+    const legacyShaped = { v: 2, e: [], hp: 1000 };
+    const decoded = await decodeCharacterShareAny(await encodeCharacterShareCompressed(legacyShaped));
+    expect(decoded).toEqual(legacyShaped);
+  });
+
+  it('level + boss count reconstruct the save-side progression pool', () => {
+    // Mirrors useItemStore.loadFromShare: shared builds rebuild the same
+    // flat pool parseHealthProgression derives from the save (level 560 +
+    // 6 bosses = 760 + 600)
+    expect(calculateLevelHealth(560) + 6 * CAMPAIGN_BOSS_HEALTH).toBe(1360);
   });
 
   it('still decodes legacy v1 uncompressed codes', async () => {


### PR DESCRIPTION
## Summary

Three changes, verified against a real level-560 save whose reconstructed max health now matches the game **exactly** (2,627.23 flat × 204% = 5,359.56 vs saved 5,359.56, diff 0.00):

### Max health from character progression (Codex patch, reviewed + applied)
- New `healthParser.js`: base pool = 100 + 2/level through 100 + 1/level after; +100 flat per campaign-boss rupture (6/12/18/24/30/36), read from `Completed Ruptures` in the save
- Main passive tree MaxHealth/MaxHealth% nodes de-opaqued via a compact generated map from `DT_GENERATED_SkillTree_Main` (`mainTreeHealth.generated.json`); aggregated like other skill effects with a `Tree` source chip
- Progression health enters the BASE layer as a `progression`-tagged character stat; `totalHealth` keeps fractional precision
- Character share `st` section gains `mh` (known health node rows) so shared builds stay consistent
- Health tooltip now shows total multiplier AND bonus portion (×204% total, +104% bonus) — the game reports the bonus form

### Live watch removed — do not re-attempt
Field testing confirmed Chrome's File System Access blocklist classifies Windows Local AppData (where UE saves live) as `kBlockAllChildren`: **both** `showDirectoryPicker` and `showOpenFilePicker` handles are rejected there. Only the traditional `<input type="file">` snapshot works, and snapshots can't be re-read after the game writes. The watcher hook, Upload-tab checkbox, and App wiring are removed; a hint explains that re-dropping the save refreshes everything (Character/Filter are store-reactive). CLAUDE.md records the finding so it isn't rediscovered.

### Character header cleanup
The header showed the save filename (a character-id hash) plus a never-populated "Unknown Class". It now shows the character's real name (`HostPlayerData.PlayerName`) and "Level N". Shares fall back to the filename stub and hide the level.

## Testing
- 307 tests green (adds healthParser, main-tree aggregation, share round-trip, name-parse coverage)
- End-to-end reconstruction on a real save: flat/bonus source-by-source breakdown matches in-game max health to the cent
- Production build clean

## Follow-up
- Drop `DT_GENERATED_SkillTree_Main.json` into `extraction/data/` so the main-tree map stays regenerable after game updates; the same export can widen the node map beyond health

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g

---
_Generated by [Claude Code](https://claude.ai/code/session_013kr5MCSxJJtYWeacgvKv3g)_