### PR TITLE
Implement pet elemental conversion routing for ED multiplier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,19 @@ Key structural points (vs the pre-split single-line model):
   (config `multiplier` on each result stat).
 - **"Both damage types"** monogram bonuses feed `edpsBothTypesDamageBonus`, which
   is added into BOTH additive buckets.
-- **Fire/Arcane/Lightning%** stay elemental-only (`edpsED`).
+- **Fire/Arcane/Lightning%** stay elemental-only (`edpsED`) and are now
+  **element-routed**: abilities only benefit from their own element's bonus, so
+  only ONE element counts — plus any element merged in by a pet (dragon)
+  conversion ability. The six `GlobalModifiers.{Fire|Arcane|Lightning}.To{…}`
+  flags on the equipped pet mean "<To> abilities also benefit from <From> damage
+  bonus" (additive merge → two elements added together). They're registered as
+  flag stats (`fireToArcane` … `lightningToArcane`, appended to `statRegistry`,
+  so they travel in character shares like any other pet stat). Routing lives in
+  `resolveElementRouting()` (`derivedStats.js`, exported): active element =
+  `edpsED.config.activeElement` override, else auto-picked as the highest
+  effective bonus with conversion sources counted in. Element-typed mine buffs
+  (`fire/arcane/lightningMineBonus`) route with their element. No pet or no
+  conversion just means a single-element ED.
 - **OffhandMods** (`edpsOffhandMods`, skill-specific extra multipliers) defaults to 1.
 - **OffhandItemBonus** = total offhand/ability damage% from items (auto from
   `damageMultiplier` aggregate + manual `offhandItemBonus` config).
@@ -265,7 +277,7 @@ Key structural points (vs the pre-split single-line model):
 | Phys bucket | `edpsPhysAdditive` | StanceCrit + Crit + PhysDmg% + StanceDmg + bloodlust/armor crit + phys monograms + both-types |
 | Elem bucket | `edpsElemAdditive` | item offhand% + affinity + both-types (skill mult added per skill) |
 | both-types% | `edpsBothTypesDamageBonus` | phasing + shroud + highestStat + phasingDuration + essence-drain(2%/10) |
-| ED | `edpsED` | fire + arcane + lightning + elemFromCrit + mines + new elemental monograms |
+| ED | `edpsED` | active element (+ pet-conversion source element) + elemFromCrit + routed mines + elemental monograms |
 | ElemCrit | `edpsElemCrit` | 1 + regular crit dmg + stance crit dmg (provisional elemental crit bucket) |
 | BD | `edpsBD` | bossBonus (gear) + phasing boss dmg |
 | EMulti | `edpsEMulti` | classWeapon × distance procs × shroud flat% (physical line) |
@@ -295,7 +307,8 @@ fold into eDPS yet.
 
 **Configurable via overrides:** result-stat `multiplier` (skill %), `edpsElemAdditive`
 (offhandItemBonus + affinity), `edpsEMulti` (classWeaponBonus), `edpsOffhandMods` (multiplier),
-`edpsElemCrit` (offhandCritFactor), `edpsPhysFlat`/`edpsPhysAdditive` (elem→phys conversion ratios).
+`edpsElemCrit` (offhandCritFactor), `edpsPhysFlat`/`edpsPhysAdditive` (elem→phys conversion ratios),
+`edpsED` (activeElement — force the routed element instead of the auto pick).
 
 **Stance detection:** `inferWeaponStance(rowName)` in `equipmentParser.js` maps weapon keywords to stance prefixes. `useDerivedStats` auto-detects stance from the equipped weapon's row name and passes it to eDPS calcs via config override. Falls back to highest-stat heuristic if no weapon detected.
 

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -685,10 +685,12 @@ export function useDerivedStats(options = {}) {
 
 /**
  * Resolve a raw tag or stat name to a statId
+ * Exported for tests — this is the aggregation path every equipped item stat
+ * (including pet conversion flags) goes through on save load.
  * @param {string} rawTag - Raw attribute tag or stat name
  * @returns {string|null} Normalized stat ID
  */
-function resolveStatId(rawTag) {
+export function resolveStatId(rawTag) {
   if (!rawTag) return null;
 
   // Try direct lookup first

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -39,6 +39,70 @@ export const LAYERS = {
 
 const MONOGRAM_CATEGORIES = new Set(['monogram-buff', 'monogram-chain', 'monogram', 'chained']);
 
+// ============================================================================
+// ELEMENT ROUTING (pet conversion abilities)
+// ============================================================================
+
+/**
+ * The six pet (dragon) elemental conversion abilities. Each is a flag stat
+ * (see statRegistry) meaning "<to> abilities also benefit from <from> damage
+ * bonus" — an additive merge of two element buckets, not a replacement.
+ */
+export const ELEMENT_CONVERSIONS = [
+  { statId: 'fireToArcane', from: 'fire', to: 'arcane' },
+  { statId: 'fireToLightning', from: 'fire', to: 'lightning' },
+  { statId: 'arcaneToFire', from: 'arcane', to: 'fire' },
+  { statId: 'arcaneToLightning', from: 'arcane', to: 'lightning' },
+  { statId: 'lightningToFire', from: 'lightning', to: 'fire' },
+  { statId: 'lightningToArcane', from: 'lightning', to: 'arcane' },
+];
+
+const ELEMENT_IDS = ['fire', 'arcane', 'lightning'];
+export const ELEMENT_LABELS = { fire: 'Fire', arcane: 'Arcane', lightning: 'Lightning' };
+
+/**
+ * Decide which element bonuses count toward the elemental damage multiplier.
+ *
+ * Abilities only benefit from their own element's damage bonus, plus any
+ * source element a pet conversion redirects into it. So exactly one element is
+ * "active" (the one the build's abilities deal), and the included set is that
+ * element plus every conversion source targeting it.
+ *
+ * Active element resolution: config.activeElement (manual override) wins;
+ * otherwise auto-pick the element with the highest effective bonus
+ * (own total + conversion sources), which assumes the player attacks with the
+ * element they invested in.
+ *
+ * @param {Object} stats - Calculated stats (needs total*DamageBonus, *MineBonus, conversion flags)
+ * @param {{activeElement?: string|null}} [config]
+ * @returns {{active: string, included: Set<string>, conversions: Array, totals: Object}}
+ */
+export function resolveElementRouting(stats, config = {}) {
+  // Per-element bonus totals (decimal). Mine buffs are element-typed too, so
+  // they route with their element (stored in percent-points, hence /100).
+  const totals = {
+    fire: (stats.totalFireDamageBonus || 0) + (stats.fireMineBonus || 0) / 100,
+    arcane: (stats.totalArcaneDamageBonus || 0) + (stats.arcaneMineBonus || 0) / 100,
+    lightning: (stats.totalLightningDamageBonus || 0) + (stats.lightningMineBonus || 0) / 100,
+  };
+
+  const conversions = ELEMENT_CONVERSIONS.filter(c => (stats[c.statId] || 0) > 0);
+  const score = el => totals[el]
+    + conversions.filter(c => c.to === el).reduce((sum, c) => sum + totals[c.from], 0);
+
+  let active = ELEMENT_IDS.includes(config?.activeElement) ? config.activeElement : null;
+  if (!active) {
+    active = ELEMENT_IDS.reduce((best, el) => (score(el) > score(best) ? el : best), ELEMENT_IDS[0]);
+  }
+
+  const included = new Set([active]);
+  for (const c of conversions) {
+    if (c.to === active) included.add(c.from);
+  }
+
+  return { active, included, conversions, totals };
+}
+
 /**
  * Build a breakdown term for a derived stat's formula tooltip.
  * Looks up the stat's display name and auto-tags monogram-sourced terms so the
@@ -2495,7 +2559,15 @@ export const DERIVED_STATS = {
   },
 
   /**
-   * edpsED — elemental damage multiplier (Fire/Arcane/Lightning + elemental monograms).
+   * edpsED — elemental damage multiplier (element-routed Fire/Arcane/Lightning
+   * + element-agnostic elemental monograms).
+   *
+   * Abilities only benefit from their own element's damage bonus, so a single
+   * "active" element counts — plus any element a pet (dragon) conversion
+   * ability merges into it ("<To> abilities also benefit from <From> damage
+   * bonus", additive). Without a conversion exactly one element counts; with
+   * one, two elements add together. See resolveElementRouting.
+   *
    * Strictly elemental-type %; applied as (1 + ED) on the elemental line only.
    */
   edpsED: {
@@ -2506,16 +2578,19 @@ export const DERIVED_STATS = {
     dependencies: ['elementFromCritChance', 'arcaneMineBonus', 'fireMineBonus', 'lightningMineBonus',
       'elementalFromEssence', 'elementalFromHighest', 'damagePercentForStat2',
       'berserkerElementalFromHighest',
-      'shroudElementalBonus', 'shroudElementalFromHighest', 'phasingElementalBonus'],
-    calculate: (stats) => {
-      const fire = stats.totalFireDamageBonus || 0;
-      const arcane = stats.totalArcaneDamageBonus || 0;
-      const lightning = stats.totalLightningDamageBonus || 0;
+      'shroudElementalBonus', 'shroudElementalFromHighest', 'phasingElementalBonus',
+      // Pet conversion flags (base stats from the dragon-slot item)
+      'fireToArcane', 'fireToLightning', 'arcaneToFire', 'arcaneToLightning',
+      'lightningToFire', 'lightningToArcane'],
+    // activeElement: 'fire' | 'arcane' | 'lightning' | null (null = auto:
+    // highest effective element bonus, conversion sources counted in)
+    config: { activeElement: null },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.edpsED.config;
+      const { included, totals } = resolveElementRouting(stats, config);
+      const elemental = [...included].reduce((sum, el) => sum + totals[el], 0);
       const elemFromCrit = (stats.elementFromCritChance || 0) / 100;
-      const arcMine = (stats.arcaneMineBonus || 0) / 100;
-      const fireMine = (stats.fireMineBonus || 0) / 100;
-      const ltngMine = (stats.lightningMineBonus || 0) / 100;
-      // New elemental-split monogram sources
+      // Element-agnostic elemental monogram sources
       const essenceElem = (stats.elementalFromEssence || 0) / 100;
       const highestElem = (stats.elementalFromHighest || 0) / 100;
       const perStat2Elem = (stats.damagePercentForStat2 || 0) / 100; // 1%/40, elemental
@@ -2524,30 +2599,68 @@ export const DERIVED_STATS = {
       const shroudElemHi = (stats.shroudElementalFromHighest || 0) / 100;
       const phasingElem = (stats.phasingElementalBonus || 0) / 100;
       const noPotionElem = (stats.damageNoPotionBonus || 0) / 100; // now elemental (15%/slot)
-      return 1 + fire + arcane + lightning + elemFromCrit + arcMine + fireMine + ltngMine
+      return 1 + elemental + elemFromCrit
         + essenceElem + highestElem + perStat2Elem + berserkerElem + shroudElem + shroudElemHi + phasingElem + noPotionElem;
     },
     format: v => `${(v * 100).toFixed(0)}%`,
-    description: 'Elemental damage multiplier (Fire/Arcane/Lightning + elemental monograms, additive)',
-    breakdown: (stats) => [
-      { label: 'base', fullName: 'Base multiplier', op: '=', value: 1, fmt: 'pct' },
-      term(stats, 'totalFireDamageBonus', '+', 'pct'),
-      term(stats, 'totalArcaneDamageBonus', '+', 'pct'),
-      term(stats, 'totalLightningDamageBonus', '+', 'pct'),
-      { label: 'elementFromCritChance', fullName: DERIVED_STATS.elementFromCritChance.name, op: '+', value: (stats.elementFromCritChance || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'arcaneMineBonus', fullName: DERIVED_STATS.arcaneMineBonus.name, op: '+', value: (stats.arcaneMineBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'fireMineBonus', fullName: DERIVED_STATS.fireMineBonus.name, op: '+', value: (stats.fireMineBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'lightningMineBonus', fullName: DERIVED_STATS.lightningMineBonus.name, op: '+', value: (stats.lightningMineBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'elementalFromEssence', fullName: DERIVED_STATS.elementalFromEssence.name, op: '+', value: (stats.elementalFromEssence || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'elementalFromHighest', fullName: DERIVED_STATS.elementalFromHighest.name, op: '+', value: (stats.elementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'damagePercentForStat2', fullName: DERIVED_STATS.damagePercentForStat2.name, op: '+', value: (stats.damagePercentForStat2 || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'berserkerElementalFromHighest', fullName: DERIVED_STATS.berserkerElementalFromHighest.name, op: '+', value: (stats.berserkerElementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'shroudElementalBonus', fullName: DERIVED_STATS.shroudElementalBonus.name, op: '+', value: (stats.shroudElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'shroudElementalFromHighest', fullName: DERIVED_STATS.shroudElementalFromHighest.name, op: '+', value: (stats.shroudElementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'phasingElementalBonus', fullName: DERIVED_STATS.phasingElementalBonus.name, op: '+', value: (stats.phasingElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'damageNoPotionBonus', fullName: DERIVED_STATS.damageNoPotionBonus.name, op: '+', value: (stats.damageNoPotionBonus || 0) / 100, fmt: 'pct', isMonogram: true },
-      { label: 'ED', fullName: 'Elemental Damage', op: '=', value: stats.edpsED, fmt: 'pct', isSubtotal: true },
-    ],
+    description: 'Elemental damage multiplier (active element + pet conversions + elemental monograms, additive)',
+    breakdown: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.edpsED.config;
+      const { active, included, conversions, totals } = resolveElementRouting(stats, config);
+      const activeConversions = conversions.filter(c => c.to === active);
+      const routeNote = activeConversions
+        .map(c => `${ELEMENT_LABELS[c.from]}→${ELEMENT_LABELS[c.to]}`)
+        .join(', ');
+      const routeSource = config?.activeElement
+        ? 'manual override'
+        : 'auto: highest bonus';
+
+      const rows = [
+        { label: 'base', fullName: 'Base multiplier', op: '=', value: 1, fmt: 'pct' },
+        {
+          label: `active: ${ELEMENT_LABELS[active]}`,
+          fullName: routeNote
+            ? `Active element (${routeSource}; pet conversion ${routeNote})`
+            : `Active element (${routeSource}; no pet conversion)`,
+          op: '·', value: null,
+        },
+      ];
+
+      const ELEMENT_ROWS = [
+        { el: 'fire', totalId: 'totalFireDamageBonus', mineId: 'fireMineBonus' },
+        { el: 'arcane', totalId: 'totalArcaneDamageBonus', mineId: 'arcaneMineBonus' },
+        { el: 'lightning', totalId: 'totalLightningDamageBonus', mineId: 'lightningMineBonus' },
+      ];
+      for (const { el, totalId, mineId } of ELEMENT_ROWS) {
+        const mineValue = (stats[mineId] || 0) / 100;
+        if (included.has(el)) {
+          rows.push(term(stats, totalId, '+', 'pct'));
+          if (mineValue) {
+            rows.push({ label: mineId, fullName: DERIVED_STATS[mineId].name, op: '+', value: mineValue, fmt: 'pct', isMonogram: true });
+          }
+        } else if (totals[el]) {
+          rows.push({
+            label: totalId,
+            fullName: `${DERIVED_STATS[totalId].name} — excluded (off-element)`,
+            op: '·', value: totals[el], fmt: 'pct',
+          });
+        }
+      }
+
+      rows.push(
+        { label: 'elementFromCritChance', fullName: DERIVED_STATS.elementFromCritChance.name, op: '+', value: (stats.elementFromCritChance || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'elementalFromEssence', fullName: DERIVED_STATS.elementalFromEssence.name, op: '+', value: (stats.elementalFromEssence || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'elementalFromHighest', fullName: DERIVED_STATS.elementalFromHighest.name, op: '+', value: (stats.elementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'damagePercentForStat2', fullName: DERIVED_STATS.damagePercentForStat2.name, op: '+', value: (stats.damagePercentForStat2 || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'berserkerElementalFromHighest', fullName: DERIVED_STATS.berserkerElementalFromHighest.name, op: '+', value: (stats.berserkerElementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'shroudElementalBonus', fullName: DERIVED_STATS.shroudElementalBonus.name, op: '+', value: (stats.shroudElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'shroudElementalFromHighest', fullName: DERIVED_STATS.shroudElementalFromHighest.name, op: '+', value: (stats.shroudElementalFromHighest || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'phasingElementalBonus', fullName: DERIVED_STATS.phasingElementalBonus.name, op: '+', value: (stats.phasingElementalBonus || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'damageNoPotionBonus', fullName: DERIVED_STATS.damageNoPotionBonus.name, op: '+', value: (stats.damageNoPotionBonus || 0) / 100, fmt: 'pct', isMonogram: true },
+        { label: 'ED', fullName: 'Elemental Damage', op: '=', value: stats.edpsED, fmt: 'pct', isSubtotal: true },
+      );
+      return rows;
+    },
   },
 
   /**

--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -1527,6 +1527,71 @@ export const STAT_REGISTRY = {
     // Anchored so the generic `damage` regex (Damage$) can never claim this.
     regexPatterns: ['ElementalDamage$', '\\.ElementalDamage$'],
   },
+
+  // Pet (dragon) elemental conversion abilities. Flag stats (value 1 when the
+  // equipped pet rolled the ability): "<To> abilities will also benefit from
+  // <From> damage bonus." Consumed by edpsED element routing — they gate which
+  // of the three element bonuses actually count toward elemental damage.
+  fireToArcane: {
+    id: 'fireToArcane',
+    name: 'Fire to Arcane',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Fire.ToArcane', 'Fire.ToArcane'],
+    canonical: 'GlobalModifiers.Fire.ToArcane',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Arcane abilities also benefit from Fire damage bonus (pet conversion)',
+  },
+  fireToLightning: {
+    id: 'fireToLightning',
+    name: 'Fire to Lightning',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Fire.ToLightning', 'Fire.ToLightning'],
+    canonical: 'GlobalModifiers.Fire.ToLightning',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Lightning abilities also benefit from Fire damage bonus (pet conversion)',
+  },
+  arcaneToFire: {
+    id: 'arcaneToFire',
+    name: 'Arcane to Fire',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Arcane.ToFire', 'Arcane.ToFire'],
+    canonical: 'GlobalModifiers.Arcane.ToFire',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Fire abilities also benefit from Arcane damage bonus (pet conversion)',
+  },
+  arcaneToLightning: {
+    id: 'arcaneToLightning',
+    name: 'Arcane to Lightning',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Arcane.ToLightning', 'Arcane.ToLightning'],
+    canonical: 'GlobalModifiers.Arcane.ToLightning',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Lightning abilities also benefit from Arcane damage bonus (pet conversion)',
+  },
+  lightningToFire: {
+    id: 'lightningToFire',
+    name: 'Lightning to Fire',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Lightning.ToFire', 'Lightning.ToFire'],
+    canonical: 'GlobalModifiers.Lightning.ToFire',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Fire abilities also benefit from Lightning damage bonus (pet conversion)',
+  },
+  lightningToArcane: {
+    id: 'lightningToArcane',
+    name: 'Lightning to Arcane',
+    category: 'elemental',
+    patterns: ['GlobalModifiers.Lightning.ToArcane', 'Lightning.ToArcane'],
+    canonical: 'GlobalModifiers.Lightning.ToArcane',
+    isPercent: false,
+    format: v => (v ? 'Active' : '—'),
+    description: 'Arcane abilities also benefit from Lightning damage bonus (pet conversion)',
+  },
 };
 
 // ============================================================================

--- a/test/attributeBonuses.test.js
+++ b/test/attributeBonuses.test.js
@@ -47,7 +47,8 @@ describe('primary attribute bonuses', () => {
     expect(result.totalArcaneDamageBonus).toBeCloseTo(0.1);
     expect(result.totalFireDamageBonus).toBeCloseTo(0.1);
     expect(result.totalLightningDamageBonus).toBeCloseTo(0.1);
-    expect(result.edpsED).toBeCloseTo(1.3);
+    // Element routing: only the single active element reaches ED (no pet conversion)
+    expect(result.edpsED).toBeCloseTo(1.1);
     expect(result.totalHealth).toBeCloseTo(1010);        // +1% from Stamina
     expect(result.totalHealthRegen).toBeCloseTo(1);      // +1.0/s from Stamina
   });
@@ -61,7 +62,8 @@ describe('primary attribute bonuses', () => {
     expect(result.luckArcaneDamageBonus).toBeCloseTo(0.741);
     expect(result.luckFireDamageBonus).toBeCloseTo(0.741);
     expect(result.luckLightningDamageBonus).toBeCloseTo(0.741);
-    expect(result.edpsED).toBeCloseTo(3.223);
+    // Luck feeds all three, but ED only counts the active element
+    expect(result.edpsED).toBeCloseTo(1.741);
   });
 });
 

--- a/test/characterShare.test.js
+++ b/test/characterShare.test.js
@@ -169,6 +169,36 @@ describe('CharacterShareModel — item round-trip', () => {
     expect(restored.displayName).toBe('Tiger Bracers');
   });
 
+  it('round-trips pet conversion abilities via the stat dictionary', () => {
+    const petItem = {
+      ...sampleItem,
+      rowName: 'Equipment_Pet_Fire',
+      displayName: 'Gralagg',
+      slot: 'dragon',
+      baseStats: [
+        { stat: 'ToFire', value: 1, rawTag: 'EasyRPG.Attributes.GlobalModifiers.Arcane.ToFire' },
+      ],
+      monograms: [],
+    };
+    const share = createItemShare(petItem);
+    // Registry hit → integer-encoded (not the ambiguous 'ToFire' string)
+    expect(typeof share.bs[0][0]).toBe('number');
+    expect(decodeIdOrString(STAT_DICT, share.bs[0][0])).toBe('arcaneToFire');
+
+    const restored = itemShareToItem(share, 0);
+    expect(restored.baseStats[0].stat).toBe('arcaneToFire');
+    expect(restored.baseStats[0].value).toBe(1);
+    // Canonical rawTag re-resolves on the receiving side's aggregation path
+    expect(restored.baseStats[0].rawTag).toBe('GlobalModifiers.Arcane.ToFire');
+
+    // And the flag drives ED routing after decode: fire+arcane merge
+    const r = calculateDerivedStats({
+      fireDamageBonus: 0.5, arcaneDamageBonus: 0.3, lightningDamageBonus: 0.6,
+      [restored.baseStats[0].stat]: restored.baseStats[0].value,
+    });
+    expect(r.edpsED).toBeCloseTo(1.8, 2);
+  });
+
   it('preserves unknown stat IDs as strings through round-trip', () => {
     const itemWithFutureStat = {
       ...sampleItem,

--- a/test/derivedStats.test.js
+++ b/test/derivedStats.test.js
@@ -10,6 +10,7 @@ import {
 } from '../src/utils/derivedStats.js';
 import { extractEquippedItems, inferWeaponStance } from '../src/utils/equipmentParser.js';
 import { findStatForAttribute } from '../src/utils/statRegistry.js';
+import { resolveStatId } from '../src/hooks/useDerivedStats.js';
 import fixtureData from './fixtures/dr-full-inventory.json';
 import dualBowFixture from './fixtures/chaos-dual-bow-equipped.json';
 
@@ -339,9 +340,10 @@ describe('derivedStats', () => {
       expect(result.edpsPhysAdditive).toBeCloseTo(1.75, 2);
     });
 
-    it('Fire/Arcane/Lightning% feed only the elemental ED multiplier', () => {
+    it('Fire/Arcane/Lightning% feed only the elemental ED multiplier (single active element)', () => {
       const result = calculateDerivedStats({ fireDamageBonus: 0.5, lightningDamageBonus: 0.3 });
-      expect(result.edpsED).toBeCloseTo(1.80, 2);
+      // No pet conversion → only the active element counts (auto = highest: fire)
+      expect(result.edpsED).toBeCloseTo(1.50, 2);
       // physical additive untouched by elemental %
       expect(result.edpsPhysAdditive).toBeCloseTo(0, 2);
     });
@@ -439,6 +441,93 @@ describe('derivedStats', () => {
     });
   });
 
+  describe('ED element routing (pet conversion abilities)', () => {
+    it('without a conversion, only the highest element bonus counts', () => {
+      const r = calculateDerivedStats({ fireDamageBonus: 0.3, arcaneDamageBonus: 0.9, lightningDamageBonus: 0.5 });
+      expect(r.edpsED).toBeCloseTo(1.9, 2);
+    });
+
+    it('a pet conversion additively merges the source element into the target', () => {
+      // Fire→Lightning pet: lightning abilities also get the fire bonus.
+      const r = calculateDerivedStats({
+        fireDamageBonus: 0.5, lightningDamageBonus: 0.3, fireToLightning: 1,
+      });
+      // score(lightning) = 0.3 + 0.5 = 0.8 beats score(fire) = 0.5 → both count
+      expect(r.edpsED).toBeCloseTo(1.8, 2);
+    });
+
+    it('a conversion into an off-element does not beat a dominant element', () => {
+      // Build stacks arcane; the Fire→Lightning conversion target is weaker.
+      const r = calculateDerivedStats({
+        arcaneDamageBonus: 1.0, fireDamageBonus: 0.1, lightningDamageBonus: 0.1,
+        fireToLightning: 1,
+      });
+      // score(arcane)=1.0 > score(lightning)=0.2 → arcane alone
+      expect(r.edpsED).toBeCloseTo(2.0, 2);
+    });
+
+    it('manual activeElement override wins and still applies matching conversions', () => {
+      const base = {
+        fireDamageBonus: 1.0, arcaneDamageBonus: 0.2, lightningDamageBonus: 0.4,
+        lightningToArcane: 1,
+      };
+      const r = calculateDerivedStats(base, { edpsED: { activeElement: 'arcane' } });
+      // Forced arcane: arcane(0.2) + lightning(0.4 via conversion); fire excluded
+      expect(r.edpsED).toBeCloseTo(1.6, 2);
+    });
+
+    it('element-typed mine buffs route with their element', () => {
+      const r = calculateDerivedStats(
+        { lightningDamageBonus: 2.0, fireDamageBonus: 0.1 },
+        { fireMineBonus: { enabled: true, bonusPerStack: 5, maxStacks: 20, currentStacks: 20 } }
+      );
+      // Fire mines (+100% fire) lose to lightning 200% → excluded from ED
+      expect(r.fireMineBonus).toBe(100);
+      expect(r.edpsED).toBeCloseTo(3.0, 2);
+
+      const withConversion = calculateDerivedStats(
+        { lightningDamageBonus: 2.0, fireDamageBonus: 0.1, fireToLightning: 1 },
+        { fireMineBonus: { enabled: true, bonusPerStack: 5, maxStacks: 20, currentStacks: 20 } }
+      );
+      // Fire→Lightning merges fire gear% AND fire mines into the lightning line
+      expect(withConversion.edpsED).toBeCloseTo(4.1, 2);
+    });
+
+    it('luck feeds all three elements but only routed elements reach ED', () => {
+      const r = calculateDerivedStats({ luck: 300, fireDamageBonus: 0.5 });
+      // Each element gets +30% from luck; active = fire (0.5 + 0.3)
+      expect(r.totalArcaneDamageBonus).toBeCloseTo(0.3, 2);
+      expect(r.edpsED).toBeCloseTo(1.8, 2);
+    });
+
+    it('all six conversion tags resolve on both aggregation paths (save load + share)', () => {
+      const TAGS = {
+        'EasyRPG.Attributes.GlobalModifiers.Fire.ToArcane': 'fireToArcane',
+        'EasyRPG.Attributes.GlobalModifiers.Fire.ToLightning': 'fireToLightning',
+        'EasyRPG.Attributes.GlobalModifiers.Arcane.ToFire': 'arcaneToFire',
+        'EasyRPG.Attributes.GlobalModifiers.Arcane.ToLightning': 'arcaneToLightning',
+        'EasyRPG.Attributes.GlobalModifiers.Lightning.ToFire': 'lightningToFire',
+        'EasyRPG.Attributes.GlobalModifiers.Lightning.ToArcane': 'lightningToArcane',
+      };
+      for (const [tag, statId] of Object.entries(TAGS)) {
+        expect(resolveStatId(tag)).toBe(statId);            // useDerivedStats save-load path
+        expect(findStatForAttribute(tag)?.id).toBe(statId); // share-encode path
+      }
+    });
+
+    it('full-inventory save: the lightning pet carries Fire→Lightning and it resolves via the hook path', () => {
+      const items = extractEquippedItems(fixtureData);
+      const pet = items.find(i => (i.rowName || '').includes('Equipment_Pet_'));
+      expect(pet).toBeDefined();
+      expect(pet.rowName).toBe('Equipment_Pet_Lightning');
+
+      const conversion = (pet.baseStats || []).find(s => /\.To(Fire|Arcane|Lightning)$/.test(s.rawTag || ''));
+      expect(conversion).toBeDefined();
+      expect(resolveStatId(conversion.rawTag)).toBe('fireToLightning');
+      expect(conversion.value).toBe(1);
+    });
+  });
+
   describe('ele/phys flat resolution (regex guard + real save)', () => {
     it('resolves Base.ElementalDamage to elementalDamage, NOT the generic damage stat', () => {
       // Guard against the `Damage$` regex on the generic `damage` stat claiming
@@ -471,6 +560,24 @@ describe('derivedStats', () => {
       expect(r.edpsElemFlat).toBe(Math.floor(base.elementalDamage));
       expect(r.edpsPhysPrimary).toBeGreaterThan(0);
       expect(r.edpsElemPrimary).toBeGreaterThan(0);
+    });
+
+    it('dual-bow save: fire pet Arcane→Fire conversion resolves and routes ED to fire+arcane', () => {
+      const base = {};
+      for (const item of dualBowFixture.equipped) {
+        for (const s of item.baseStats || []) {
+          const def = findStatForAttribute(s.rawTag || s.stat || '');
+          if (!def) continue;
+          base[def.id] = (base[def.id] || 0) + (s.value || 0);
+        }
+      }
+      // The Equipment_Pet_Fire dragon carries GlobalModifiers.Arcane.ToFire
+      expect(base.arcaneToFire).toBe(1);
+
+      const r = calculateDerivedStats(base);
+      // Ring grants Fire% 0.1 and Lightning% 0.1, no arcane gear. The
+      // conversion keeps fire competitive; ED counts fire + arcane only.
+      expect(r.edpsED).toBeCloseTo(1 + (r.totalFireDamageBonus + r.totalArcaneDamageBonus), 2);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds support for pet (dragon) elemental conversion abilities that merge damage bonuses between elements. The six conversion flags (`fireToArcane`, `fireToLightning`, etc.) now gate which element bonuses count toward the elemental damage (ED) multiplier, implementing the game mechanic: "<To> abilities also benefit from <From> damage bonus."

## Key Changes

- **New `resolveElementRouting()` function** (`derivedStats.js`): Determines the active element and which element bonuses contribute to ED. Implements auto-selection (highest effective bonus with conversions counted) and manual override via `config.activeElement`.

- **Six new flag stats** (`statRegistry.js`): Registered `fireToArcane`, `fireToLightning`, `arcaneToFire`, `arcaneToLightning`, `lightningToFire`, `lightningToArcane` with patterns matching `GlobalModifiers.{From}.To{To}` tags from equipped pets.

- **Refactored `edpsED` calculation** (`derivedStats.js`): Now uses element routing to include only the active element + any conversion source elements. Element-typed mine buffs (`fire/arcane/lightningMineBonus`) route with their element. Breakdown tooltip updated to show active element selection logic and excluded off-element bonuses.

- **Updated tests** (`derivedStats.test.js`, `attributeBonuses.test.js`, `characterShare.test.js`): Added comprehensive coverage for single-element routing, multi-element conversions, mine bonus routing, manual overrides, and round-trip encoding of pet conversion flags in character shares.

- **Documentation** (`CLAUDE.md`): Clarified element routing behavior, conversion mechanics, and the role of `resolveElementRouting()` in the aggregation pipeline.

## Implementation Details

- **Element routing logic**: Without a conversion, only the highest-scoring element counts. With a conversion, the source element additively merges into the target, potentially making the target the new active element if its combined score is highest.

- **Mine bonus routing**: Element-typed mine bonuses (`fireMineBonus`, etc.) are converted to decimal and added to their element's total before routing decisions, ensuring they participate in active element selection.

- **Config support**: `edpsED` now accepts a `config` object with optional `activeElement` override, allowing manual element selection while still applying matching conversions.

- **Share encoding**: Pet conversion flags travel through character shares via the stat dictionary (integer-encoded), with canonical rawTag re-resolution on the receiving side.

- **Exported utility**: `resolveElementRouting()` is exported for use in UI components and tests, enabling element routing visualization and manual override controls.

https://claude.ai/code/session_01EEjr1D3CP7emMyAc7TiPAq