### PR TITLE
Make Character stat sections collapsible

### DIFF
--- a/src/components/character/StatsPanel.jsx
+++ b/src/components/character/StatsPanel.jsx
@@ -26,10 +26,18 @@ const categoryOrder = ['vitals', 'edps', 'attributes', 'offense', 'stance', 'ele
  */
 export function StatsPanel({ characterData }) {
   const [hideZero, setHideZero] = useState(false);
+  const [collapsedCategories, setCollapsedCategories] = useState({});
   const { categories } = useDerivedStats(characterData);
 
   const toggleHideZero = useCallback(() => {
     setHideZero(prev => !prev);
+  }, []);
+
+  const toggleCategory = useCallback((categoryKey) => {
+    setCollapsedCategories(prev => ({
+      ...prev,
+      [categoryKey]: !prev[categoryKey],
+    }));
   }, []);
 
   if (!characterData) {
@@ -67,16 +75,29 @@ export function StatsPanel({ characterData }) {
             if (stats.length === 0) return null;
           }
 
+          const isCollapsed = Boolean(collapsedCategories[categoryKey]);
+          const contentId = `stats-category-${categoryKey}`;
+
           return (
-            <div key={categoryKey} className="stats-category">
-              <div className="category-header">
-                {categoryLabels[categoryKey] || categoryKey}
-              </div>
-              <div className="category-stats">
-                {stats.map(stat => (
-                  <StatLine key={stat.id} stat={stat} />
-                ))}
-              </div>
+            <div key={categoryKey} className={`stats-category${isCollapsed ? ' is-collapsed' : ''}`}>
+              <button
+                type="button"
+                className="category-header category-toggle"
+                aria-expanded={!isCollapsed}
+                aria-controls={contentId}
+                onClick={() => toggleCategory(categoryKey)}
+              >
+                <span>{categoryLabels[categoryKey] || categoryKey}</span>
+                <span className="category-count">{stats.length}</span>
+                <span className="category-chevron" aria-hidden="true">▾</span>
+              </button>
+              {!isCollapsed && (
+                <div id={contentId} className="category-stats">
+                  {stats.map(stat => (
+                    <StatLine key={stat.id} stat={stat} />
+                  ))}
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1322,15 +1322,61 @@ h1::before {
   margin-bottom: 0.5rem;
 }
 
+.stats-category.is-collapsed {
+  margin-bottom: 0;
+}
+
 .category-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: 0;
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.75rem;
+  font-family: inherit;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--accent);
   font-weight: 600;
+  text-align: left;
   margin-bottom: 0.5rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 1px solid var(--border-color);
+  padding: 0 0 0.25rem;
+}
+
+.category-toggle {
+  cursor: pointer;
+}
+
+.category-toggle:hover {
+  color: var(--text-primary);
+}
+
+.category-toggle:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.category-count {
+  color: var(--text-secondary);
+  font-size: 0.65rem;
+  font-weight: 500;
+}
+
+.category-chevron {
+  margin-left: auto;
+  color: var(--text-secondary);
+  transition: transform 0.15s ease;
+}
+
+.stats-category.is-collapsed .category-header {
+  margin-bottom: 0;
+}
+
+.stats-category.is-collapsed .category-chevron {
+  transform: rotate(-90deg);
 }
 
 .category-stats {


### PR DESCRIPTION
## What changed

- Make every Character Stats category independently collapsible.
- Keep all categories expanded by default while formula work is still underway.
- Show the current visible-stat count in each category header; counts respect `Hide zero`.
- Add keyboard-accessible button semantics, focus styling, and an expansion chevron.

This keeps the full elemental/eDPS diagnostics available without forcing every category to occupy vertical space. No calculation, category ordering, or tooltip formula behavior changes.

## Validation

- `npm test -- --run` — 313 tests pass
- `npm run build` — production build succeeds