### PR TITLE
Wire primary attribute bonuses from DT_Attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,9 +652,13 @@ adjusted to game values.
 - These edge cases can use config overrides for now.
 
 ### Attribute → Stat Mappings
-- Primary attributes are NOT balanced and do NOT all map to damage.
-- Known: STR→Armor, DEX→Crit, VIT→Health. Others TBD.
-- Once confirmed, these can feed into appropriate eDPS buckets or defense calcs.
+- Generated from the primary-characteristic dependency rows in
+  `DT_Attributes.json` (`src/data/attributeBonuses.generated.json`).
+- STR→Armor%, DEX→Attack Speed, WIS→Boss Damage%, END→Energy Regen,
+  AGI→Critical Damage%, LUCK→XP% + Fire/Arcane/Lightning%,
+  STA→Max Health% + Health Regen.
+- Runtime values are calculated from total attributes (including attribute%)
+  and feed the matching defense, utility, and eDPS buckets.
 
 ### WAD Monogram Bonuses
 - Various monograms add to WAD (weapon ability damage multiplier).

--- a/extraction/generate-registries.mjs
+++ b/extraction/generate-registries.mjs
@@ -17,6 +17,7 @@
  *   DT_GENERATED_SkillTree_Main.json — optional main-tree UI-node effects
  *
  * Outputs (committed, consumed by src/):
+ *   src/data/attributeBonuses.generated.json
  *   src/data/monograms.generated.json
  *   src/data/affixes.generated.json
  *   src/data/modifierPools.generated.json
@@ -44,6 +45,18 @@ const GEN_DIR = path.join(REPO_ROOT, 'src', 'data');
 
 const MODIFIER_PREFIX = 'EasyRPG.Items.Modifiers.';
 
+const PRIMARY_ATTRIBUTE_TAGS = {
+  strength: 'EasyRPG.Attributes.Characteristics.Strength',
+  dexterity: 'EasyRPG.Attributes.Characteristics.Dexterity',
+  wisdom: 'EasyRPG.Attributes.Characteristics.Wisdom',
+  // The game exposes this to players as Endurance but retains Intelligence in
+  // the underlying gameplay tag.
+  endurance: 'EasyRPG.Attributes.Characteristics.Intelligence',
+  agility: 'EasyRPG.Attributes.Characteristics.Agility',
+  luck: 'EasyRPG.Attributes.Characteristics.Luck',
+  stamina: 'EasyRPG.Attributes.Characteristics.Stamina',
+};
+
 function loadTable(fileName) {
   const raw = JSON.parse(fs.readFileSync(path.join(DATA_DIR, fileName), 'utf8'));
   const objects = Array.isArray(raw) ? raw : [raw];
@@ -67,6 +80,29 @@ function textOf(ftext) {
   // SourceString is the developer's current English; LocalizedString can lag
   // behind it when the localization table hasn't been rebuilt.
   return ftext.SourceString ?? ftext.LocalizedString ?? ftext.CultureInvariantString ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Primary attribute dependencies (from DT_Attributes)
+// ---------------------------------------------------------------------------
+
+function generateAttributeBonuses(attributeRows) {
+  return Object.fromEntries(Object.entries(PRIMARY_ATTRIBUTE_TAGS).map(([id, tag]) => {
+    const row = attributeRows[tag];
+    if (!row) throw new Error(`Missing primary attribute row: ${tag}`);
+
+    const effects = (prop(row, 'Dependencies') ?? []).map((dep) => ({
+      tag: prop(dep, 'GameplayTag')?.TagName,
+      valuePerPoint: prop(dep, 'Value') ?? 0,
+    })).filter(effect => effect.tag);
+
+    return [id, {
+      tag,
+      name: textOf(prop(row, 'AttributeName')) ?? id,
+      description: textOf(prop(row, 'Description')) ?? '',
+      effects,
+    }];
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -330,6 +366,7 @@ try {
 }
 
 const monograms = generateMonograms(attributeRows);
+const attributeBonuses = generateAttributeBonuses(attributeRows);
 const affixes = generateAffixes(affixRows);
 const pools = generatePools(poolRows);
 const cards = generateCards(cardRows);
@@ -339,6 +376,8 @@ const weaponSkills = generateWeaponSkills(statusEffects);
 fs.mkdirSync(GEN_DIR, { recursive: true });
 const banner = { _generated: 'by extraction/generate-registries.mjs — do not edit by hand' };
 
+fs.writeFileSync(path.join(GEN_DIR, 'attributeBonuses.generated.json'),
+  JSON.stringify({ ...banner, _source: 'DT_Attributes primary-characteristic dependencies', attributeBonuses }, null, 2));
 fs.writeFileSync(path.join(GEN_DIR, 'monograms.generated.json'),
   JSON.stringify({ ...banner, monograms }, null, 2));
 fs.writeFileSync(path.join(GEN_DIR, 'affixes.generated.json'),
@@ -356,6 +395,7 @@ if (mainTreeHealth) {
     JSON.stringify({ ...banner, _source: 'DT_GENERATED_SkillTree_Main (MaxHealth effects only)', effectsByRow: mainTreeHealth }, null, 2));
 }
 
+console.log(`Attributes:     ${Object.keys(attributeBonuses).length}`);
 console.log(`Monograms:      ${Object.keys(monograms).length}`);
 console.log(`Affixes:        ${Object.keys(affixes).length}`);
 console.log(`Pools:          ${Object.keys(pools).length}`);

--- a/src/components/character/StatTooltip.jsx
+++ b/src/components/character/StatTooltip.jsx
@@ -21,6 +21,7 @@ const sourceChip = (source) => {
     case 'progression': return { label: 'Base', cls: 'base' };
     case 'monogram': return { label: 'Mono', cls: 'monogram' };
     case 'allocated': return { label: 'Base', cls: 'base' };
+    case 'attribute': return { label: 'Stat', cls: 'base' };
     case 'stance': return { label: 'Stance', cls: 'stance' };
     case 'save': return { label: 'Save', cls: 'base' };
     default: return { label: 'Item', cls: 'item' };

--- a/src/data/attributeBonuses.generated.json
+++ b/src/data/attributeBonuses.generated.json
@@ -1,0 +1,99 @@
+{
+  "_generated": "by extraction/generate-registries.mjs — do not edit by hand",
+  "_source": "DT_Attributes primary-characteristic dependencies",
+  "attributeBonuses": {
+    "strength": {
+      "tag": "EasyRPG.Attributes.Characteristics.Strength",
+      "name": "Strength",
+      "description": "10 Strength = 1% Armor",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.Armor%",
+          "valuePerPoint": 0.001
+        }
+      ]
+    },
+    "dexterity": {
+      "tag": "EasyRPG.Attributes.Characteristics.Dexterity",
+      "name": "Dexterity",
+      "description": "1 Dexterity = 1 Attack Speed",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.AttackSpeed",
+          "valuePerPoint": 1
+        }
+      ]
+    },
+    "wisdom": {
+      "tag": "EasyRPG.Attributes.Characteristics.Wisdom",
+      "name": "Wisdom",
+      "description": "10 Wisdom = 0.5% Boss Damage",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.DamageSystem.Damage.Boss%",
+          "valuePerPoint": 0.0005
+        }
+      ]
+    },
+    "endurance": {
+      "tag": "EasyRPG.Attributes.Characteristics.Intelligence",
+      "name": "Endurance",
+      "description": "10 Endurance = 0.1 Energy Regen",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.EnergyRegeneration",
+          "valuePerPoint": 0.01
+        }
+      ]
+    },
+    "agility": {
+      "tag": "EasyRPG.Attributes.Characteristics.Agility",
+      "name": "Agility",
+      "description": "10 Agility = 0.5% Critical Damage",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.CriticalDamage",
+          "valuePerPoint": 0.0005
+        }
+      ]
+    },
+    "luck": {
+      "tag": "EasyRPG.Attributes.Characteristics.Luck",
+      "name": "Luck",
+      "description": "10 Luck = 1% XP Bonus;10 Luck = 1% Elemental Damage Bonus",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.XPBonus",
+          "valuePerPoint": 0.001
+        },
+        {
+          "tag": "EasyRPG.Attributes.DamageSystem.Damage.Arcane%",
+          "valuePerPoint": 0.001
+        },
+        {
+          "tag": "EasyRPG.Attributes.DamageSystem.Damage.Fire%",
+          "valuePerPoint": 0.001
+        },
+        {
+          "tag": "EasyRPG.Attributes.DamageSystem.Damage.Lightning%",
+          "valuePerPoint": 0.001
+        }
+      ]
+    },
+    "stamina": {
+      "tag": "EasyRPG.Attributes.Characteristics.Stamina",
+      "name": "Stamina",
+      "description": "10 Stamina = 0.1% Max Health;10 Stamina = 0.1 Health Regeneration",
+      "effects": [
+        {
+          "tag": "EasyRPG.Attributes.Base.MaxHealth%",
+          "valuePerPoint": 0.0001
+        },
+        {
+          "tag": "EasyRPG.Attributes.Base.HealthRegeneration",
+          "valuePerPoint": 0.01
+        }
+      ]
+    }
+  }
+}

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -5,6 +5,7 @@ import { STAT_REGISTRY } from '../utils/statRegistry.js';
 import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
 import { inferWeaponStance } from '../utils/equipmentParser.js';
 import { aggregateSkillEffects, hasWeaponSkillData } from '../utils/skillEffectAggregator.js';
+import { ATTRIBUTE_BONUSES } from '../utils/attributeBonuses.js';
 
 // Re-export for backward compatibility
 export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
@@ -315,18 +316,27 @@ export function useDerivedStats(options = {}) {
   const categories = useMemo(() => {
     const { values, detailed } = calculatedStats;
 
-    // Map total stats to their base components and display routing.
-    // Total stats apply bonus%: base × (1 + bonus%) and replace the raw flat display.
+    // Map calculated totals to their raw sources and display routing. Primary,
+    // armor, and health totals multiply bonus%; the remaining targets add the
+    // generated primary-attribute dependency contribution.
     const TOTAL_STAT_ROUTING = {
-      totalStrength: { base: 'strength', bonus: 'strengthBonus', category: 'attributes', name: 'Strength' },
-      totalDexterity: { base: 'dexterity', bonus: 'dexterityBonus', category: 'attributes', name: 'Dexterity' },
-      totalWisdom: { base: 'wisdom', bonus: 'wisdomBonus', category: 'attributes', name: 'Wisdom' },
-      totalEndurance: { base: 'endurance', bonus: 'enduranceBonus', category: 'attributes', name: 'Endurance' },
-      totalAgility: { base: 'agility', bonus: 'agilityBonus', category: 'attributes', name: 'Agility' },
-      totalLuck: { base: 'luck', bonus: 'luckBonus', category: 'attributes', name: 'Luck' },
-      totalStamina: { base: 'stamina', bonus: 'staminaBonus', category: 'attributes', name: 'Stamina' },
-      totalArmor: { base: 'armor', bonus: 'armorBonus', category: 'defense', name: 'Armor' },
-      totalHealth: { base: 'health', bonus: 'healthBonus', category: 'defense', name: 'Health' },
+      totalStrength: { base: 'strength', bonus: 'strengthBonus', attribute: 'strength', category: 'attributes', name: 'Strength' },
+      totalDexterity: { base: 'dexterity', bonus: 'dexterityBonus', attribute: 'dexterity', category: 'attributes', name: 'Dexterity' },
+      totalWisdom: { base: 'wisdom', bonus: 'wisdomBonus', attribute: 'wisdom', category: 'attributes', name: 'Wisdom' },
+      totalEndurance: { base: 'endurance', bonus: 'enduranceBonus', attribute: 'endurance', category: 'attributes', name: 'Endurance' },
+      totalAgility: { base: 'agility', bonus: 'agilityBonus', attribute: 'agility', category: 'attributes', name: 'Agility' },
+      totalLuck: { base: 'luck', bonus: 'luckBonus', attribute: 'luck', category: 'attributes', name: 'Luck' },
+      totalStamina: { base: 'stamina', bonus: 'staminaBonus', attribute: 'stamina', category: 'attributes', name: 'Stamina' },
+      totalArmor: { base: 'armor', bonus: 'armorBonus', derivedBonus: { id: 'strengthArmorBonus', source: 'Strength' }, category: 'defense', name: 'Armor' },
+      totalHealth: { base: 'health', bonus: 'healthBonus', derivedBonus: { id: 'staminaHealthBonus', source: 'Stamina' }, category: 'defense', name: 'Health' },
+      totalCritDamage: { base: 'critDamage', additions: [{ id: 'agilityCritDamageBonus', source: 'Agility' }], isPercent: true, category: 'offense', name: 'Critical Damage' },
+      totalBossBonus: { base: 'bossBonus', additions: [{ id: 'wisdomBossBonus', source: 'Wisdom' }], isPercent: true, category: 'offense', name: 'Boss Damage Bonus' },
+      totalHealthRegen: { base: 'healthRegen', additions: [{ id: 'staminaHealthRegen', source: 'Stamina' }], category: 'defense', name: 'Health Regen' },
+      totalEnergyRegen: { base: 'energyRegen', additions: [{ id: 'enduranceEnergyRegen', source: 'Endurance' }], category: 'defense', name: 'Energy Regen' },
+      totalXpBonus: { base: 'xpBonus', additions: [{ id: 'luckXpBonus', source: 'Luck' }], isPercent: true, category: 'utility', name: 'XP Bonus' },
+      totalFireDamageBonus: { base: 'fireDamageBonus', additions: [{ id: 'luckFireDamageBonus', source: 'Luck' }], isPercent: true, category: 'elemental', name: 'Fire Damage' },
+      totalArcaneDamageBonus: { base: 'arcaneDamageBonus', additions: [{ id: 'luckArcaneDamageBonus', source: 'Luck' }], isPercent: true, category: 'elemental', name: 'Arcane Damage' },
+      totalLightningDamageBonus: { base: 'lightningDamageBonus', additions: [{ id: 'luckLightningDamageBonus', source: 'Luck' }], isPercent: true, category: 'elemental', name: 'Lightning Damage' },
       // totalDamage is intentionally omitted from the display routing: the
       // Effective Damage headline (edpsEffective) is the canonical damage
       // number and its tooltip covers the full formula. totalDamage is still
@@ -337,10 +347,10 @@ export function useDerivedStats(options = {}) {
     // Base/bonus stat IDs consumed by total stats (don't show separately).
     // damage and damageBonus are consumed manually since totalDamage no longer
     // owns them in the display routing above.
-    const consumedByTotals = new Set(['damage', 'damageBonus']);
+    const consumedByTotals = new Set(['damage', 'damageBonus', 'attackSpeed']);
     for (const info of Object.values(TOTAL_STAT_ROUTING)) {
-      consumedByTotals.add(info.base);
-      consumedByTotals.add(info.bonus);
+      if (info.base) consumedByTotals.add(info.base);
+      if (info.bonus) consumedByTotals.add(info.bonus);
     }
 
     // Monogram-derived stat IDs - these go in the monograms section
@@ -421,23 +431,51 @@ export function useDerivedStats(options = {}) {
 
         // Build combined sources from flat base + bonus%
         const baseSources = aggregatedWithSources[routing.base]?.sources || [];
-        const bonusSources = aggregatedWithSources[routing.bonus]?.sources || [];
+        const bonusSources = routing.bonus ? aggregatedWithSources[routing.bonus]?.sources || [] : [];
         const baseTotal = aggregatedWithSources[routing.base]?.total || 0;
-        const bonusTotal = aggregatedWithSources[routing.bonus]?.total || 0;
+        const rawBonusTotal = routing.bonus ? aggregatedWithSources[routing.bonus]?.total || 0 : 0;
+        const derivedBonusTotal = routing.derivedBonus ? values[routing.derivedBonus.id] || 0 : 0;
+        const additions = routing.additions || [];
+        const additionsTotal = additions.reduce((sum, addition) => sum + (values[addition.id] || 0), 0);
+        const bonusTotal = rawBonusTotal + derivedBonusTotal;
 
         const sources = [
-          ...baseSources.map(s => ({ ...s, isPercent: false })),
+          ...baseSources.map(s => ({ ...s, isPercent: Boolean(routing.isPercent) })),
           ...bonusSources.map(s => ({ ...s, itemName: `${s.itemName} (%)`, isPercent: true })),
+          ...(routing.derivedBonus && derivedBonusTotal ? [{
+            itemName: routing.derivedBonus.source,
+            slot: 'attribute',
+            value: derivedBonusTotal,
+            sourceType: 'attribute',
+            isPercent: true,
+          }] : []),
+          ...additions.filter(addition => values[addition.id]).map(addition => ({
+            itemName: addition.source,
+            slot: 'attribute',
+            value: values[addition.id],
+            sourceType: 'attribute',
+            isPercent: Boolean(routing.isPercent),
+          })),
         ];
 
         // Show both the total multiplier and bonus portion. The game reports
         // "+104%" while the formula multiplies by 204%.
         let description;
-        if (bonusTotal) {
+        if (additions.length) {
+          const formatPart = value => routing.isPercent
+            ? `${(value * 100).toFixed(1)}%`
+            : value.toFixed(2);
+          description = `${formatPart(baseTotal)} base + ${formatPart(additionsTotal)} from attributes = ${stat.formattedValue}`;
+        } else if (bonusTotal) {
           const flatDisplay = routing.base === 'health' ? baseTotal.toFixed(2) : Math.floor(baseTotal);
           description = `${flatDisplay} flat \u00d7 ${((1 + bonusTotal) * 100).toFixed(0)}% total (+${(bonusTotal * 100).toFixed(0)}% bonus) = ${stat.formattedValue}`;
         } else {
-          description = `${routing.name} from gear`;
+          description = routing.attribute ? `${routing.name} total` : `${routing.name} from gear`;
+        }
+
+        if (routing.attribute) {
+          const dependency = ATTRIBUTE_BONUSES[routing.attribute].description.replace(/;(?!\s)/g, '; ');
+          description = `${description}. ${dependency}`;
         }
 
         // For primary attributes, append bonus% to the displayed value

--- a/src/utils/attributeBonuses.js
+++ b/src/utils/attributeBonuses.js
@@ -1,0 +1,34 @@
+import generated from '../data/attributeBonuses.generated.json';
+import { findStatForAttribute, STAT_REGISTRY } from './statRegistry.js';
+
+// DT_Attributes stores AttackSpeed in display points (1 Dexterity = 1 Attack
+// Speed), while the app's canonical percent stats use decimals (0.01 = 1%).
+const normalizeValue = (statId, value) => statId === 'attackSpeed' ? value / 100 : value;
+
+const resolveEffect = ({ tag, valuePerPoint }) => {
+  const stat = findStatForAttribute(tag);
+  if (!stat) throw new Error(`Unmapped primary-attribute dependency: ${tag}`);
+
+  return {
+    tag,
+    statId: stat.id,
+    valuePerPoint: normalizeValue(stat.id, valuePerPoint),
+    isPercent: Boolean(STAT_REGISTRY[stat.id]?.isPercent),
+  };
+};
+
+/**
+ * Compact runtime view of the primary-characteristic dependency rows exported
+ * from DT_Attributes. Values are normalized to the units used by STAT_REGISTRY.
+ */
+export const ATTRIBUTE_BONUSES = Object.freeze(Object.fromEntries(
+  Object.entries(generated.attributeBonuses).map(([id, attribute]) => [id, Object.freeze({
+    ...attribute,
+    effects: Object.freeze(attribute.effects.map(resolveEffect)),
+  })]),
+));
+
+export function getAttributeBonusEffect(attributeId, targetStatId) {
+  return ATTRIBUTE_BONUSES[attributeId]?.effects.find(effect => effect.statId === targetStatId) ?? null;
+}
+

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -18,6 +18,7 @@
  */
 
 import { STAT_REGISTRY } from './statRegistry.js';
+import { ATTRIBUTE_BONUSES, getAttributeBonusEffect } from './attributeBonuses.js';
 
 // ============================================================================
 // LAYER DEFINITIONS
@@ -56,6 +57,24 @@ function term(stats, id, op, fmt, overrides = {}) {
   };
 }
 
+function attributeEffect({ id, name, attributeId, totalId, targetStatId }) {
+  const effect = getAttributeBonusEffect(attributeId, targetStatId);
+  if (!effect) throw new Error(`Missing ${attributeId} → ${targetStatId} dependency`);
+
+  return {
+    id,
+    name,
+    category: 'attribute-bonus',
+    layer: LAYERS.TOTALS,
+    dependencies: [totalId],
+    calculate: stats => (stats[totalId] || 0) * effect.valuePerPoint,
+    format: effect.isPercent
+      ? value => `+${(value * 100).toFixed(1)}%`
+      : value => `+${value.toFixed(2)}`,
+    description: ATTRIBUTE_BONUSES[attributeId].description,
+  };
+}
+
 // ============================================================================
 // DERIVED STAT DEFINITIONS
 // ============================================================================
@@ -76,7 +95,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Strength after bonuses applied',
+    description: ATTRIBUTE_BONUSES.strength.description,
   },
   totalDexterity: {
     id: 'totalDexterity',
@@ -90,7 +109,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Dexterity after bonuses applied',
+    description: ATTRIBUTE_BONUSES.dexterity.description,
   },
   totalWisdom: {
     id: 'totalWisdom',
@@ -104,7 +123,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Wisdom after bonuses applied',
+    description: ATTRIBUTE_BONUSES.wisdom.description,
   },
   totalEndurance: {
     id: 'totalEndurance',
@@ -118,7 +137,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Endurance after bonuses applied',
+    description: ATTRIBUTE_BONUSES.endurance.description,
   },
   totalAgility: {
     id: 'totalAgility',
@@ -132,7 +151,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Agility after bonuses applied',
+    description: ATTRIBUTE_BONUSES.agility.description,
   },
   totalLuck: {
     id: 'totalLuck',
@@ -146,7 +165,7 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Luck after bonuses applied',
+    description: ATTRIBUTE_BONUSES.luck.description,
   },
   totalStamina: {
     id: 'totalStamina',
@@ -160,8 +179,56 @@ export const DERIVED_STATS = {
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
-    description: 'Stamina after bonuses applied',
+    description: ATTRIBUTE_BONUSES.stamina.description,
   },
+
+  // Attribute dependency values come directly from DT_Attributes. Keep them
+  // as named intermediates so downstream totals and tooltip sources can show
+  // exactly what each primary characteristic contributes.
+  strengthArmorBonus: attributeEffect({
+    id: 'strengthArmorBonus', name: 'Armor from Strength',
+    attributeId: 'strength', totalId: 'totalStrength', targetStatId: 'armorBonus',
+  }),
+  dexterityAttackSpeed: attributeEffect({
+    id: 'dexterityAttackSpeed', name: 'Attack Speed from Dexterity',
+    attributeId: 'dexterity', totalId: 'totalDexterity', targetStatId: 'attackSpeed',
+  }),
+  wisdomBossBonus: attributeEffect({
+    id: 'wisdomBossBonus', name: 'Boss Damage from Wisdom',
+    attributeId: 'wisdom', totalId: 'totalWisdom', targetStatId: 'bossBonus',
+  }),
+  enduranceEnergyRegen: attributeEffect({
+    id: 'enduranceEnergyRegen', name: 'Energy Regen from Endurance',
+    attributeId: 'endurance', totalId: 'totalEndurance', targetStatId: 'energyRegen',
+  }),
+  agilityCritDamageBonus: attributeEffect({
+    id: 'agilityCritDamageBonus', name: 'Critical Damage from Agility',
+    attributeId: 'agility', totalId: 'totalAgility', targetStatId: 'critDamage',
+  }),
+  luckXpBonus: attributeEffect({
+    id: 'luckXpBonus', name: 'XP Bonus from Luck',
+    attributeId: 'luck', totalId: 'totalLuck', targetStatId: 'xpBonus',
+  }),
+  luckArcaneDamageBonus: attributeEffect({
+    id: 'luckArcaneDamageBonus', name: 'Arcane Damage from Luck',
+    attributeId: 'luck', totalId: 'totalLuck', targetStatId: 'arcaneDamageBonus',
+  }),
+  luckFireDamageBonus: attributeEffect({
+    id: 'luckFireDamageBonus', name: 'Fire Damage from Luck',
+    attributeId: 'luck', totalId: 'totalLuck', targetStatId: 'fireDamageBonus',
+  }),
+  luckLightningDamageBonus: attributeEffect({
+    id: 'luckLightningDamageBonus', name: 'Lightning Damage from Luck',
+    attributeId: 'luck', totalId: 'totalLuck', targetStatId: 'lightningDamageBonus',
+  }),
+  staminaHealthBonus: attributeEffect({
+    id: 'staminaHealthBonus', name: 'Max Health from Stamina',
+    attributeId: 'stamina', totalId: 'totalStamina', targetStatId: 'healthBonus',
+  }),
+  staminaHealthRegen: attributeEffect({
+    id: 'staminaHealthRegen', name: 'Health Regen from Stamina',
+    attributeId: 'stamina', totalId: 'totalStamina', targetStatId: 'healthRegen',
+  }),
 
   // Defense totals
   totalArmor: {
@@ -169,10 +236,10 @@ export const DERIVED_STATS = {
     name: 'Total Armor',
     category: 'totals',
     layer: LAYERS.TOTALS,
-    dependencies: ['armor', 'armorBonus'],
+    dependencies: ['armor', 'armorBonus', 'strengthArmorBonus'],
     calculate: (stats) => {
       const base = stats.armor || 0;
-      const bonus = stats.armorBonus || 0;
+      const bonus = (stats.armorBonus || 0) + (stats.strengthArmorBonus || 0);
       return Math.floor(base * (1 + bonus));
     },
     format: v => v.toFixed(0),
@@ -183,10 +250,10 @@ export const DERIVED_STATS = {
     name: 'Total Health',
     category: 'totals',
     layer: LAYERS.TOTALS,
-    dependencies: ['health', 'healthBonus'],
+    dependencies: ['health', 'healthBonus', 'staminaHealthBonus'],
     calculate: (stats) => {
       const base = stats.health || 0;
-      const bonus = stats.healthBonus || 0;
+      const bonus = (stats.healthBonus || 0) + (stats.staminaHealthBonus || 0);
       return base * (1 + bonus);
     },
     format: v => v.toFixed(2),
@@ -205,6 +272,62 @@ export const DERIVED_STATS = {
     },
     format: v => v.toFixed(0),
     description: 'Damage after bonuses applied',
+  },
+  totalCritDamage: {
+    id: 'totalCritDamage', name: 'Critical Damage', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['critDamage', 'agilityCritDamageBonus'],
+    calculate: stats => (stats.critDamage || 0) + (stats.agilityCritDamageBonus || 0),
+    format: v => `+${(v * 100).toFixed(1)}%`,
+    description: 'Critical damage including the Agility dependency',
+  },
+  totalBossBonus: {
+    id: 'totalBossBonus', name: 'Boss Damage Bonus', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['bossBonus', 'wisdomBossBonus'],
+    calculate: stats => (stats.bossBonus || 0) + (stats.wisdomBossBonus || 0),
+    format: v => `+${(v * 100).toFixed(1)}%`,
+    description: 'Boss damage including the Wisdom dependency',
+  },
+  totalHealthRegen: {
+    id: 'totalHealthRegen', name: 'Health Regen', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['healthRegen', 'staminaHealthRegen'],
+    calculate: stats => (stats.healthRegen || 0) + (stats.staminaHealthRegen || 0),
+    format: v => `+${v.toFixed(2)}/s`,
+    description: 'Health regeneration including the Stamina dependency',
+  },
+  totalEnergyRegen: {
+    id: 'totalEnergyRegen', name: 'Energy Regen', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['energyRegen', 'enduranceEnergyRegen'],
+    calculate: stats => (stats.energyRegen || 0) + (stats.enduranceEnergyRegen || 0),
+    format: v => `+${v.toFixed(2)}/s`,
+    description: 'Energy regeneration including the Endurance dependency',
+  },
+  totalXpBonus: {
+    id: 'totalXpBonus', name: 'XP Bonus', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['xpBonus', 'luckXpBonus'],
+    calculate: stats => (stats.xpBonus || 0) + (stats.luckXpBonus || 0),
+    format: v => `+${(v * 100).toFixed(1)}%`,
+    description: 'Experience bonus including the Luck dependency',
+  },
+  totalFireDamageBonus: {
+    id: 'totalFireDamageBonus', name: 'Fire Damage', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['fireDamageBonus', 'luckFireDamageBonus'],
+    calculate: stats => (stats.fireDamageBonus || 0) + (stats.luckFireDamageBonus || 0),
+    format: v => `${(v * 100).toFixed(1)}%`,
+    description: 'Fire damage including the Luck dependency',
+  },
+  totalArcaneDamageBonus: {
+    id: 'totalArcaneDamageBonus', name: 'Arcane Damage', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['arcaneDamageBonus', 'luckArcaneDamageBonus'],
+    calculate: stats => (stats.arcaneDamageBonus || 0) + (stats.luckArcaneDamageBonus || 0),
+    format: v => `${(v * 100).toFixed(1)}%`,
+    description: 'Arcane damage including the Luck dependency',
+  },
+  totalLightningDamageBonus: {
+    id: 'totalLightningDamageBonus', name: 'Lightning Damage', category: 'totals', layer: LAYERS.TOTALS,
+    dependencies: ['lightningDamageBonus', 'luckLightningDamageBonus'],
+    calculate: stats => (stats.lightningDamageBonus || 0) + (stats.luckLightningDamageBonus || 0),
+    format: v => `${(v * 100).toFixed(1)}%`,
+    description: 'Lightning damage including the Luck dependency',
   },
 
   // ---------------------------------------------------------------------------
@@ -1508,7 +1631,7 @@ export const DERIVED_STATS = {
     name: 'Crit% (Energy Regen)',
     category: 'monogram-buff',
     layer: LAYERS.PRIMARY_DERIVED,
-    dependencies: [],
+    dependencies: ['totalEnergyRegen'],
     config: {
       enabled: false,
       ratio: 1, // 1% crit per 1 energy regen
@@ -1516,7 +1639,7 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.critChanceFromEnergyRegen.config;
       if (!config.enabled) return 0;
-      const energyRegen = stats.energyRegen || 0;
+      const energyRegen = stats.totalEnergyRegen || 0;
       return energyRegen * config.ratio;
     },
     format: v => `+${v.toFixed(0)}%`,
@@ -2067,7 +2190,7 @@ export const DERIVED_STATS = {
     name: 'Effective Attack Speed',
     category: 'offense',
     layer: LAYERS.SECONDARY_DERIVED,
-    dependencies: ['bloodlustAttackSpeedBonus', 'eliteAttackSpeedBonus'],
+    dependencies: ['dexterityAttackSpeed', 'bloodlustAttackSpeedBonus', 'eliteAttackSpeedBonus'],
     config: {
       cap: 3.0,           // 300% hard cap
       effectiveness: 0.5, // all AS bonuses at 50% effectiveness
@@ -2075,9 +2198,10 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.effectiveAttackSpeed.config;
       const gear = stats.attackSpeed || 0;                          // decimal from items
+      const dexterity = stats.dexterityAttackSpeed || 0;
       const bloodlust = (stats.bloodlustAttackSpeedBonus || 0) / 100;
       const elite = (stats.eliteAttackSpeedBonus || 0) / 100;
-      const raw = gear + bloodlust + elite;
+      const raw = gear + dexterity + bloodlust + elite;
       return Math.min(config.cap, raw * config.effectiveness);
     },
     format: v => `${(v * 100).toFixed(0)}%`,
@@ -2085,11 +2209,13 @@ export const DERIVED_STATS = {
     breakdown: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.effectiveAttackSpeed.config;
       const gear = stats.attackSpeed || 0;
+      const dexterity = stats.dexterityAttackSpeed || 0;
       const bloodlust = (stats.bloodlustAttackSpeedBonus || 0) / 100;
       const elite = (stats.eliteAttackSpeedBonus || 0) / 100;
-      const raw = gear + bloodlust + elite;
+      const raw = gear + dexterity + bloodlust + elite;
       return [
         { label: 'attackSpeed', fullName: 'Gear Attack Speed', op: '+', value: gear, fmt: 'pct' },
+        { label: 'dexterityAttackSpeed', fullName: DERIVED_STATS.dexterityAttackSpeed.name, op: '+', value: dexterity, fmt: 'pct' },
         { label: 'bloodlustAttackSpeedBonus', fullName: DERIVED_STATS.bloodlustAttackSpeedBonus.name, op: '+', value: bloodlust, fmt: 'pct', isMonogram: true },
         { label: 'eliteAttackSpeedBonus', fullName: DERIVED_STATS.eliteAttackSpeedBonus.name, op: '+', value: elite, fmt: 'pct', isMonogram: true },
         { label: 'raw', fullName: 'Raw AS (sum)', op: '=', value: raw, fmt: 'pct', isSubtotal: true },
@@ -2258,7 +2384,7 @@ export const DERIVED_STATS = {
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.edpsPhysAdditive.config;
-      const critDmg = stats.critDamage || 0;
+      const critDmg = stats.totalCritDamage || 0;
       const physBonus = stats.damageBonus || 0; // generic damage bonus = physical
       const STANCE_DMG_IDS = {
         maul: 'maulDamage', sword: 'swordDamage', archery: 'archeryDamage',
@@ -2316,7 +2442,7 @@ export const DERIVED_STATS = {
       return [
         scId ? term(stats, scId, '+', 'pct', { fullName: `Stance Crit Damage (${config.stance || 'highest'})` })
              : { label: 'stanceCritDamage', fullName: 'Stance Crit Damage', op: '+', value: 0, fmt: 'pct' },
-        term(stats, 'critDamage', '+', 'pct'),
+        term(stats, 'totalCritDamage', '+', 'pct'),
         term(stats, 'damageBonus', '+', 'pct', { fullName: 'Physical Damage Bonus' }),
         sdId ? term(stats, sdId, '+', 'pct', { fullName: `Stance Damage (${config.stance || 'highest'})` })
              : { label: 'stanceDamage', fullName: 'Stance Damage', op: '+', value: 0, fmt: 'pct' },
@@ -2382,9 +2508,9 @@ export const DERIVED_STATS = {
       'berserkerElementalFromHighest',
       'shroudElementalBonus', 'shroudElementalFromHighest', 'phasingElementalBonus'],
     calculate: (stats) => {
-      const fire = stats.fireDamageBonus || 0;
-      const arcane = stats.arcaneDamageBonus || 0;
-      const lightning = stats.lightningDamageBonus || 0;
+      const fire = stats.totalFireDamageBonus || 0;
+      const arcane = stats.totalArcaneDamageBonus || 0;
+      const lightning = stats.totalLightningDamageBonus || 0;
       const elemFromCrit = (stats.elementFromCritChance || 0) / 100;
       const arcMine = (stats.arcaneMineBonus || 0) / 100;
       const fireMine = (stats.fireMineBonus || 0) / 100;
@@ -2405,9 +2531,9 @@ export const DERIVED_STATS = {
     description: 'Elemental damage multiplier (Fire/Arcane/Lightning + elemental monograms, additive)',
     breakdown: (stats) => [
       { label: 'base', fullName: 'Base multiplier', op: '=', value: 1, fmt: 'pct' },
-      term(stats, 'fireDamageBonus', '+', 'pct'),
-      term(stats, 'arcaneDamageBonus', '+', 'pct'),
-      term(stats, 'lightningDamageBonus', '+', 'pct'),
+      term(stats, 'totalFireDamageBonus', '+', 'pct'),
+      term(stats, 'totalArcaneDamageBonus', '+', 'pct'),
+      term(stats, 'totalLightningDamageBonus', '+', 'pct'),
       { label: 'elementFromCritChance', fullName: DERIVED_STATS.elementFromCritChance.name, op: '+', value: (stats.elementFromCritChance || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'arcaneMineBonus', fullName: DERIVED_STATS.arcaneMineBonus.name, op: '+', value: (stats.arcaneMineBonus || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'fireMineBonus', fullName: DERIVED_STATS.fireMineBonus.name, op: '+', value: (stats.fireMineBonus || 0) / 100, fmt: 'pct', isMonogram: true },
@@ -2453,7 +2579,7 @@ export const DERIVED_STATS = {
       } else {
         for (const id of Object.values(STANCE_CRIT_IDS)) if ((stats[id] || 0) > stanceCrit) stanceCrit = stats[id];
       }
-      const critDmg = stats.critDamage || 0;
+      const critDmg = stats.totalCritDamage || 0;
       const factor = config.offhandCritFactor ?? 1;
       return 1 + factor * (critDmg + stanceCrit);
     },
@@ -2472,7 +2598,7 @@ export const DERIVED_STATS = {
       const factor = config.offhandCritFactor ?? 1;
       return [
         { label: 'base', fullName: 'Base multiplier', op: '=', value: 1, fmt: 'pct' },
-        term(stats, 'critDamage', '+', 'pct'),
+        term(stats, 'totalCritDamage', '+', 'pct'),
         scId ? term(stats, scId, '+', 'pct', { fullName: `Stance Crit Damage (${config.stance || 'highest'})` })
              : { label: 'stanceCritDamage', fullName: 'Stance Crit Damage', op: '+', value: 0, fmt: 'pct' },
         { label: 'offhandCritFactor', fullName: 'Offhand crit weighting (TODO: 10% of crit chance)', op: '×', value: factor, fmt: 'pct' },
@@ -2512,7 +2638,7 @@ export const DERIVED_STATS = {
     layer: LAYERS.EDPS,
     dependencies: ['phasingBossDamageBonus'],
     calculate: (stats) => {
-      const bossBonus = stats.bossBonus || 0;
+      const bossBonus = stats.totalBossBonus || 0;
       const phasingBoss = (stats.phasingBossDamageBonus || 0) / 100;
       return 1 + bossBonus + phasingBoss;
     },
@@ -2520,7 +2646,7 @@ export const DERIVED_STATS = {
     description: 'Boss/Elite damage multiplier',
     breakdown: (stats) => [
       { label: 'base', fullName: 'Base multiplier', op: '=', value: 1, fmt: 'pct' },
-      term(stats, 'bossBonus', '+', 'pct'),
+      term(stats, 'totalBossBonus', '+', 'pct'),
       { label: 'phasingBossDamageBonus', fullName: DERIVED_STATS.phasingBossDamageBonus.name, op: '+', value: (stats.phasingBossDamageBonus || 0) / 100, fmt: 'pct', isMonogram: true },
       { label: 'BD', fullName: 'Boss Damage', op: '=', value: stats.edpsBD, fmt: 'pct', isSubtotal: true },
     ],

--- a/test/attributeBonuses.test.js
+++ b/test/attributeBonuses.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import fixtureData from './fixtures/dr-full-inventory.json';
+import { ATTRIBUTE_BONUSES, getAttributeBonusEffect } from '../src/utils/attributeBonuses.js';
+import { calculateDerivedStats } from '../src/utils/derivedStats.js';
+import { parseAllocatedAttributes } from '../src/utils/stanceSkills.js';
+
+describe('primary attribute bonuses', () => {
+  it('resolves all DT_Attributes characteristic dependencies', () => {
+    expect(Object.keys(ATTRIBUTE_BONUSES)).toEqual([
+      'strength', 'dexterity', 'wisdom', 'endurance', 'agility', 'luck', 'stamina',
+    ]);
+
+    expect(getAttributeBonusEffect('strength', 'armorBonus').valuePerPoint).toBe(0.001);
+    expect(getAttributeBonusEffect('dexterity', 'attackSpeed').valuePerPoint).toBe(0.01);
+    expect(getAttributeBonusEffect('wisdom', 'bossBonus').valuePerPoint).toBe(0.0005);
+    expect(getAttributeBonusEffect('endurance', 'energyRegen').valuePerPoint).toBe(0.01);
+    expect(getAttributeBonusEffect('agility', 'critDamage').valuePerPoint).toBe(0.0005);
+    expect(getAttributeBonusEffect('luck', 'xpBonus').valuePerPoint).toBe(0.001);
+    expect(getAttributeBonusEffect('luck', 'arcaneDamageBonus').valuePerPoint).toBe(0.001);
+    expect(getAttributeBonusEffect('luck', 'fireDamageBonus').valuePerPoint).toBe(0.001);
+    expect(getAttributeBonusEffect('luck', 'lightningDamageBonus').valuePerPoint).toBe(0.001);
+    expect(getAttributeBonusEffect('stamina', 'healthBonus').valuePerPoint).toBe(0.0001);
+    expect(getAttributeBonusEffect('stamina', 'healthRegen').valuePerPoint).toBe(0.01);
+  });
+
+  it('feeds every primary attribute into its real target stat', () => {
+    const result = calculateDerivedStats({
+      strength: 100,
+      dexterity: 100,
+      wisdom: 100,
+      endurance: 100,
+      agility: 100,
+      luck: 100,
+      stamina: 100,
+      armor: 100,
+      health: 1000,
+    });
+
+    expect(result.totalArmor).toBe(110);                 // +10% from Strength
+    expect(result.effectiveAttackSpeed).toBeCloseTo(0.5); // +100 AS, then 50% effectiveness
+    expect(result.totalBossBonus).toBeCloseTo(0.05);     // +5% from Wisdom
+    expect(result.edpsBD).toBeCloseTo(1.05);
+    expect(result.totalEnergyRegen).toBeCloseTo(1);      // +1.0/s from Endurance
+    expect(result.totalCritDamage).toBeCloseTo(0.05);    // +5% from Agility
+    expect(result.edpsPhysAdditive).toBeCloseTo(0.05);
+    expect(result.totalXpBonus).toBeCloseTo(0.1);        // +10% from Luck
+    expect(result.totalArcaneDamageBonus).toBeCloseTo(0.1);
+    expect(result.totalFireDamageBonus).toBeCloseTo(0.1);
+    expect(result.totalLightningDamageBonus).toBeCloseTo(0.1);
+    expect(result.edpsED).toBeCloseTo(1.3);
+    expect(result.totalHealth).toBeCloseTo(1010);        // +1% from Stamina
+    expect(result.totalHealthRegen).toBeCloseTo(1);      // +1.0/s from Stamina
+  });
+
+  it('applies the fixture Luck allocation to XP and all three elements', () => {
+    const luck = parseAllocatedAttributes(fixtureData).luck.value;
+    expect(luck).toBe(741);
+
+    const result = calculateDerivedStats({ luck });
+    expect(result.luckXpBonus).toBeCloseTo(0.741);
+    expect(result.luckArcaneDamageBonus).toBeCloseTo(0.741);
+    expect(result.luckFireDamageBonus).toBeCloseTo(0.741);
+    expect(result.luckLightningDamageBonus).toBeCloseTo(0.741);
+    expect(result.edpsED).toBeCloseTo(3.223);
+  });
+});
+


### PR DESCRIPTION
## What changed

- Generate a compact primary-attribute dependency map from the committed `DT_Attributes.json` export.
- Apply every main stat's real dependency to the matching displayed/derived stat and eDPS bucket.
- Show the authoritative game description on each row in the Attributes section and label attribute-derived tooltip sources as `Stat`.
- Add fixture-backed coverage for Luck's XP + Fire/Arcane/Lightning contributions and unit coverage for all seven attributes.

## Confirmed mappings

| Attribute | Dependency |
|---|---|
| Strength | 10 = +1% Armor |
| Dexterity | 1 = +1 Attack Speed |
| Wisdom | 10 = +0.5% Boss Damage |
| Endurance | 10 = +0.1 Energy Regen |
| Agility | 10 = +0.5% Critical Damage |
| Luck | 10 = +1% XP and +1% each Fire/Arcane/Lightning |
| Stamina | 10 = +0.1% Max Health and +0.1 Health Regen |

## Why

The app already computed total primary attributes, but it did not apply the dependency effects defined by the game's master attribute table. That understated the Luck/Wisdom eDPS buckets and omitted the remaining characteristic bonuses from displayed totals.

## Validation

- `npm test -- --run` — 313 tests pass
- `npm run build` — production build succeeds
- `node extraction/generate-registries.mjs` — 7 primary attributes generated; zero rollable-affix drift