### PR TITLE
Map offhand ability affinities into eDPS and cooldowns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ uesave-wasm/pkg/         # Pre-built WASM module (do not modify)
 | Skill tree extraction | `src/utils/skillTreeParser.js` |
 | Skill→stat contributions (cards/skills/buffs) | `src/utils/skillEffectAggregator.js` |
 | Skill/card/keystone registry | `src/utils/skillTreeRegistry.js` |
+| Offhand ability/affinity detection | `src/utils/offhandAbilities.js` |
 | Styling/theming | `src/styles/index.css` |
 
 ## Tab Architecture
@@ -275,7 +276,7 @@ Key structural points (vs the pre-split single-line model):
 | BasePhys | `edpsPhysFlat` | raw `damage` + damageFromHealth + statDamageFlat + paragon + flat monograms |
 | BaseElem | `edpsElemFlat` | `elementalDamage` + damageFromHealth + statDamageFlat + paragon + energy→elem + essence→elem |
 | Phys bucket | `edpsPhysAdditive` | StanceCrit + Crit + PhysDmg% + StanceDmg + bloodlust/armor crit + phys monograms + both-types |
-| Elem bucket | `edpsElemAdditive` | item offhand% + affinity + both-types (skill mult added per skill) |
+| Elem bucket | `edpsElemAdditive` | item offhand% + routed affinity damage (auto from equipped abilities) + manual affinity + both-types (skill mult added per skill) |
 | both-types% | `edpsBothTypesDamageBonus` | phasing + shroud + highestStat + phasingDuration + essence-drain(2%/10) |
 | ED | `edpsED` | active element (+ pet-conversion source element) + elemFromCrit + routed mines + elemental monograms |
 | ElemCrit | `edpsElemCrit` | 1 + regular crit dmg + stance crit dmg (provisional elemental crit bucket) |
@@ -306,9 +307,49 @@ fold into eDPS yet.
 - `edpsElemPrimary` / `edpsElemQ` / `edpsElemR` — elemental on-hit (Left/Q/R)
 
 **Configurable via overrides:** result-stat `multiplier` (skill %), `edpsElemAdditive`
-(offhandItemBonus + affinity), `edpsEMulti` (classWeaponBonus), `edpsOffhandMods` (multiplier),
+(offhandItemBonus + affinity + activeAffinities), `edpsEMulti` (classWeaponBonus), `edpsOffhandMods` (multiplier),
 `edpsElemCrit` (offhandCritFactor), `edpsPhysFlat`/`edpsPhysAdditive` (elem→phys conversion ratios),
 `edpsED` (activeElement — force the routed element instead of the auto pick).
+
+### Offhand Affinities (OffhandCategories)
+
+The 12 offhand affinity categories (`EasyRPG.OffhandCategories.*`): Dragon,
+Creature, Sky, Explosion, Projectile, Ground, Orbit, Blade, Charging (displayed
+"Momentum"), Totem, Area, Hazard. Each has a `Damage%Bonus` and a
+`CooldownBonus` stat, registered in `statRegistry` as
+`<cat>AffinityDamage`/`<cat>AffinityCooldown` (category `affinity`, appended
+zone — `OFFHAND_AFFINITY_CATEGORIES` order is share-codec wire format, append
+only). Exact full-tag patterns keep the loose `Damage%` regex from swallowing
+them into physical `damageBonus`.
+
+**Sources of affinity bonuses:**
+- **Main skill tree**: 236 nodes grant affinity damage%/CDR
+  (`src/data/mainTreeAffinity.generated.json`, with node display names like
+  "Dragon Force"). Aggregated by `skillEffectAggregator` alongside health nodes
+  and preserved in v2 character shares (`st.mh` carries health + affinity rows).
+- **Race** (pending): races grant affinity bonuses scaling with character level
+  capped at 200 (`RACE_LEVEL_CAP`). Race enum index is detected from the save
+  (`parseCharacterRace` → `metadata.characterRace`; `E_CharacterRace::NewEnumeratorN`),
+  but the index→name/bonus mapping awaits a race table extraction.
+
+**Which affinities are active** (`src/utils/offhandAbilities.js`): equipped
+offhand items carry `EasyRPG.Attributes.Abilities.<Ability>.*` stats;
+`detectEquippedAbilities()` resolves them against
+`src/data/playerAbilities.generated.json` (from `DT_PlayerAbilities`, all 26
+proc abilities: base affinities, element, base damage multiplier, cooldown
+steps). Some rolled ability modifiers ADD an affinity via the table's
+`AffinityBehaviours` (e.g. ElectricDragons' `Modifier.AdditionalDragons` adds
+Area → Dragon+Orbit+Area). Only offhand items count — weapons can never carry
+an affinity tag. `useDerivedStats` feeds the union of active categories into
+`edpsElemAdditive.config.activeAffinities`, which routes the matching
+`<cat>AffinityDamage` totals into the elemental bucket.
+
+**Cooldown:** affinity CDR is additive with item `cooldownReduction` →
+`offhandCooldownReduction`. Ability base cooldowns step down with equipped
+offhand count (`Initial`/`TwoOffhands`/`ThreeOffhands` per ability; 3+ offhands
+share the last step — no fourth exists). `offhandCooldownSeconds` shows the
+dominant ability's effective cooldown as `stepBase × (1 − CDR)` (provisional
+application model).
 
 **Stance detection:** `inferWeaponStance(rowName)` in `equipmentParser.js` maps weapon keywords to stance prefixes. `useDerivedStats` auto-detects stance from the equipped weapon's row name and passes it to eDPS calcs via config override. Falls back to highest-stat heuristic if no weapon detected.
 
@@ -438,6 +479,7 @@ npm run test:coverage  # With coverage report
 - `test/shareUrl.test.js` - URL sharing encode/decode tests (filter)
 - `test/characterShare.test.js` - Character sharing codec/round-trip tests
 - `test/skillTreeParser.test.js` - Skill tree parsing/registry tests
+- `test/offhandAffinities.test.js` - Offhand ability/affinity detection, tree affinity aggregation, race/level parse
 
 ### Key Testable Modules
 | Module | Pure Functions | Notes |
@@ -450,12 +492,14 @@ npm run test:coverage  # With coverage report
 | `CharacterShareModel.js` | `createItemShare()`, `itemShareToItem()`, `createCharacterSharePayload()` | Character data round-trip |
 | `skillTreeParser.js` | `extractSkillTree()`, `categorizeSkill()` | Skill tree extraction |
 | `skillTreeRegistry.js` | `getWeaponSkillDef()`, `getCraftingSkillDef()`, `getCardDef()` | Skill/card/keystone lookups |
+| `offhandAbilities.js` | `detectEquippedAbilities()`, `getStepCooldown()`, `unionAffinities()` | Offhand ability/affinity detection |
+| `healthParser.js` | `parseCharacterRace()`, `parseCharacterLevel()`, `parseHealthProgression()` | Character identity/progression |
 
 ## Test Fixtures
 
 Located in `test/fixtures/`. Kept lean — fixtures back current-season tests, not a
 lifetime archive. Old unreferenced save dumps were pruned.
-- `dr-full-inventory.json` - Complete parsed save file (~7.8MB) with full character data (parsing/extract/share/stance tests)
+- `dr-full-inventory.json` - Complete parsed save file (~7.8MB) with full character data; Electric Dragons build with all 4 offhands + Dragon/Orbit/Area tree nodes (parsing/extract/share/stance/affinity tests)
 - `dr-character-skills.json` - CharacterSkills array + metadata (381 skills, weapon XP, skill points)
 - `chaos-dual-bow-equipped.json` - Slim extracted equipped items from a dual-bow build; has both `Base.Damage` and `Base.ElementalDamage` flats (ele/phys split regression test)
 
@@ -599,6 +643,8 @@ node extraction/generate-registries.mjs
 | `src/data/cards.generated.json` | 81 crystal cards: per-level `{tag, value}` effects (× card level) | `skillTreeRegistry.js` `getCardDef()` merge |
 | `src/data/weaponSkills.generated.json` | 112 weapon skills: per-level effects, game max level, buff join | `skillTreeRegistry.js` `getWeaponSkillDef()` merge |
 | `src/data/statusEffects.generated.json` | 170 buffs/debuffs: name, description, duration, stacks, effect values | joined into weapon skills; standalone lookup TBD |
+| `src/data/mainTreeAffinity.generated.json` | 236 main-tree affinity nodes: OffhandCategories effects + node names | `skillEffectAggregator.js` main-tree pass |
+| `src/data/playerAbilities.generated.json` | 26 offhand proc abilities: affinities, element, cooldown steps, AffinityBehaviours | `offhandAbilities.js` detection |
 
 The generator also emits a drift report (`extraction/out/drift-report.md`,
 gitignored) flagging rollable affix tags `findStatForAttribute()` cannot
@@ -613,6 +659,8 @@ Key source tables in `extraction/data/`:
 - `DT_Crystal_Cards_Skills.json` — card effects (registry integration TBD)
 - `DT_Skills_*.json` (8 weapons), `DT_Stance_Levels.json` — weapon skill trees
 - `DT_StatusEffects.json` — buff/status lexicon
+- `DT_GENERATED_SkillTree_Main.json` — main passive tree (1677 nodes; health + affinity extraction)
+- `DT_PlayerAbilities.json` — offhand proc abilities (affinities, AffinityBehaviours, cooldown steps)
 
 ## Integration TODOs
 
@@ -649,9 +697,21 @@ adjusted to game values.
   Replace with the proper `0.1 × critChance` expected-value weighting once confirmed.
 
 ### Skill Tree / Affinity Data
-- **AFFIN** (affinity damage from skill tree): Currently manual config in `edpsAD`. Need to parse skill tree data from save or provide UI input.
-- Skill tree also provides **racial bonuses** — broad damage/crit damage totals that feed into eDPS buckets.
-- Affinities contribute to AD (offhand ability damage) and potentially to other buckets.
+- **AFFIN — DONE**: main-tree affinity nodes are parsed from the save
+  (`mainTreeAffinity.generated.json`), routed by the equipped offhand abilities'
+  affinities, and fed into `edpsElemAdditive` automatically. Manual `affinity`
+  config remains as an extra/override.
+- **Racial bonuses — pending race table**: race grants affinity bonuses scaling
+  with character level capped at 200 (`RACE_LEVEL_CAP`). The save's race enum
+  index is detected (`metadata.characterRace`), but `E_CharacterRace`
+  enumerator→name and race→affinity-grant data still need extraction from game
+  files (likely the race blueprints under
+  `/Game/EasySurvivalRPG/Blueprints/Characters/Base/Races/`). The generated
+  `Affinity_*` affix rows (base 3, +0.5/level, canRoll=false) look like the
+  scaling definition those grants use.
+- **Cooldown application model — provisional**: `offhandCooldownSeconds` uses
+  `stepBase × (1 − CDR)`; confirm in-game whether CDR applies that way or as
+  `base / (1 + CDR)`, and whether a CDR cap exists.
 
 ### Ability Damage (AD)
 - AD exists on offhand items as skill damage affixes (gear `DamageMultiplier` stats).

--- a/extraction/README.md
+++ b/extraction/README.md
@@ -123,8 +123,16 @@ node extraction/generate-registries.mjs
 ```
 
 `DT_GENERATED_SkillTree_Main.json` is optional. When present, the generator
-emits a compact `mainTreeHealth.generated.json` containing only MaxHealth and
-MaxHealth% effects keyed by the opaque `UI_SkillTreeNode_*` save row names.
+emits compact maps keyed by the opaque `UI_SkillTreeNode_*` save row names:
+`mainTreeHealth.generated.json` (MaxHealth/MaxHealth% effects) and
+`mainTreeAffinity.generated.json` (EasyRPG.OffhandCategories.* affinity
+damage%/cooldown effects, plus node display names).
+
+`DT_PlayerAbilities.json` is optional. When present, the generator emits
+`playerAbilities.generated.json` — the 26 offhand proc abilities with their
+affinity categories, element, base damage multiplier, offhand-count cooldown
+steps, and `AffinityBehaviours` (ability modifiers that add an affinity when
+rolled on an offhand item).
 
 ## Handing data back to a remote Claude session
 

--- a/extraction/generate-registries.mjs
+++ b/extraction/generate-registries.mjs
@@ -15,6 +15,8 @@
  *   DT_StatusEffects.json           — buff/status lexicon (names, durations,
  *                                     stacks, effect values)
  *   DT_GENERATED_SkillTree_Main.json — optional main-tree UI-node effects
+ *   DT_PlayerAbilities.json         — optional offhand ability definitions
+ *                                     (affinities, cooldown steps, modifiers)
  *
  * Outputs (committed, consumed by src/):
  *   src/data/attributeBonuses.generated.json
@@ -25,6 +27,8 @@
  *   src/data/weaponSkills.generated.json
  *   src/data/statusEffects.generated.json
  *   src/data/mainTreeHealth.generated.json (when the optional export exists)
+ *   src/data/mainTreeAffinity.generated.json (when the optional export exists)
+ *   src/data/playerAbilities.generated.json (when the optional export exists)
  *
  * Also prints a drift report comparing affix tags against STAT_REGISTRY
  * patterns (written to extraction/out/drift-report.md, gitignored).
@@ -233,6 +237,103 @@ function generateMainTreeHealth(mainTreeRows) {
 }
 
 // ---------------------------------------------------------------------------
+// Main passive tree offhand-affinity effects (DT_GENERATED_SkillTree_Main)
+//
+// Same opaque UI_SkillTreeNode_* rows as the health map, filtered to
+// EasyRPG.OffhandCategories.* effects (Damage%Bonus / CooldownBonus per
+// affinity). Node display names ("Sky Rush") ship alongside so stat
+// breakdowns can label sources readably.
+// ---------------------------------------------------------------------------
+
+const OFFHAND_CATEGORY_PREFIX = 'EasyRPG.OffhandCategories.';
+
+function generateMainTreeAffinity(mainTreeRows) {
+  const effectsByRow = {};
+  const namesByRow = {};
+
+  for (const [rowName, row] of Object.entries(mainTreeRows)) {
+    const effects = [];
+    for (const level of prop(row, 'SkillLevels') ?? []) {
+      effects.push(...effectList(prop(level, 'BonusAttributes'))
+        .filter(effect => effect.tag.startsWith(OFFHAND_CATEGORY_PREFIX)));
+    }
+    if (effects.length > 0) {
+      effectsByRow[rowName] = effects;
+      const name = textOf(prop(row, 'SkillName'));
+      if (name) namesByRow[rowName] = name;
+    }
+  }
+  return { effectsByRow, namesByRow };
+}
+
+// ---------------------------------------------------------------------------
+// Offhand abilities (DT_PlayerAbilities)
+//
+// One row per proc ability (Electric Dragons, Vortex, …). Each carries:
+// - Affinities: base OffhandCategories the ability benefits from
+// - AffinityBehaviours: item-rollable ability modifiers that ADD an affinity
+//   (e.g. ElectricDragons.Modifier.AdditionalDragons adds Area). Only offhand
+//   items can roll these — weapons can never contribute an affinity tag.
+// - CooldownSettings: cooldown step function by number of equipped offhands
+//   (Initial = 1, TwoOffhands = 2, ThreeOffhands = 3+; there is no 4th step)
+// ---------------------------------------------------------------------------
+
+const ABILITY_TAG_PREFIX = 'EasyRPG.Attributes.Abilities.';
+
+const DAMAGE_TYPE_ENUM = {
+  'E_DamageType_DR::NewEnumerator1': 'fire',
+  'E_DamageType_DR::NewEnumerator2': 'lightning',
+  'E_DamageType_DR::NewEnumerator3': 'arcane',
+};
+
+function generatePlayerAbilities(abilityRows) {
+  const abilities = {};
+  for (const [rowName, row] of Object.entries(abilityRows)) {
+    const identifier = prop(row, 'IdentifierTag')?.TagName ?? '';
+    // BurningShield's identifier is "…BurningShield.ProcChance" — strip the
+    // stray attribute suffix so keys always name the ability itself.
+    const key = identifier
+      .replace(ABILITY_TAG_PREFIX, '')
+      .replace(/\.ProcChance$/, '');
+    if (!key) continue;
+
+    const affinities = (prop(row, 'Affinities') ?? [])
+      .map(entry => entry?.TagName?.replace(OFFHAND_CATEGORY_PREFIX, ''))
+      .filter(Boolean);
+
+    // Modifier tag → affinity category it adds when rolled on an offhand item
+    const affinityBehaviours = {};
+    for (const entry of prop(row, 'AffinityBehaviours') ?? []) {
+      const modifierTag = entry?.Key?.TagName;
+      const category = entry?.Value?.TagName?.replace(OFFHAND_CATEGORY_PREFIX, '');
+      if (modifierTag && category) affinityBehaviours[modifierTag] = category;
+    }
+
+    const cd = prop(row, 'CooldownSettings') ?? {};
+    const cooldown = prop(cd, 'HasCooldown?')
+      ? {
+        initial: prop(cd, 'Initial') ?? 0,
+        twoOffhands: prop(cd, 'TwoOffhandsCooldown') ?? 0,
+        threeOffhands: prop(cd, 'ThreeOffhandsCooldown') ?? 0,
+      }
+      : null;
+
+    const element = prop(row, 'ElementalType');
+    abilities[key] = {
+      rowName,
+      name: textOf(prop(row, 'Title')) ?? key,
+      description: textOf(prop(row, 'Description')) ?? '',
+      element: DAMAGE_TYPE_ENUM[element] ?? element ?? null,
+      baseDamageMultiplier: prop(prop(row, 'DmgModifierAttribute') ?? {}, 'Value') ?? 0,
+      affinities,
+      affinityBehaviours,
+      ...(cooldown ? { cooldown } : {}),
+    };
+  }
+  return abilities;
+}
+
+// ---------------------------------------------------------------------------
 // Weapon stance skills (DT_Skills_* — STR_SkillInstance rows)
 //
 // Same row struct as cards: one SkillLevels entry whose BonusAttributes apply
@@ -359,10 +460,19 @@ const poolRows = loadTable('DT_Yellow_Orange_Modifiers.json');
 const cardRows = loadTable('DT_Crystal_Cards_Skills.json');
 const statusRows = loadTable('DT_StatusEffects.json');
 let mainTreeHealth = null;
+let mainTreeAffinity = null;
 try {
-  mainTreeHealth = generateMainTreeHealth(loadTable('DT_GENERATED_SkillTree_Main.json'));
+  const mainTreeRows = loadTable('DT_GENERATED_SkillTree_Main.json');
+  mainTreeHealth = generateMainTreeHealth(mainTreeRows);
+  mainTreeAffinity = generateMainTreeAffinity(mainTreeRows);
 } catch {
   console.warn('  (skipping DT_GENERATED_SkillTree_Main.json — not present)');
+}
+let playerAbilities = null;
+try {
+  playerAbilities = generatePlayerAbilities(loadTable('DT_PlayerAbilities.json'));
+} catch {
+  console.warn('  (skipping DT_PlayerAbilities.json — not present)');
 }
 
 const monograms = generateMonograms(attributeRows);
@@ -394,6 +504,19 @@ if (mainTreeHealth) {
   fs.writeFileSync(path.join(GEN_DIR, 'mainTreeHealth.generated.json'),
     JSON.stringify({ ...banner, _source: 'DT_GENERATED_SkillTree_Main (MaxHealth effects only)', effectsByRow: mainTreeHealth }, null, 2));
 }
+if (mainTreeAffinity) {
+  fs.writeFileSync(path.join(GEN_DIR, 'mainTreeAffinity.generated.json'),
+    JSON.stringify({
+      ...banner,
+      _source: 'DT_GENERATED_SkillTree_Main (EasyRPG.OffhandCategories.* effects only)',
+      effectsByRow: mainTreeAffinity.effectsByRow,
+      namesByRow: mainTreeAffinity.namesByRow,
+    }, null, 2));
+}
+if (playerAbilities) {
+  fs.writeFileSync(path.join(GEN_DIR, 'playerAbilities.generated.json'),
+    JSON.stringify({ ...banner, _source: 'DT_PlayerAbilities', abilities: playerAbilities }, null, 2));
+}
 
 console.log(`Attributes:     ${Object.keys(attributeBonuses).length}`);
 console.log(`Monograms:      ${Object.keys(monograms).length}`);
@@ -403,6 +526,8 @@ console.log(`Cards:          ${Object.keys(cards).length}`);
 console.log(`Weapon skills:  ${Object.keys(weaponSkills).length}`);
 console.log(`Status effects: ${Object.keys(statusEffects).length}`);
 if (mainTreeHealth) console.log(`Main-tree health nodes: ${Object.keys(mainTreeHealth).length}`);
+if (mainTreeAffinity) console.log(`Main-tree affinity nodes: ${Object.keys(mainTreeAffinity.effectsByRow).length}`);
+if (playerAbilities) console.log(`Player abilities: ${Object.keys(playerAbilities).length}`);
 
 const { reportPath, missing } = await driftReport(affixes);
 console.log(`Drift:     ${missing} rollable affixes unmatched by STAT_REGISTRY patterns`);

--- a/src/components/character/StatsPanel.jsx
+++ b/src/components/character/StatsPanel.jsx
@@ -10,6 +10,7 @@ const categoryLabels = {
   defense: 'Defense',
   elemental: 'Elemental',
   edps: 'eDPS',
+  affinity: 'Offhand Affinity',
   monograms: 'Monograms',
   abilities: 'Abilities',
   utility: 'Utility',
@@ -18,7 +19,7 @@ const categoryLabels = {
 
 // Vitals (in-game max health) and eDPS first — the progress-indicator numbers
 // belong above the fold; monograms last.
-const categoryOrder = ['vitals', 'edps', 'attributes', 'offense', 'stance', 'elemental', 'defense', 'monograms', 'abilities', 'utility', 'unmapped'];
+const categoryOrder = ['vitals', 'edps', 'attributes', 'offense', 'stance', 'elemental', 'affinity', 'defense', 'monograms', 'abilities', 'utility', 'unmapped'];
 
 /**
  * @param {Object} props

--- a/src/data/mainTreeAffinity.generated.json
+++ b/src/data/mainTreeAffinity.generated.json
@@ -1,0 +1,1660 @@
+{
+  "_generated": "by extraction/generate-registries.mjs — do not edit by hand",
+  "_source": "DT_GENERATED_SkillTree_Main (EasyRPG.OffhandCategories.* effects only)",
+  "effectsByRow": {
+    "UI_SkillTreeNode_Large_57": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_58": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_60": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_61": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_64": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_67": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_68": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_71": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_32": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_45": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_49": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_79": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_82": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Small_386": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_387": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_416": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_417": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_418": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_419": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_420": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_421": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_422": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_423": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_424": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Large_84": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Small_425": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_426": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_427": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_428": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_429": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_430": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_431": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_432": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_433": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_434": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_435": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_436": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_437": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_438": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Large_86": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_87": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_88": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_89": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_90": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_91": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_92": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_93": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.15
+      }
+    ],
+    "UI_SkillTreeNode_Large_94": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Large_95": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.07
+      }
+    ],
+    "UI_SkillTreeNode_Small_439": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_440": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_441": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_442": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_443": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_444": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_445": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_446": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_447": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_448": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_456": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_459": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_460": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_461": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_462": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_463": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_464": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_465": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_466": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_467": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_468": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_469": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_470": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_471": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_472": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_473": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_474": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_475": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_476": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_477": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_478": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_479": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_480": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_481": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_482": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_483": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_484": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_489": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_494": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_495": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_496": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_497": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_498": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_499": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_500": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_458": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_501": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_502": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_503": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_504": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_505": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_506": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_507": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_508": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_509": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_510": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_511": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_512": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_513": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_514": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_515": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_516": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_517": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_527": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_528": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_529": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_530": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_531": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_532": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_533": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_534": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_535": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_536": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_537": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_538": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_539": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_540": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_541": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_542": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_543": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_544": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_545": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_546": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_547": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_548": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_549": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_550": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_551": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_552": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_553": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_554": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_555": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_556": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_557": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_558": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_559": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_560": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_561": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_562": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_563": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_573": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_574": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_575": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_576": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_577": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_578": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_579": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_580": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_581": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_582": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_583": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_584": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_585": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_586": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_587": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_588": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_589": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_590": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_591": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_592": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_593": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_594": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_595": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_596": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_597": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_598": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_600": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_601": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_602": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_603": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_604": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_605": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_606": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_607": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_616": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_617": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_618": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_619": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_620": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_621": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_622": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_623": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_624": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_625": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_626": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_627": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_628": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_629": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_630": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_631": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_632": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_633": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_634": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_635": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_636": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_637": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_638": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_639": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_640": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_641": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_642": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_643": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_644": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_645": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_646": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_647": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_648": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_649": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_650": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_651": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_652": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_653": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_654": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_655": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_656": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_657": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_658": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_891": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_892": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_893": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_894": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_895": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_896": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_897": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_914": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_915": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_916": [
+      {
+        "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+        "value": 0.01
+      }
+    ]
+  },
+  "namesByRow": {
+    "UI_SkillTreeNode_Large_57": "Sky Rush",
+    "UI_SkillTreeNode_Large_58": "Blade Rush",
+    "UI_SkillTreeNode_Large_60": "Projectile Velocity",
+    "UI_SkillTreeNode_Large_61": "Momentum Potency",
+    "UI_SkillTreeNode_Large_64": "Totem Brawn",
+    "UI_SkillTreeNode_Large_67": "Dragon Speed",
+    "UI_SkillTreeNode_Large_68": "Creature Haste",
+    "UI_SkillTreeNode_Large_71": "Ground Force",
+    "UI_SkillTreeNode_Large_32": "Hazard Force",
+    "UI_SkillTreeNode_Large_45": "Dragon Force",
+    "UI_SkillTreeNode_Large_49": "Orbit Power",
+    "UI_SkillTreeNode_Large_79": "Explosion Pace",
+    "UI_SkillTreeNode_Large_82": "Area Tempo",
+    "UI_SkillTreeNode_Small_386": "Dragon Force",
+    "UI_SkillTreeNode_Small_387": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_416": "Dragon Force",
+    "UI_SkillTreeNode_Small_417": "Dragon Speed",
+    "UI_SkillTreeNode_Small_418": "Dragon Force",
+    "UI_SkillTreeNode_Small_419": "Dragon Force",
+    "UI_SkillTreeNode_Small_420": "Dragon Force",
+    "UI_SkillTreeNode_Small_421": "Dragon Force",
+    "UI_SkillTreeNode_Small_422": "Dragon Force",
+    "UI_SkillTreeNode_Small_423": "Dragon Force",
+    "UI_SkillTreeNode_Small_424": "Dragon Force",
+    "UI_SkillTreeNode_Large_84": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_425": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_426": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_427": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_428": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_429": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_430": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_431": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_432": "Orbit Velocity",
+    "UI_SkillTreeNode_Small_433": "Dragon Speed",
+    "UI_SkillTreeNode_Small_434": "Dragon Speed",
+    "UI_SkillTreeNode_Small_435": "Dragon Speed",
+    "UI_SkillTreeNode_Small_436": "Dragon Speed",
+    "UI_SkillTreeNode_Small_437": "Dragon Speed",
+    "UI_SkillTreeNode_Small_438": "Dragon Speed",
+    "UI_SkillTreeNode_Large_86": "Creature Brawn",
+    "UI_SkillTreeNode_Large_87": "Sky Might",
+    "UI_SkillTreeNode_Large_88": "Ground Speed",
+    "UI_SkillTreeNode_Large_89": "Explosion Potency",
+    "UI_SkillTreeNode_Large_90": "Projectile Power",
+    "UI_SkillTreeNode_Large_91": "Momentum Pace",
+    "UI_SkillTreeNode_Large_92": "Blade Might",
+    "UI_SkillTreeNode_Large_93": "Area Capacity",
+    "UI_SkillTreeNode_Large_94": "Totem Haste",
+    "UI_SkillTreeNode_Large_95": "Hazard Speed",
+    "UI_SkillTreeNode_Small_439": "Orbit Power",
+    "UI_SkillTreeNode_Small_440": "Orbit Power",
+    "UI_SkillTreeNode_Small_441": "Orbit Power",
+    "UI_SkillTreeNode_Small_442": "Orbit Power",
+    "UI_SkillTreeNode_Small_443": "Orbit Power",
+    "UI_SkillTreeNode_Small_444": "Orbit Power",
+    "UI_SkillTreeNode_Small_445": "Orbit Power",
+    "UI_SkillTreeNode_Small_446": "Orbit Power",
+    "UI_SkillTreeNode_Small_447": "Orbit Power",
+    "UI_SkillTreeNode_Small_448": "Dragon Speed",
+    "UI_SkillTreeNode_Small_456": "Creature Haste",
+    "UI_SkillTreeNode_Small_459": "Creature Haste",
+    "UI_SkillTreeNode_Small_460": "Creature Haste",
+    "UI_SkillTreeNode_Small_461": "Creature Haste",
+    "UI_SkillTreeNode_Small_462": "Creature Haste",
+    "UI_SkillTreeNode_Small_463": "Creature Haste",
+    "UI_SkillTreeNode_Small_464": "Creature Haste",
+    "UI_SkillTreeNode_Small_465": "Creature Haste",
+    "UI_SkillTreeNode_Small_466": "Creature Haste",
+    "UI_SkillTreeNode_Small_467": "Creature Brawn",
+    "UI_SkillTreeNode_Small_468": "Creature Brawn",
+    "UI_SkillTreeNode_Small_469": "Creature Brawn",
+    "UI_SkillTreeNode_Small_470": "Creature Brawn",
+    "UI_SkillTreeNode_Small_471": "Creature Brawn",
+    "UI_SkillTreeNode_Small_472": "Creature Brawn",
+    "UI_SkillTreeNode_Small_473": "Creature Brawn",
+    "UI_SkillTreeNode_Small_474": "Creature Brawn",
+    "UI_SkillTreeNode_Small_475": "Creature Brawn",
+    "UI_SkillTreeNode_Small_476": "Sky Might",
+    "UI_SkillTreeNode_Small_477": "Sky Might",
+    "UI_SkillTreeNode_Small_478": "Sky Might",
+    "UI_SkillTreeNode_Small_479": "Sky Might",
+    "UI_SkillTreeNode_Small_480": "Sky Might",
+    "UI_SkillTreeNode_Small_481": "Sky Might",
+    "UI_SkillTreeNode_Small_482": "Sky Might",
+    "UI_SkillTreeNode_Small_483": "Sky Might",
+    "UI_SkillTreeNode_Small_484": "Sky Might",
+    "UI_SkillTreeNode_Small_489": "Sky Rush",
+    "UI_SkillTreeNode_Small_494": "Sky Rush",
+    "UI_SkillTreeNode_Small_495": "Sky Rush",
+    "UI_SkillTreeNode_Small_496": "Sky Rush",
+    "UI_SkillTreeNode_Small_497": "Sky Rush",
+    "UI_SkillTreeNode_Small_498": "Sky Rush",
+    "UI_SkillTreeNode_Small_499": "Sky Rush",
+    "UI_SkillTreeNode_Small_500": "Sky Rush",
+    "UI_SkillTreeNode_Small_458": "Explosion Pace",
+    "UI_SkillTreeNode_Small_501": "Explosion Pace",
+    "UI_SkillTreeNode_Small_502": "Explosion Pace",
+    "UI_SkillTreeNode_Small_503": "Explosion Pace",
+    "UI_SkillTreeNode_Small_504": "Explosion Pace",
+    "UI_SkillTreeNode_Small_505": "Explosion Pace",
+    "UI_SkillTreeNode_Small_506": "Explosion Pace",
+    "UI_SkillTreeNode_Small_507": "Explosion Pace",
+    "UI_SkillTreeNode_Small_508": "Explosion Pace",
+    "UI_SkillTreeNode_Small_509": "Explosion Potency",
+    "UI_SkillTreeNode_Small_510": "Explosion Potency",
+    "UI_SkillTreeNode_Small_511": "Explosion Potency",
+    "UI_SkillTreeNode_Small_512": "Explosion Potency",
+    "UI_SkillTreeNode_Small_513": "Explosion Potency",
+    "UI_SkillTreeNode_Small_514": "Explosion Potency",
+    "UI_SkillTreeNode_Small_515": "Explosion Potency",
+    "UI_SkillTreeNode_Small_516": "Explosion Potency",
+    "UI_SkillTreeNode_Small_517": "Explosion Potency",
+    "UI_SkillTreeNode_Small_527": "Ground Speed",
+    "UI_SkillTreeNode_Small_528": "Ground Speed",
+    "UI_SkillTreeNode_Small_529": "Ground Speed",
+    "UI_SkillTreeNode_Small_530": "Ground Speed",
+    "UI_SkillTreeNode_Small_531": "Ground Speed",
+    "UI_SkillTreeNode_Small_532": "Ground Speed",
+    "UI_SkillTreeNode_Small_533": "Ground Speed",
+    "UI_SkillTreeNode_Small_534": "Ground Speed",
+    "UI_SkillTreeNode_Small_535": "Ground Speed",
+    "UI_SkillTreeNode_Small_536": "Ground Force",
+    "UI_SkillTreeNode_Small_537": "Ground Force",
+    "UI_SkillTreeNode_Small_538": "Ground Force",
+    "UI_SkillTreeNode_Small_539": "Ground Force",
+    "UI_SkillTreeNode_Small_540": "Ground Force",
+    "UI_SkillTreeNode_Small_541": "Ground Force",
+    "UI_SkillTreeNode_Small_542": "Ground Force",
+    "UI_SkillTreeNode_Small_543": "Ground Force",
+    "UI_SkillTreeNode_Small_544": "Ground Force",
+    "UI_SkillTreeNode_Small_545": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_546": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_547": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_548": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_549": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_550": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_551": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_552": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_553": "Projectile Velocity",
+    "UI_SkillTreeNode_Small_554": "Projectile Power",
+    "UI_SkillTreeNode_Small_555": "Projectile Power",
+    "UI_SkillTreeNode_Small_556": "Projectile Power",
+    "UI_SkillTreeNode_Small_557": "Projectile Power",
+    "UI_SkillTreeNode_Small_558": "Projectile Power",
+    "UI_SkillTreeNode_Small_559": "Projectile Power",
+    "UI_SkillTreeNode_Small_560": "Projectile Power",
+    "UI_SkillTreeNode_Small_561": "Projectile Power",
+    "UI_SkillTreeNode_Small_562": "Projectile Power",
+    "UI_SkillTreeNode_Small_563": "Projectile Power",
+    "UI_SkillTreeNode_Small_573": "Momentum Pace",
+    "UI_SkillTreeNode_Small_574": "Momentum Pace",
+    "UI_SkillTreeNode_Small_575": "Momentum Pace",
+    "UI_SkillTreeNode_Small_576": "Momentum Pace",
+    "UI_SkillTreeNode_Small_577": "Momentum Pace",
+    "UI_SkillTreeNode_Small_578": "Momentum Pace",
+    "UI_SkillTreeNode_Small_579": "Momentum Pace",
+    "UI_SkillTreeNode_Small_580": "Momentum Pace",
+    "UI_SkillTreeNode_Small_581": "Momentum Pace",
+    "UI_SkillTreeNode_Small_582": "Momentum Potency",
+    "UI_SkillTreeNode_Small_583": "Momentum Potency",
+    "UI_SkillTreeNode_Small_584": "Momentum Potency",
+    "UI_SkillTreeNode_Small_585": "Momentum Potency",
+    "UI_SkillTreeNode_Small_586": "Momentum Potency",
+    "UI_SkillTreeNode_Small_587": "Momentum Potency",
+    "UI_SkillTreeNode_Small_588": "Momentum Potency",
+    "UI_SkillTreeNode_Small_589": "Momentum Potency",
+    "UI_SkillTreeNode_Small_590": "Momentum Pace",
+    "UI_SkillTreeNode_Small_591": "Blade Rush",
+    "UI_SkillTreeNode_Small_592": "Blade Rush",
+    "UI_SkillTreeNode_Small_593": "Blade Rush",
+    "UI_SkillTreeNode_Small_594": "Blade Rush",
+    "UI_SkillTreeNode_Small_595": "Blade Rush",
+    "UI_SkillTreeNode_Small_596": "Blade Rush",
+    "UI_SkillTreeNode_Small_597": "Blade Rush",
+    "UI_SkillTreeNode_Small_598": "Blade Rush",
+    "UI_SkillTreeNode_Small_600": "Blade Might",
+    "UI_SkillTreeNode_Small_601": "Blade Might",
+    "UI_SkillTreeNode_Small_602": "Blade Might",
+    "UI_SkillTreeNode_Small_603": "Blade Might",
+    "UI_SkillTreeNode_Small_604": "Blade Might",
+    "UI_SkillTreeNode_Small_605": "Blade Might",
+    "UI_SkillTreeNode_Small_606": "Blade Might",
+    "UI_SkillTreeNode_Small_607": "Blade Might",
+    "UI_SkillTreeNode_Small_616": "Area Tempo",
+    "UI_SkillTreeNode_Small_617": "Area Tempo",
+    "UI_SkillTreeNode_Small_618": "Area Tempo",
+    "UI_SkillTreeNode_Small_619": "Area Tempo",
+    "UI_SkillTreeNode_Small_620": "Area Tempo",
+    "UI_SkillTreeNode_Small_621": "Area Tempo",
+    "UI_SkillTreeNode_Small_622": "Area Tempo",
+    "UI_SkillTreeNode_Small_623": "Area Tempo",
+    "UI_SkillTreeNode_Small_624": "Area Capacity",
+    "UI_SkillTreeNode_Small_625": "Area Capacity",
+    "UI_SkillTreeNode_Small_626": "Area Capacity",
+    "UI_SkillTreeNode_Small_627": "Area Capacity",
+    "UI_SkillTreeNode_Small_628": "Area Capacity",
+    "UI_SkillTreeNode_Small_629": "Area Capacity",
+    "UI_SkillTreeNode_Small_630": "Area Capacity",
+    "UI_SkillTreeNode_Small_631": "Area Capacity",
+    "UI_SkillTreeNode_Small_632": "Totem Brawn",
+    "UI_SkillTreeNode_Small_633": "Totem Brawn",
+    "UI_SkillTreeNode_Small_634": "Totem Brawn",
+    "UI_SkillTreeNode_Small_635": "Totem Brawn",
+    "UI_SkillTreeNode_Small_636": "Totem Brawn",
+    "UI_SkillTreeNode_Small_637": "Totem Brawn",
+    "UI_SkillTreeNode_Small_638": "Totem Brawn",
+    "UI_SkillTreeNode_Small_639": "Totem Brawn",
+    "UI_SkillTreeNode_Small_640": "Totem Haste",
+    "UI_SkillTreeNode_Small_641": "Totem Haste",
+    "UI_SkillTreeNode_Small_642": "Totem Haste",
+    "UI_SkillTreeNode_Small_643": "Totem Haste",
+    "UI_SkillTreeNode_Small_644": "Totem Haste",
+    "UI_SkillTreeNode_Small_645": "Totem Haste",
+    "UI_SkillTreeNode_Small_646": "Totem Haste",
+    "UI_SkillTreeNode_Small_647": "Totem Haste",
+    "UI_SkillTreeNode_Small_648": "Totem Haste",
+    "UI_SkillTreeNode_Small_649": "Totem Brawn",
+    "UI_SkillTreeNode_Small_650": "Hazard Force",
+    "UI_SkillTreeNode_Small_651": "Hazard Force",
+    "UI_SkillTreeNode_Small_652": "Hazard Force",
+    "UI_SkillTreeNode_Small_653": "Hazard Force",
+    "UI_SkillTreeNode_Small_654": "Hazard Force",
+    "UI_SkillTreeNode_Small_655": "Hazard Force",
+    "UI_SkillTreeNode_Small_656": "Hazard Force",
+    "UI_SkillTreeNode_Small_657": "Hazard Force",
+    "UI_SkillTreeNode_Small_658": "Hazard Force",
+    "UI_SkillTreeNode_Small_891": "Hazard Speed",
+    "UI_SkillTreeNode_Small_892": "Hazard Speed",
+    "UI_SkillTreeNode_Small_893": "Hazard Speed",
+    "UI_SkillTreeNode_Small_894": "Hazard Speed",
+    "UI_SkillTreeNode_Small_895": "Hazard Speed",
+    "UI_SkillTreeNode_Small_896": "Hazard Speed",
+    "UI_SkillTreeNode_Small_897": "Blade Might",
+    "UI_SkillTreeNode_Small_914": "Hazard Speed",
+    "UI_SkillTreeNode_Small_915": "Hazard Speed",
+    "UI_SkillTreeNode_Small_916": "Hazard Speed"
+  }
+}

--- a/src/data/playerAbilities.generated.json
+++ b/src/data/playerAbilities.generated.json
@@ -1,0 +1,502 @@
+{
+  "_generated": "by extraction/generate-registries.mjs — do not edit by hand",
+  "_source": "DT_PlayerAbilities",
+  "abilities": {
+    "FlameShowerMeteor": {
+      "rowName": "RainOfFlames",
+      "name": "Rain of Flames",
+      "description": "Conjures a barrage of meteors. Celestial projectiles rain down, inflicting area-of-effect damage to adversaries within range.",
+      "element": "fire",
+      "baseDamageMultiplier": 0.58,
+      "affinities": [
+        "Sky",
+        "Explosion"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.FlameShowerMeteor.Modifier.Ticks": "Hazard"
+      },
+      "cooldown": {
+        "initial": 5.4,
+        "twoOffhands": 4.2,
+        "threeOffhands": 3
+      }
+    },
+    "CarnageOfFire": {
+      "rowName": "CarnageOfFire",
+      "name": "Carnage of Fire",
+      "description": "Generates volatile lava droplets. Molten projectiles detonate on impact, dealing area-of-effect damage to enemies within the blast radius.",
+      "element": "fire",
+      "baseDamageMultiplier": 1.12,
+      "affinities": [
+        "Sky",
+        "Explosion"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.CarnageOfFire.Modifier.LavaSpike": "Ground"
+      },
+      "cooldown": {
+        "initial": 10.8,
+        "twoOffhands": 8.4,
+        "threeOffhands": 6
+      }
+    },
+    "DelusionOfZelkors": {
+      "rowName": "DelusionOfZelkors",
+      "name": "Delusion of Zelkors",
+      "description": "Channels the combined energies of two Zelkorian spellcasters. Unleashes a potent area-of-effect explosion, engulfing the targeted zone in magical devastation.",
+      "element": "fire",
+      "baseDamageMultiplier": 2.2,
+      "affinities": [
+        "Creature",
+        "Explosion"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.DelusionOfZelkors.Modifier.FireSpikeTicks": "Ground"
+      },
+      "cooldown": {
+        "initial": 4.2,
+        "twoOffhands": 3.6,
+        "threeOffhands": 3
+      }
+    },
+    "BurningShield": {
+      "rowName": "BurningShield",
+      "name": "Burning Shield",
+      "description": "Conjures a blazing barrier that protects the caster and damages nearby foes. Creates a hazardous zone, deterring close-quarters engagement.",
+      "element": "fire",
+      "baseDamageMultiplier": 1,
+      "affinities": [
+        "Orbit"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.BurningShield.Modifier.BruningDragonsRadius": "Blade",
+        "EasyRPG.Attributes.Abilities.BurningShield.Modifier.StackBuff": "Explosion"
+      },
+      "cooldown": {
+        "initial": 10.13,
+        "twoOffhands": 7.6,
+        "threeOffhands": 6.33
+      }
+    },
+    "FireBeam": {
+      "rowName": "FireBeam",
+      "name": "Fire Beam",
+      "description": "Projects an intense beam of concentrated fire forward. Inflicts damage to enemies in its path, creating a linear zone of destruction.",
+      "element": "fire",
+      "baseDamageMultiplier": 0.8,
+      "affinities": [
+        "Projectile",
+        "Hazard"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.FireBeam.Modifier.ExpandedBeam": "Charging"
+      },
+      "cooldown": {
+        "initial": 6.3,
+        "twoOffhands": 5.2,
+        "threeOffhands": 3.9
+      }
+    },
+    "DragonFlame": {
+      "rowName": "DragonFlame",
+      "name": "Dragon Flame",
+      "description": "Manifests a colossal fire dragon on the battlefield. Unleashes devastating waves of fire, incinerating foes within its vicinity.",
+      "element": "fire",
+      "baseDamageMultiplier": 2,
+      "affinities": [
+        "Dragon",
+        "Creature"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.DragonFlame.Modifier.BonusRadius": "Area"
+      },
+      "cooldown": {
+        "initial": 8.67,
+        "twoOffhands": 6.93,
+        "threeOffhands": 5.2
+      }
+    },
+    "ChainLightning": {
+      "rowName": "ChainLightning",
+      "name": "Chain Lightning",
+      "description": "Unleashes electrical energy that arcs between targets. Creates a chain reaction of lightning, damaging multiple enemies in rapid succession.",
+      "element": "lightning",
+      "baseDamageMultiplier": 2.4,
+      "affinities": [
+        "Charging"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ChainLightning.Modifier.Overload": "Sky",
+        "EasyRPG.Attributes.Abilities.ChainLightning.Modifier.AdditionalJumps": "Area"
+      },
+      "cooldown": {
+        "initial": 5.06,
+        "twoOffhands": 4.06,
+        "threeOffhands": 3.54
+      }
+    },
+    "Spark": {
+      "rowName": "Spark",
+      "name": "Spark",
+      "description": "Generates electric sparks. Sparks leap between nearby adversaries, creating unpredictable patterns of electrical damage.",
+      "element": "lightning",
+      "baseDamageMultiplier": 0.75,
+      "affinities": [
+        "Charging",
+        "Sky"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.Spark.Modifier.PlasmaSphere": "Explosion"
+      },
+      "cooldown": {
+        "initial": 6.4,
+        "twoOffhands": 5.6,
+        "threeOffhands": 4.8
+      }
+    },
+    "Vortex": {
+      "rowName": "Vortex",
+      "name": "Vortex",
+      "description": "Conjures a powerful wind vortex at the target location. Lifts and suspends enemies, dealing continuous damage from intense pressure and turbulent forces.",
+      "element": "lightning",
+      "baseDamageMultiplier": 1.2,
+      "affinities": [
+        "Sky",
+        "Hazard"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.Vortex.Modifier.Tornados": "Area"
+      },
+      "cooldown": {
+        "initial": 4,
+        "twoOffhands": 3.33,
+        "threeOffhands": 2.67
+      }
+    },
+    "EyeOfTheStorm": {
+      "rowName": "EyeOfTheStorm",
+      "name": "Eye of the Storm",
+      "description": "Summons a localized maelstrom around the caster. Unleashes destructive forces on nearby enemies, combining violent winds and lightning.",
+      "element": "lightning",
+      "baseDamageMultiplier": 2.6,
+      "affinities": [
+        "Sky"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.EyeOfTheStorm.Modifier.Radius": "Area",
+        "EasyRPG.Attributes.Abilities.EyeOfTheStorm.Modifier.Cloud": "Hazard"
+      },
+      "cooldown": {
+        "initial": 10.67,
+        "twoOffhands": 8.53,
+        "threeOffhands": 6.4
+      }
+    },
+    "FerocityOfWolves": {
+      "rowName": "FerocityOfWolves",
+      "name": "Ferocity of Wolves",
+      "description": "Manifests spectral wolves charged with electrical energy. Unleashes ethereal canines that materialize near the caster. Wolves lunge at nearby foes, delivering shocking assaults.",
+      "element": "lightning",
+      "baseDamageMultiplier": 0.4,
+      "affinities": [
+        "Creature",
+        "Ground"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.FerocityOfWolves.Modifier.AdditionalWolves": "Charging"
+      },
+      "cooldown": {
+        "initial": 5.58,
+        "twoOffhands": 4.68,
+        "threeOffhands": 4.14
+      }
+    },
+    "StaticCharge": {
+      "rowName": "StaticCharge",
+      "name": "Static Charge",
+      "description": "Transfers static charge to the ground. Creates an electrified field in the targeted area. Damages enemies who traverse the charged terrain.",
+      "element": "lightning",
+      "baseDamageMultiplier": 0.65,
+      "affinities": [
+        "Ground",
+        "Charging"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.StaticCharge.Modifier.ExplodeChargeBuff": "Sky"
+      },
+      "cooldown": {
+        "initial": 3.48,
+        "twoOffhands": 2.71,
+        "threeOffhands": 1.93
+      }
+    },
+    "StarBlades": {
+      "rowName": "StarBlades",
+      "name": "Starblades",
+      "description": "Invokes cosmic forces to manifest razor-sharp blades from the sky. Blades rain down and embed in the ground in a radial pattern, damaging nearby adversaries.",
+      "element": "lightning",
+      "baseDamageMultiplier": 0.6,
+      "affinities": [
+        "Sky",
+        "Blade"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.StarBlades.Modifier.KunamiDaggers": "Charging"
+      },
+      "cooldown": {
+        "initial": 3.76,
+        "twoOffhands": 3.04,
+        "threeOffhands": 2.54
+      }
+    },
+    "ElectricDragons": {
+      "rowName": "ElectricDragons",
+      "name": "Electric Dragons",
+      "description": "Manifests a ring of electric dragons around the caster. Dragons orbit the user, crackling with intense electrical energy. Inflicts damage to foes who come into contact with the ethereal serpents.",
+      "element": "lightning",
+      "baseDamageMultiplier": 2,
+      "affinities": [
+        "Dragon",
+        "Orbit"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ElectricDragons.Modifier.AdditionalDragons": "Area"
+      },
+      "cooldown": {
+        "initial": 8.07,
+        "twoOffhands": 6.6,
+        "threeOffhands": 5.13
+      }
+    },
+    "SpinningBlade": {
+      "rowName": "SpinnigBlade",
+      "name": "Spinning Blade",
+      "description": "Conjures a rotating array of razor-sharp blades around the caster. Creates a mobile zone of cutting force, damaging enemies who venture too close.",
+      "element": "arcane",
+      "baseDamageMultiplier": 1,
+      "affinities": [
+        "Orbit",
+        "Blade"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.SpinningBlade.Modifier.Shurikans": "Projectile"
+      },
+      "cooldown": {
+        "initial": 8.23,
+        "twoOffhands": 6.5,
+        "threeOffhands": 4.77
+      }
+    },
+    "PoisonCloud": {
+      "rowName": "Toxicity",
+      "name": "Toxicity",
+      "description": "Generates pools of poison around the caster. Creates hazardous zones on the ground that persist briefly. Damages enemies who come into contact with or traverse the toxic areas.",
+      "element": "arcane",
+      "baseDamageMultiplier": 1.25,
+      "affinities": [
+        "Ground",
+        "Hazard"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.PoisonCloud.Modifier.ToxicProjectile": "Projectile"
+      },
+      "cooldown": {
+        "initial": 8.27,
+        "twoOffhands": 6.2,
+        "threeOffhands": 4.13
+      }
+    },
+    "EnemyDeath": {
+      "rowName": "DeathBlades",
+      "name": "Death Blades",
+      "description": "Manifests an ethereal blade imbued with arcane energy. Blade rotates, emitting waves of force that damage nearby foes.",
+      "element": "arcane",
+      "baseDamageMultiplier": 2.4,
+      "affinities": [
+        "Blade",
+        "Hazard"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.EnemyDeath.Modifier.ArcaneSpikeTicks": "Ground"
+      },
+      "cooldown": {
+        "initial": 9.18,
+        "twoOffhands": 7.14,
+        "threeOffhands": 5.1
+      }
+    },
+    "ArcaneOrb": {
+      "rowName": "ArcaneOrb",
+      "name": "Arcane Orb",
+      "description": "Unleashes a homing orb of arcane energy. Orb phase-shifts through enemies, damaging them as it travels outward. On its return path, it continues to damage foes in its way back to the caster.",
+      "element": "arcane",
+      "baseDamageMultiplier": 0.9,
+      "affinities": [
+        "Projectile",
+        "Charging"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ArcaneOrb.Modifier.SpawnOnHit": "Explosion",
+        "EasyRPG.Attributes.Abilities.ArcaneOrb.Modifier.ChaosOrb": "Explosion"
+      },
+      "cooldown": {
+        "initial": 4.46,
+        "twoOffhands": 3.53,
+        "threeOffhands": 2.6
+      }
+    },
+    "BloodDragons": {
+      "rowName": "BloodDragons",
+      "name": "Blood Dragons",
+      "description": "Summons ethereal blood dragons from thin air. Dragons surge towards foes, leaving trails of caustic mist that damage enemies.",
+      "element": "arcane",
+      "baseDamageMultiplier": 0.85,
+      "affinities": [
+        "Dragon",
+        "Ground"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.BloodDragons.Modifier.ExplosionChance": "Explosion"
+      },
+      "cooldown": {
+        "initial": 12,
+        "twoOffhands": 9.33,
+        "threeOffhands": 6.67
+      }
+    },
+    "ArcaneApocalypse": {
+      "rowName": "ArcaneApocalypse",
+      "name": "Arcane Apocalypse",
+      "description": "Unleashes chaotic bursts of reality-warping arcane energy. Creates multiple explosions, forming a sphere of otherworldly devastation around the battlefield.",
+      "element": "arcane",
+      "baseDamageMultiplier": 1.86,
+      "affinities": [
+        "Explosion",
+        "Ground"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ArcaneApocalypse.Modifier.AdditionalExplosions": "Hazard"
+      },
+      "cooldown": {
+        "initial": 3.99,
+        "twoOffhands": 3.36,
+        "threeOffhands": 2.31
+      }
+    },
+    "FireAtom": {
+      "rowName": "FireAtom",
+      "name": "Fire Orb",
+      "description": "Conjures a pulsating orb on the ground. Orb accumulates charge over time, periodically releasing damaging waves of increasing intensity.",
+      "element": "fire",
+      "baseDamageMultiplier": 1.3,
+      "affinities": [
+        "Ground",
+        "Area"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.FireAtom.Modifier.Explode": "Explosion"
+      },
+      "cooldown": {
+        "initial": 4.73,
+        "twoOffhands": 3.79,
+        "threeOffhands": 2.84
+      }
+    },
+    "FieryTotem": {
+      "rowName": "FieryTotem",
+      "name": "Fiery Totem",
+      "description": "Manifests incendiary totems around the caster. Totems explode on contact, creating a tactical minefield of fiery eruptions.",
+      "element": "fire",
+      "baseDamageMultiplier": 2.2,
+      "affinities": [
+        "Totem",
+        "Hazard"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.FieryTotem.Modifier.ExplodeOnOverlap": "Explosion"
+      },
+      "cooldown": {
+        "initial": 7,
+        "twoOffhands": 5.6,
+        "threeOffhands": 4.2
+      }
+    },
+    "ArcaneTotem": {
+      "rowName": "ArcaneTotem",
+      "name": "Arcane Totem",
+      "description": "Erects a mystical totem infused with arcane and primordial fire. Totem radiates waves of eldritch flame, searing nearby foes.",
+      "element": "arcane",
+      "baseDamageMultiplier": 0.8,
+      "affinities": [
+        "Totem",
+        "Ground"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ArcaneTotem.Modifier.ArcaneExplosion": "Explosion"
+      },
+      "cooldown": {
+        "initial": 8.8,
+        "twoOffhands": 7.2,
+        "threeOffhands": 5.6
+      }
+    },
+    "LightningTotem": {
+      "rowName": "LightningTotem",
+      "name": "Lightning Totem",
+      "description": "Erects an electrified totem channeling celestial lightning. Obelisk draws down lightning bolts, creating a field of electrical havoc around it.",
+      "element": "lightning",
+      "baseDamageMultiplier": 0.9,
+      "affinities": [
+        "Totem"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.LightningTotem.Modifier.LargerRadius": "Area",
+        "EasyRPG.Attributes.Abilities.LightningTotem.Modifier.TimedExplosions": "Explosion"
+      },
+      "cooldown": {
+        "initial": 9.8,
+        "twoOffhands": 8.4,
+        "threeOffhands": 7
+      }
+    },
+    "ArcaneCrackedSeed": {
+      "rowName": "ArcaneSeed",
+      "name": "Kraken Seed",
+      "description": "Spawns a Kraken Seed near the target. Seeds appear in random locations around struck enemies, ready to unleash aquatic fury.",
+      "element": "arcane",
+      "baseDamageMultiplier": 1.4,
+      "affinities": [
+        "Creature",
+        "Ground"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.ArcaneCrackedSeed.Modifier.Darts": "Projectile",
+        "EasyRPG.Attributes.Abilities.ArcaneCrackedSeed.Modifier.TentacleExplosion": "Projectile"
+      },
+      "cooldown": {
+        "initial": 8.4,
+        "twoOffhands": 6.53,
+        "threeOffhands": 4.67
+      }
+    },
+    "LightningPlasma": {
+      "rowName": "LightningPlasma",
+      "name": "Lightning Plasma",
+      "description": "Channels crackling lightning force through both arms. Emits damaging electrical energy to enemies on either side of the caster.",
+      "element": "lightning",
+      "baseDamageMultiplier": 1,
+      "affinities": [
+        "Projectile"
+      ],
+      "affinityBehaviours": {
+        "EasyRPG.Attributes.Abilities.LightningPlasma.Modifier.GrowLarger": "Area",
+        "EasyRPG.Attributes.Abilities.LightningPlasma.Modifier.Ticks": "Charging"
+      },
+      "cooldown": {
+        "initial": 6.67,
+        "twoOffhands": 5,
+        "threeOffhands": 3.33
+      }
+    }
+  }
+}

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -5,6 +5,7 @@ import { STAT_REGISTRY } from '../utils/statRegistry.js';
 import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
 import { inferWeaponStance } from '../utils/equipmentParser.js';
 import { aggregateSkillEffects, hasWeaponSkillData } from '../utils/skillEffectAggregator.js';
+import { detectEquippedAbilities, getStepCooldown, unionAffinities } from '../utils/offhandAbilities.js';
 import { ATTRIBUTE_BONUSES } from '../utils/attributeBonuses.js';
 
 // Re-export for backward compatibility
@@ -260,6 +261,15 @@ export function useDerivedStats(options = {}) {
     return null;
   }, [equippedItems]);
 
+  // Detect proc abilities on the equipped offhand items. Affinities (base +
+  // modifier-added) route the main-tree affinity damage/cooldown stats into
+  // the eDPS elemental bucket and the offhand cooldown stat. Only offhand
+  // items count — weapons can never carry an affinity tag.
+  const offhandAbilities = useMemo(
+    () => detectEquippedAbilities(equippedItems),
+    [equippedItems],
+  );
+
   // Merge stance detection into config overrides for eDPS.
   // Post ele/phys split, stance feeds the single physical additive bucket
   // (SCHD is merged in — no separate standalone multiplier).
@@ -271,6 +281,31 @@ export function useDerivedStats(options = {}) {
       merged.edpsElemCrit = { ...(configOverrides.edpsElemCrit || {}), stance: detectedStance };
     }
 
+    // Route equipped offhand ability affinities into the elemental bucket and
+    // the offhand cooldown stats. activeAffinities is the union across all
+    // equipped abilities (builds in practice stack one ability across the four
+    // offhand slots); the cooldown row tracks the dominant ability.
+    const { abilities, offhandCount } = offhandAbilities;
+    if (abilities.length > 0) {
+      const activeAffinities = unionAffinities(abilities);
+      merged.edpsElemAdditive = {
+        ...DERIVED_STATS.edpsElemAdditive.config,
+        ...(merged.edpsElemAdditive || {}),
+        activeAffinities,
+      };
+      merged.offhandCooldownReduction = {
+        ...(merged.offhandCooldownReduction || {}),
+        activeAffinities,
+      };
+      const dominant = abilities[0];
+      merged.offhandCooldownSeconds = {
+        ...(merged.offhandCooldownSeconds || {}),
+        baseCooldown: getStepCooldown(dominant, offhandCount),
+        abilityName: dominant.name,
+        offhandCount,
+      };
+    }
+
     // The 1%-of-max-Health monogram needs real max health (gear can't supply it).
     // Inject it into the damageFromHealth override the monogram already created.
     if (maxHealth > 0 && merged.damageFromHealth) {
@@ -278,7 +313,7 @@ export function useDerivedStats(options = {}) {
     }
 
     return merged;
-  }, [configOverrides, detectedStance, maxHealth]);
+  }, [configOverrides, detectedStance, offhandAbilities, maxHealth]);
 
   // Calculate all derived stats
   const calculatedStats = useMemo(() => {
@@ -404,6 +439,7 @@ export function useDerivedStats(options = {}) {
       stance: [],
       defense: [],
       elemental: [],
+      affinity: [],
       edps: [],
       monograms: [],
       abilities: [],
@@ -677,6 +713,9 @@ export function useDerivedStats(options = {}) {
 
     // Applied monograms list
     appliedMonograms,
+
+    // Detected offhand proc abilities ({ abilities, offhandCount })
+    offhandAbilities,
 
     // Config overrides applied
     configOverrides,

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -3,7 +3,7 @@ import { extractEquippedItems } from '../utils/equipmentParser';
 import { transformAllItems } from '../models/itemTransformer';
 import { parseStanceContext, parseAllocatedAttributes, parseMaxHealth, convertMasteryToStanceContext } from '../utils/stanceSkills';
 import { extractSkillTree } from '../utils/skillTreeParser';
-import { parseHealthProgression, parseCharacterName, calculateLevelHealth, CAMPAIGN_BOSS_HEALTH } from '../utils/healthParser';
+import { parseHealthProgression, parseCharacterName, parseCharacterRace, calculateLevelHealth, CAMPAIGN_BOSS_HEALTH } from '../utils/healthParser';
 import { itemShareToItem } from '../models/CharacterShareModel';
 
 /**
@@ -76,6 +76,9 @@ export function useItemStore() {
       // HostPlayerData.PlayerName
       characterName: parseCharacterName(saveJson),
       characterLevel: healthProgression.level,
+      // E_CharacterRace enum index; index→name/bonus mapping pending the race
+      // table extraction. Racial grants scale with level capped at 200.
+      characterRace: parseCharacterRace(saveJson),
       stanceContext,
       allocatedAttributes,
       characterStats,

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -20,7 +20,7 @@ import {
 } from '../utils/shareCodec.js';
 import { findStatForAttribute, getStatById } from '../utils/statRegistry.js';
 import { getWeaponSkillDef } from '../utils/skillTreeRegistry.js';
-import { hasMainTreeHealthEffect } from '../utils/skillEffectAggregator.js';
+import { hasMainTreeHealthEffect, hasMainTreeAffinityEffect } from '../utils/skillEffectAggregator.js';
 import { createEmptySkillTreeData } from './SkillTree.js';
 import { createEmptyItem } from './Item.js';
 
@@ -167,12 +167,13 @@ export function createSkillTreeShare(skillTree) {
   if (ws.length > 0) st.ws = ws;
 
   // Main-tree rows are normally too numerous for a share URL. Preserve only
-  // the generated nodes with known health effects so shared health remains
-  // consistent with an imported save.
-  const mainHealth = (skillTree.mainTree ?? [])
-    .filter(skill => skill.rowName && hasMainTreeHealthEffect(skill.rowName))
+  // the generated nodes with known effects (health + offhand affinity) so
+  // shared health and affinity eDPS remain consistent with an imported save.
+  const mainNodes = (skillTree.mainTree ?? [])
+    .filter(skill => skill.rowName
+      && (hasMainTreeHealthEffect(skill.rowName) || hasMainTreeAffinityEffect(skill.rowName)))
     .map(skill => skill.rowName);
-  if (mainHealth.length > 0) st.mh = mainHealth;
+  if (mainNodes.length > 0) st.mh = mainNodes;
 
   return Object.keys(st).length > 0 ? st : null;
 }
@@ -201,7 +202,7 @@ export function skillTreeShareToData(st) {
   }
 
   for (const rowName of st.mh || []) {
-    if (!rowName || !hasMainTreeHealthEffect(rowName)) continue;
+    if (!rowName || !(hasMainTreeHealthEffect(rowName) || hasMainTreeAffinityEffect(rowName))) continue;
     tree.mainTree.push({ rowName, level: 1, category: 'main' });
   }
 

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -17,7 +17,7 @@
  * - 'custom': Arbitrary calculation function
  */
 
-import { STAT_REGISTRY } from './statRegistry.js';
+import { STAT_REGISTRY, OFFHAND_AFFINITY_CATEGORIES, affinityDamageStatId, affinityCooldownStatId } from './statRegistry.js';
 import { ATTRIBUTE_BONUSES, getAttributeBonusEffect } from './attributeBonuses.js';
 
 // ============================================================================
@@ -102,6 +102,41 @@ export function resolveElementRouting(stats, config = {}) {
 
   return { active, included, conversions, totals };
 }
+
+// ============================================================================
+// OFFHAND AFFINITY ROUTING
+// ============================================================================
+
+/**
+ * Sum the affinity damage% / cooldown% bonuses for a set of active affinity
+ * categories. Categories come from the equipped offhand abilities (base
+ * affinities + modifier-added ones, see offhandAbilities.js); the per-category
+ * bonus values are aggregated base stats (main-tree affinity nodes today,
+ * race grants once the race table is extracted).
+ *
+ * @param {Object} stats - Calculated stats (needs <cat>AffinityDamage/Cooldown)
+ * @param {string[]} activeAffinities - Category tags ('Dragon') or keys ('dragon')
+ * @returns {{damage: number, cooldown: number, perCategory: Array<{category: string, damage: number, cooldown: number}>}}
+ */
+export function resolveAffinityBonuses(stats, activeAffinities = []) {
+  let damage = 0;
+  let cooldown = 0;
+  const perCategory = [];
+  for (const category of activeAffinities) {
+    const damageId = affinityDamageStatId(category);
+    const cooldownId = affinityCooldownStatId(category);
+    if (!damageId) continue;
+    const catDamage = stats[damageId] || 0;
+    const catCooldown = stats[cooldownId] || 0;
+    damage += catDamage;
+    cooldown += catCooldown;
+    perCategory.push({ category, damage: catDamage, cooldown: catCooldown });
+  }
+  return { damage, cooldown, perCategory };
+}
+
+const AFFINITY_DAMAGE_STAT_IDS = OFFHAND_AFFINITY_CATEGORIES.map(c => `${c.key}AffinityDamage`);
+const AFFINITY_COOLDOWN_STAT_IDS = OFFHAND_AFFINITY_CATEGORIES.map(c => `${c.key}AffinityCooldown`);
 
 /**
  * Build a breakdown term for a derived stat's formula tooltip.
@@ -2533,15 +2568,20 @@ export const DERIVED_STATS = {
     name: 'Elemental Offhand Bucket',
     category: 'edps',
     layer: LAYERS.EDPS,
-    dependencies: ['edpsBothTypesDamageBonus'],
+    dependencies: ['edpsBothTypesDamageBonus', ...AFFINITY_DAMAGE_STAT_IDS],
     config: {
-      offhandItemBonus: 0, // manual extra; item DamageMultiplier affixes auto-add via stats.damageMultiplier
-      affinity: 0,         // skill tree affinity (manual until parsed)
+      offhandItemBonus: 0,  // manual extra; item DamageMultiplier affixes auto-add via stats.damageMultiplier
+      affinity: 0,          // manual affinity extra (kept for shared builds / overrides)
+      // Active affinity categories ('Dragon', 'Orbit', …) — auto-set by
+      // useDerivedStats from the equipped offhand abilities (base affinities
+      // + modifier-added ones). Routes <cat>AffinityDamage tree stats in.
+      activeAffinities: [],
     },
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.edpsElemAdditive.config;
       const itemOffhand = (stats.damageMultiplier || 0) + (config.offhandItemBonus || 0);
-      const affinity = config.affinity || 0;
+      const affinity = (config.affinity || 0)
+        + resolveAffinityBonuses(stats, config.activeAffinities || []).damage;
       const bothTypes = stats.edpsBothTypesDamageBonus || 0;
       return itemOffhand + affinity + bothTypes;
     },
@@ -2549,9 +2589,13 @@ export const DERIVED_STATS = {
     description: 'Elemental offhand bucket: item offhand damage% + affinity + both-types (skill mult added per skill)',
     breakdown: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.edpsElemAdditive.config;
+      const { perCategory } = resolveAffinityBonuses(stats, config.activeAffinities || []);
       return [
         { label: 'offhandItems', fullName: 'Offhand Damage% (from items)', op: '+', value: (stats.damageMultiplier || 0) + (config.offhandItemBonus || 0), fmt: 'pct' },
-        { label: 'affinity', fullName: 'Affinity Damage (skill tree)', op: '+', value: config.affinity || 0, fmt: 'pct' },
+        ...perCategory.map(({ category, damage }) => (
+          { label: `${category} affinity`, fullName: `${category} Affinity Damage (skill tree)`, op: '+', value: damage, fmt: 'pct' }
+        )),
+        { label: 'affinity (manual)', fullName: 'Affinity Damage (manual config)', op: '+', value: config.affinity || 0, fmt: 'pct' },
         { label: 'edpsBothTypesDamageBonus', fullName: 'Damage% (Both Types)', op: '+', value: stats.edpsBothTypesDamageBonus || 0, fmt: 'pct', isMonogram: true },
         { label: 'ElemBucket', fullName: 'Elemental Offhand Bucket (sum, pre-skill)', op: '=', value: stats.edpsElemAdditive, fmt: 'pct', isSubtotal: true },
       ];
@@ -2822,6 +2866,79 @@ export const DERIVED_STATS = {
     },
     format: v => `${(v * 100).toFixed(0)}%`,
     description: 'Skill-specific extra damage multiplier on the elemental line (default 1)',
+  },
+
+  /**
+   * offhandCooldownReduction — total CDR applying to the equipped offhand
+   * abilities. Per confirmed behavior, affinity cooldown bonuses are ADDITIVE
+   * with the regular item CooldownReduction% value.
+   */
+  offhandCooldownReduction: {
+    id: 'offhandCooldownReduction',
+    name: 'Offhand Cooldown Reduction',
+    category: 'abilities',
+    layer: LAYERS.PRIMARY_DERIVED,
+    dependencies: ['cooldownReduction', ...AFFINITY_COOLDOWN_STAT_IDS],
+    config: { activeAffinities: [] }, // auto-set from equipped offhand abilities
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.offhandCooldownReduction.config;
+      const affinity = resolveAffinityBonuses(stats, config.activeAffinities || []).cooldown;
+      return (stats.cooldownReduction || 0) + affinity;
+    },
+    format: v => `${(v * 100).toFixed(1)}%`,
+    description: 'Item Cooldown Reduction% + active affinity cooldown bonuses (additive)',
+    breakdown: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.offhandCooldownReduction.config;
+      const { perCategory } = resolveAffinityBonuses(stats, config.activeAffinities || []);
+      return [
+        { label: 'cooldownReduction', fullName: 'Cooldown Reduction (items)', op: '+', value: stats.cooldownReduction || 0, fmt: 'pct' },
+        ...perCategory.map(({ category, cooldown }) => (
+          { label: `${category} affinity`, fullName: `${category} Affinity Cooldown (skill tree)`, op: '+', value: cooldown, fmt: 'pct' }
+        )),
+        { label: 'total', fullName: 'Offhand Cooldown Reduction (total)', op: '=', value: stats.offhandCooldownReduction, fmt: 'pct', isSubtotal: true },
+      ];
+    },
+  },
+
+  /**
+   * offhandCooldownSeconds — effective cooldown of the build's dominant
+   * offhand ability. The base steps down with equipped-offhand count
+   * (Initial/TwoOffhands/ThreeOffhands from DT_PlayerAbilities; 3+ share the
+   * last step). CDR application modeled as base × (1 − CDR) — provisional
+   * until confirmed in-game.
+   */
+  offhandCooldownSeconds: {
+    id: 'offhandCooldownSeconds',
+    name: 'Offhand Cooldown',
+    category: 'abilities',
+    layer: LAYERS.SECONDARY_DERIVED,
+    dependencies: ['offhandCooldownReduction'],
+    // baseCooldown/abilityName/offhandCount auto-set by useDerivedStats from
+    // the dominant equipped offhand ability (most offhands carrying it)
+    config: { baseCooldown: 0, abilityName: null, offhandCount: 0 },
+    calculate: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.offhandCooldownSeconds.config;
+      const base = config.baseCooldown || 0;
+      if (base <= 0) return 0;
+      const cdr = stats.offhandCooldownReduction || 0;
+      return Math.max(base * (1 - cdr), 0);
+    },
+    format: v => (v > 0 ? `${v.toFixed(2)}s` : '—'),
+    description: 'Effective cooldown of the dominant offhand ability: step base (by equipped-offhand count) × (1 − CDR)',
+    breakdown: (stats, cfg) => {
+      const config = cfg || DERIVED_STATS.offhandCooldownSeconds.config;
+      return [
+        {
+          label: 'baseCooldown',
+          fullName: config.abilityName
+            ? `${config.abilityName} base cooldown (${config.offhandCount || 0} offhands equipped)`
+            : 'Base cooldown (no offhand ability detected)',
+          op: '=', value: config.baseCooldown || 0, fmt: 'flat',
+        },
+        { label: 'offhandCooldownReduction', fullName: 'Offhand Cooldown Reduction (total)', op: '−', value: stats.offhandCooldownReduction || 0, fmt: 'pct' },
+        { label: 'effective', fullName: 'Effective cooldown (seconds)', op: '=', value: stats.offhandCooldownSeconds, fmt: 'flat', isSubtotal: true },
+      ];
+    },
   },
 
   // ---------------------------------------------------------------------------

--- a/src/utils/healthParser.js
+++ b/src/utils/healthParser.js
@@ -38,6 +38,33 @@ export function parseCharacterName(saveData) {
   return typeof name === 'string' ? name : '';
 }
 
+/**
+ * Character race from HostPlayerData customization data. Stored as a byte of
+ * the game's E_CharacterRace enum ("E_CharacterRace::NewEnumerator2") — the
+ * enum labels are opaque indices; the index→name/bonus mapping awaits a race
+ * table extraction. Race grants scale with character level capped at 200
+ * (see RACE_LEVEL_CAP), so the index + capped level are what downstream
+ * racial-affinity calculations will need.
+ *
+ * @returns {number|null} Race enum index (e.g. 2), or null when unavailable.
+ */
+export function parseCharacterRace(saveData) {
+  const hostPlayerStruct = findHostPlayerStruct(saveData);
+  if (!hostPlayerStruct) return null;
+  const customizationKey = Object.keys(hostPlayerStruct).find(k => k.startsWith('CustumizationData_'));
+  const customization = customizationKey
+    ? hostPlayerStruct[customizationKey]?.Struct?.Struct
+    : null;
+  if (!customization) return null;
+  const raceKey = Object.keys(customization).find(k => k.startsWith('Race_'));
+  const label = raceKey ? customization[raceKey]?.Byte?.Label : null;
+  const match = typeof label === 'string' ? label.match(/NewEnumerator(\d+)$/) : null;
+  return match ? Number(match[1]) : null;
+}
+
+/** Racial bonuses scale with character level up to this cap. */
+export const RACE_LEVEL_CAP = 200;
+
 /** @returns {number[]} Completed rupture numbers from the map-select save data. */
 export function parseCompletedRuptures(saveData) {
   const props = saveData?.root?.properties || saveData?.properties;

--- a/src/utils/offhandAbilities.js
+++ b/src/utils/offhandAbilities.js
@@ -1,0 +1,136 @@
+/**
+ * Offhand Ability Detection
+ *
+ * Offhand items (goblet/horn/trinket/belt) carry proc-ability stats under
+ * EasyRPG.Attributes.Abilities.<Ability>.* — this module resolves those tags
+ * against the generated DT_PlayerAbilities data to answer:
+ *
+ * - Which abilities are equipped, and on how many offhands?
+ * - Which affinity categories are active for each ability? Base affinities
+ *   come from the ability itself; some ability modifiers ADD an affinity when
+ *   rolled on an offhand item (AffinityBehaviours — e.g. Electric Dragons'
+ *   AdditionalDragons modifier adds Area). Only offhand items count: weapons
+ *   can never contribute an affinity tag.
+ * - What is the ability's base cooldown? Cooldowns step down with the number
+ *   of equipped offhands (Initial = 1, TwoOffhands = 2, ThreeOffhands = 3+;
+ *   the game defines no fourth step, so a full 4-offhand loadout uses the
+ *   3-offhand value).
+ *
+ * @module utils/offhandAbilities
+ */
+
+import playerAbilitiesGenerated from '../data/playerAbilities.generated.json';
+
+const ABILITIES = playerAbilitiesGenerated.abilities || {};
+const ABILITY_TAG_PREFIX = 'EasyRPG.Attributes.Abilities.';
+
+/** Look up a generated ability definition by key (e.g. 'ElectricDragons'). */
+export function getAbilityDef(abilityKey) {
+  return ABILITIES[abilityKey] || null;
+}
+
+function statTags(item) {
+  const baseStats = item?.baseStats || item?.model?.baseStats || [];
+  return baseStats
+    .map(stat => stat.rawTag || stat.stat || stat.name)
+    .filter(tag => typeof tag === 'string');
+}
+
+/**
+ * @typedef {Object} EquippedAbility
+ * @property {string} key - Ability key ('ElectricDragons')
+ * @property {string} name - Display name ('Electric Dragons')
+ * @property {string|null} element - 'fire' | 'lightning' | 'arcane'
+ * @property {string[]} baseAffinities - Categories from the ability itself
+ * @property {Array<{category: string, modifierTag: string}>} addedAffinities -
+ *   Categories added by equipped ability modifiers (AffinityBehaviours)
+ * @property {string[]} affinities - base + added, deduped
+ * @property {number} itemCount - How many equipped offhands carry this ability
+ * @property {{initial:number, twoOffhands:number, threeOffhands:number}|null} cooldown
+ */
+
+/**
+ * Detect proc abilities on the equipped offhand items.
+ *
+ * @param {Array} equippedItems - Item-model list (extractEquippedItems output)
+ * @returns {{abilities: EquippedAbility[], offhandCount: number}}
+ */
+export function detectEquippedAbilities(equippedItems = []) {
+  const offhandItems = equippedItems.filter(item => (item?.slot || item?.slotKey) === 'offhand');
+
+  // abilityKey → { itemCount, modifierTags:Set }
+  const found = new Map();
+  for (const item of offhandItems) {
+    const abilitiesOnItem = new Set();
+    const modifierTags = [];
+    for (const tag of statTags(item)) {
+      if (!tag.startsWith(ABILITY_TAG_PREFIX)) continue;
+      const key = tag.slice(ABILITY_TAG_PREFIX.length).split('.')[0];
+      if (!ABILITIES[key]) continue;
+      abilitiesOnItem.add(key);
+      if (tag.includes('.Modifier.')) modifierTags.push(tag);
+    }
+    for (const key of abilitiesOnItem) {
+      if (!found.has(key)) found.set(key, { itemCount: 0, modifierTags: new Set() });
+      const entry = found.get(key);
+      entry.itemCount += 1;
+      for (const tag of modifierTags) entry.modifierTags.add(tag);
+    }
+  }
+
+  const abilities = [];
+  for (const [key, entry] of found) {
+    const def = ABILITIES[key];
+    const addedAffinities = [];
+    for (const [modifierTag, category] of Object.entries(def.affinityBehaviours || {})) {
+      if (entry.modifierTags.has(modifierTag)) {
+        addedAffinities.push({ category, modifierTag });
+      }
+    }
+    const affinities = [...new Set([
+      ...(def.affinities || []),
+      ...addedAffinities.map(a => a.category),
+    ])];
+    abilities.push({
+      key,
+      name: def.name || key,
+      element: def.element || null,
+      baseAffinities: def.affinities || [],
+      addedAffinities,
+      affinities,
+      itemCount: entry.itemCount,
+      cooldown: def.cooldown || null,
+    });
+  }
+
+  // Most-equipped ability first — the dominant proc of the build
+  abilities.sort((a, b) => b.itemCount - a.itemCount);
+
+  return { abilities, offhandCount: offhandItems.length };
+}
+
+/**
+ * Base cooldown (seconds) for an ability at a given equipped-offhand count.
+ * The step function is defined per ability in DT_PlayerAbilities; 3+ offhands
+ * share the ThreeOffhands value (no fourth step exists).
+ *
+ * @param {{cooldown: Object|null}} ability - EquippedAbility or ability def
+ * @param {number} offhandCount
+ * @returns {number} Base cooldown in seconds (0 when the ability has none)
+ */
+export function getStepCooldown(ability, offhandCount) {
+  const cd = ability?.cooldown;
+  if (!cd) return 0;
+  if (offhandCount >= 3) return cd.threeOffhands || 0;
+  if (offhandCount === 2) return cd.twoOffhands || 0;
+  return cd.initial || 0;
+}
+
+/**
+ * Union of active affinity categories across all equipped abilities.
+ * @param {EquippedAbility[]} abilities
+ * @returns {string[]} Category tags ('Dragon', 'Orbit', …)
+ */
+export function unionAffinities(abilities = []) {
+  return [...new Set(abilities.flatMap(a => a.affinities))];
+}

--- a/src/utils/skillEffectAggregator.js
+++ b/src/utils/skillEffectAggregator.js
@@ -21,14 +21,21 @@
 import cardsGenerated from '../data/cards.generated.json';
 import weaponSkillsGenerated from '../data/weaponSkills.generated.json';
 import mainTreeHealthGenerated from '../data/mainTreeHealth.generated.json';
+import mainTreeAffinityGenerated from '../data/mainTreeAffinity.generated.json';
 import { findStatForAttribute } from './statRegistry.js';
 
 const GENERATED_CARDS = cardsGenerated.cards || {};
 const GENERATED_WEAPON_SKILLS = weaponSkillsGenerated.weaponSkills || {};
 const MAIN_TREE_HEALTH_EFFECTS = mainTreeHealthGenerated.effectsByRow || {};
+const MAIN_TREE_AFFINITY_EFFECTS = mainTreeAffinityGenerated.effectsByRow || {};
+const MAIN_TREE_AFFINITY_NAMES = mainTreeAffinityGenerated.namesByRow || {};
 
 export function hasMainTreeHealthEffect(rowName) {
   return !!MAIN_TREE_HEALTH_EFFECTS[rowName];
+}
+
+export function hasMainTreeAffinityEffect(rowName) {
+  return !!MAIN_TREE_AFFINITY_EFFECTS[rowName];
 }
 
 // UE row names (FNames) are case-insensitive: saves contain e.g.
@@ -52,8 +59,10 @@ function lookupWeaponSkill(rowName) {
 
 // Only stat-granting tags flow into the calc engine. Cards/skills can also
 // grant modifier tags (e.g. EasyRPG.Items.Modifiers.AdditionalPotionSlots.1)
-// — those are behavior grants, not aggregatable stats.
+// — those are behavior grants, not aggregatable stats. Offhand affinity
+// bonuses live under their own EasyRPG.OffhandCategories.* prefix.
 const ATTR_PREFIX = 'EasyRPG.Attributes.';
+const OFFHAND_CATEGORY_PREFIX = 'EasyRPG.OffhandCategories.';
 
 /**
  * @typedef {Object} SkillContribution
@@ -66,7 +75,7 @@ const ATTR_PREFIX = 'EasyRPG.Attributes.';
 
 function pushEffects(contributions, effects, multiplier, source, kind) {
   for (const eff of effects ?? []) {
-    if (!eff.tag?.startsWith(ATTR_PREFIX)) continue;
+    if (!eff.tag?.startsWith(ATTR_PREFIX) && !eff.tag?.startsWith(OFFHAND_CATEGORY_PREFIX)) continue;
     if (!eff.value) continue;
     contributions.push({
       tag: eff.tag,
@@ -92,15 +101,22 @@ export function aggregateSkillEffects(skillTree, options = {}) {
   const contributions = [];
   if (!skillTree) return contributions;
 
-  // --- Main passive tree: generated node IDs → health effects -----------
-  // The save stores opaque UI_SkillTreeNode_* row names. The compact map is
-  // generated from DT_GENERATED_SkillTree_Main and intentionally contains
-  // only MaxHealth/MaxHealth% effects for now.
+  // --- Main passive tree: generated node IDs → health + affinity effects --
+  // The save stores opaque UI_SkillTreeNode_* row names. The compact maps are
+  // generated from DT_GENERATED_SkillTree_Main: MaxHealth/MaxHealth% effects
+  // plus OffhandCategories affinity damage%/cooldown nodes (which carry
+  // display names like "Sky Rush" for readable breakdowns).
   for (const skill of skillTree.mainTree ?? []) {
-    const effects = MAIN_TREE_HEALTH_EFFECTS[skill.rowName];
-    if (!effects) continue;
     const level = skill.level || 1;
-    pushEffects(contributions, effects, level, `${skill.rowName} (L${level})`, 'mainTree');
+    const healthEffects = MAIN_TREE_HEALTH_EFFECTS[skill.rowName];
+    if (healthEffects) {
+      pushEffects(contributions, healthEffects, level, `${skill.rowName} (L${level})`, 'mainTree');
+    }
+    const affinityEffects = MAIN_TREE_AFFINITY_EFFECTS[skill.rowName];
+    if (affinityEffects) {
+      const label = MAIN_TREE_AFFINITY_NAMES[skill.rowName] || skill.rowName;
+      pushEffects(contributions, affinityEffects, level, `${label} (L${level})`, 'mainTree');
+    }
   }
 
   // --- Crystal cards: effects scale linearly with card level -------------

--- a/src/utils/statRegistry.js
+++ b/src/utils/statRegistry.js
@@ -1594,6 +1594,77 @@ export const STAT_REGISTRY = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// OFFHAND AFFINITY STATS (still inside the append-only zone)
+//
+// The 12 EasyRPG.OffhandCategories.* affinities. Each gets a Damage%Bonus and
+// a CooldownBonus stat (main-tree nodes grant both; the matching item affix
+// rows exist but have canRoll=false — weapons can never carry affinity tags).
+// Exact full-tag patterns are load-bearing: findStatForAttribute's exact-match
+// pass must claim these before the generic `Damage%` regex on damageBonus
+// swallows them into the physical bucket.
+//
+// This array is the generation order for STAT_REGISTRY keys and therefore part
+// of the share-codec wire format: append new categories at the END only.
+// ---------------------------------------------------------------------------
+
+export const OFFHAND_AFFINITY_CATEGORIES = [
+  { key: 'dragon', tag: 'Dragon', label: 'Dragon' },
+  { key: 'creature', tag: 'Creature', label: 'Creature' },
+  { key: 'sky', tag: 'Sky', label: 'Sky' },
+  { key: 'explosion', tag: 'Explosion', label: 'Explosion' },
+  { key: 'projectile', tag: 'Projectile', label: 'Projectile' },
+  { key: 'ground', tag: 'Ground', label: 'Ground' },
+  { key: 'orbit', tag: 'Orbit', label: 'Orbit' },
+  { key: 'blade', tag: 'Blade', label: 'Blade' },
+  // The game displays the Charging category as "Momentum"
+  { key: 'charging', tag: 'Charging', label: 'Momentum' },
+  { key: 'totem', tag: 'Totem', label: 'Totem' },
+  { key: 'area', tag: 'Area', label: 'Area' },
+  { key: 'hazard', tag: 'Hazard', label: 'Hazard' },
+];
+
+/** Affinity category tag ('Dragon') → damage stat id ('dragonAffinityDamage') */
+export function affinityDamageStatId(categoryTag) {
+  const entry = OFFHAND_AFFINITY_CATEGORIES.find(c => c.tag === categoryTag || c.key === categoryTag);
+  return entry ? `${entry.key}AffinityDamage` : null;
+}
+
+/** Affinity category tag ('Dragon') → cooldown stat id ('dragonAffinityCooldown') */
+export function affinityCooldownStatId(categoryTag) {
+  const entry = OFFHAND_AFFINITY_CATEGORIES.find(c => c.tag === categoryTag || c.key === categoryTag);
+  return entry ? `${entry.key}AffinityCooldown` : null;
+}
+
+for (const { key, tag, label } of OFFHAND_AFFINITY_CATEGORIES) {
+  STAT_REGISTRY[`${key}AffinityDamage`] = {
+    id: `${key}AffinityDamage`,
+    name: `${label} Affinity Damage`,
+    category: 'affinity',
+    patterns: [
+      `EasyRPG.OffhandCategories.${tag}.Damage%Bonus`,
+      `${tag}.Damage%Bonus`,
+    ],
+    canonical: `EasyRPG.OffhandCategories.${tag}.Damage%Bonus`,
+    isPercent: true,
+    format: v => `+${(v * 100).toFixed(0)}%`,
+    description: `Damage bonus for offhand abilities with ${label} affinity`,
+  };
+  STAT_REGISTRY[`${key}AffinityCooldown`] = {
+    id: `${key}AffinityCooldown`,
+    name: `${label} Affinity Cooldown`,
+    category: 'affinity',
+    patterns: [
+      `EasyRPG.OffhandCategories.${tag}.CooldownBonus`,
+      `${tag}.CooldownBonus`,
+    ],
+    canonical: `EasyRPG.OffhandCategories.${tag}.CooldownBonus`,
+    isPercent: true,
+    format: v => `+${(v * 100).toFixed(0)}%`,
+    description: `Cooldown reduction for offhand abilities with ${label} affinity`,
+  };
+}
+
 // ============================================================================
 // ADDITIONAL DISPLAY PATTERNS (for attributes not in stat calculations)
 // ============================================================================

--- a/test/offhandAffinities.test.js
+++ b/test/offhandAffinities.test.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { findStatForAttribute, STAT_REGISTRY, OFFHAND_AFFINITY_CATEGORIES } from '../src/utils/statRegistry.js';
+import { detectEquippedAbilities, getStepCooldown, unionAffinities, getAbilityDef } from '../src/utils/offhandAbilities.js';
+import { aggregateSkillEffects, hasMainTreeAffinityEffect } from '../src/utils/skillEffectAggregator.js';
+import { extractSkillTree } from '../src/utils/skillTreeParser.js';
+import { extractEquippedItems } from '../src/utils/equipmentParser.js';
+import { calculateDerivedStats, resolveAffinityBonuses, DERIVED_STATS } from '../src/utils/derivedStats.js';
+import { parseCharacterRace, parseCharacterLevel, RACE_LEVEL_CAP } from '../src/utils/healthParser.js';
+import { resolveStatId } from '../src/hooks/useDerivedStats.js';
+
+// The dr-full-inventory fixture is an Electric Dragons build: all four
+// offhands proc ElectricDragons and the main tree has Dragon/Orbit/Area
+// affinity nodes allocated.
+let saveFixture;
+let equippedItems;
+
+beforeAll(() => {
+  const fixturePath = path.join(import.meta.dirname, 'fixtures', 'dr-full-inventory.json');
+  saveFixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  equippedItems = extractEquippedItems(saveFixture);
+});
+
+// =============================================================================
+// Stat registry: affinity tags classify to their own stats
+// =============================================================================
+
+describe('offhand affinity stat registration', () => {
+  it('registers damage + cooldown stats for all 12 categories', () => {
+    for (const { key } of OFFHAND_AFFINITY_CATEGORIES) {
+      expect(STAT_REGISTRY[`${key}AffinityDamage`]).toBeDefined();
+      expect(STAT_REGISTRY[`${key}AffinityCooldown`]).toBeDefined();
+    }
+    expect(OFFHAND_AFFINITY_CATEGORIES).toHaveLength(12);
+  });
+
+  it('classifies OffhandCategories tags to affinity stats, not the physical damage bucket', () => {
+    // Regression: the loose 'Damage%' regex on damageBonus used to swallow these
+    expect(findStatForAttribute('EasyRPG.OffhandCategories.Dragon.Damage%Bonus')?.id)
+      .toBe('dragonAffinityDamage');
+    expect(findStatForAttribute('EasyRPG.OffhandCategories.Dragon.CooldownBonus')?.id)
+      .toBe('dragonAffinityCooldown');
+    expect(findStatForAttribute('EasyRPG.OffhandCategories.Charging.Damage%Bonus')?.id)
+      .toBe('chargingAffinityDamage');
+  });
+
+  it('does not disturb existing damage/cooldown classification', () => {
+    expect(findStatForAttribute('EasyRPG.Attributes.Base.Damage%6')?.id).toBe('damageBonus');
+    expect(findStatForAttribute('EasyRPG.Attributes.CooldownReduction%')?.id).toBe('cooldownReduction');
+  });
+
+  it('resolveStatId (item aggregation path) resolves affinity tags', () => {
+    expect(resolveStatId('EasyRPG.OffhandCategories.Orbit.Damage%Bonus')).toBe('orbitAffinityDamage');
+    expect(resolveStatId('EasyRPG.OffhandCategories.Area.CooldownBonus')).toBe('areaAffinityCooldown');
+  });
+
+  it('displays Charging as Momentum', () => {
+    expect(STAT_REGISTRY.chargingAffinityDamage.name).toBe('Momentum Affinity Damage');
+  });
+});
+
+// =============================================================================
+// Generated player abilities
+// =============================================================================
+
+describe('playerAbilities generated data', () => {
+  it('ElectricDragons is Dragon + Orbit, lightning element', () => {
+    const def = getAbilityDef('ElectricDragons');
+    expect(def).toBeTruthy();
+    expect(def.affinities).toEqual(['Dragon', 'Orbit']);
+    expect(def.element).toBe('lightning');
+    expect(def.baseDamageMultiplier).toBe(2);
+  });
+
+  it('ElectricDragons AdditionalDragons modifier adds Area affinity', () => {
+    const def = getAbilityDef('ElectricDragons');
+    expect(def.affinityBehaviours).toEqual({
+      'EasyRPG.Attributes.Abilities.ElectricDragons.Modifier.AdditionalDragons': 'Area',
+    });
+  });
+
+  it('carries the offhand-count cooldown step function', () => {
+    const def = getAbilityDef('ElectricDragons');
+    expect(def.cooldown).toEqual({ initial: 8.07, twoOffhands: 6.6, threeOffhands: 5.13 });
+  });
+
+  it('normalizes BurningShield despite its .ProcChance identifier tag', () => {
+    const def = getAbilityDef('BurningShield');
+    expect(def).toBeTruthy();
+    expect(def.affinities).toEqual(['Orbit']);
+  });
+});
+
+// =============================================================================
+// Equipped offhand ability detection (Electric Dragons save)
+// =============================================================================
+
+describe('detectEquippedAbilities', () => {
+  it('detects ElectricDragons on all four offhands', () => {
+    const { abilities, offhandCount } = detectEquippedAbilities(equippedItems);
+    expect(offhandCount).toBe(4);
+    expect(abilities).toHaveLength(1);
+    expect(abilities[0].key).toBe('ElectricDragons');
+    expect(abilities[0].itemCount).toBe(4);
+  });
+
+  it('activates Area via the AdditionalDragons modifier on the equipped items', () => {
+    const { abilities } = detectEquippedAbilities(equippedItems);
+    const ed = abilities[0];
+    expect(ed.baseAffinities).toEqual(['Dragon', 'Orbit']);
+    expect(ed.addedAffinities).toEqual([{
+      category: 'Area',
+      modifierTag: 'EasyRPG.Attributes.Abilities.ElectricDragons.Modifier.AdditionalDragons',
+    }]);
+    expect(ed.affinities.sort()).toEqual(['Area', 'Dragon', 'Orbit']);
+    expect(unionAffinities(abilities).sort()).toEqual(['Area', 'Dragon', 'Orbit']);
+  });
+
+  it('never derives affinities from the weapon slot', () => {
+    // Weapons can't carry affinity tags — only offhand items are scanned
+    const weaponOnly = equippedItems.filter(item => item.slot === 'weapon');
+    const { abilities, offhandCount } = detectEquippedAbilities(weaponOnly);
+    expect(abilities).toHaveLength(0);
+    expect(offhandCount).toBe(0);
+  });
+
+  it('steps the cooldown down by offhand count, flooring at 3+', () => {
+    const ed = getAbilityDef('ElectricDragons');
+    expect(getStepCooldown(ed, 1)).toBe(8.07);
+    expect(getStepCooldown(ed, 2)).toBe(6.6);
+    expect(getStepCooldown(ed, 3)).toBe(5.13);
+    expect(getStepCooldown(ed, 4)).toBe(5.13); // full loadout uses the 3-offhand value
+    expect(getStepCooldown({ cooldown: null }, 4)).toBe(0);
+  });
+});
+
+// =============================================================================
+// Main-tree affinity node aggregation
+// =============================================================================
+
+describe('main-tree affinity aggregation', () => {
+  it('knows the generated affinity nodes', () => {
+    // "Sky Rush" — 7% Sky cooldown
+    expect(hasMainTreeAffinityEffect('UI_SkillTreeNode_Large_57')).toBe(true);
+    expect(hasMainTreeAffinityEffect('UI_SkillTreeNode_Start')).toBe(false);
+  });
+
+  it('aggregates allocated affinity nodes from the ED save into affinity stats', () => {
+    const skillTree = extractSkillTree(saveFixture);
+    const contributions = aggregateSkillEffects(skillTree);
+    const affinity = contributions.filter(c => c.tag.startsWith('EasyRPG.OffhandCategories.'));
+    expect(affinity.length).toBeGreaterThan(0);
+
+    const totals = {};
+    for (const c of affinity) {
+      expect(c.statId).toBeTruthy(); // every affinity tag resolves to a stat
+      expect(c.kind).toBe('mainTree');
+      totals[c.statId] = (totals[c.statId] || 0) + c.value;
+    }
+    // The build runs Electric Dragons: Dragon/Orbit/Area investment is expected
+    expect(totals.dragonAffinityDamage).toBeGreaterThan(0);
+    expect(totals.orbitAffinityDamage).toBeGreaterThan(0);
+    expect(totals.dragonAffinityCooldown).toBeGreaterThan(0);
+  });
+
+  it('labels contributions with node display names', () => {
+    const skillTree = extractSkillTree(saveFixture);
+    const contributions = aggregateSkillEffects(skillTree);
+    const dragonForce = contributions.find(c => c.source.startsWith('Dragon Force'));
+    expect(dragonForce).toBeTruthy();
+    expect(dragonForce.statId).toBe('dragonAffinityDamage');
+  });
+});
+
+// =============================================================================
+// Derived stats: eDPS elemental bucket + offhand cooldown
+// =============================================================================
+
+describe('affinity routing in derived stats', () => {
+  it('resolveAffinityBonuses sums only active categories', () => {
+    const stats = {
+      dragonAffinityDamage: 0.30,
+      orbitAffinityDamage: 0.16,
+      areaAffinityDamage: 0.05,
+      skyAffinityDamage: 0.99, // inactive — must not count
+      dragonAffinityCooldown: 0.08,
+    };
+    const { damage, cooldown, perCategory } = resolveAffinityBonuses(stats, ['Dragon', 'Orbit', 'Area']);
+    expect(damage).toBeCloseTo(0.51, 10);
+    expect(cooldown).toBeCloseTo(0.08, 10);
+    expect(perCategory.map(c => c.category)).toEqual(['Dragon', 'Orbit', 'Area']);
+  });
+
+  it('accepts lowercase keys as well as category tags', () => {
+    const stats = { dragonAffinityDamage: 0.1 };
+    expect(resolveAffinityBonuses(stats, ['dragon']).damage).toBeCloseTo(0.1, 10);
+  });
+
+  it('edpsElemAdditive includes routed affinity damage', () => {
+    const base = {
+      damageMultiplier: 0.5,
+      dragonAffinityDamage: 0.30,
+      orbitAffinityDamage: 0.16,
+    };
+    const withoutAffinity = calculateDerivedStats(base, {});
+    const withAffinity = calculateDerivedStats(base, {
+      edpsElemAdditive: { ...DERIVED_STATS.edpsElemAdditive.config, activeAffinities: ['Dragon', 'Orbit'] },
+    });
+    expect(withAffinity.edpsElemAdditive - withoutAffinity.edpsElemAdditive).toBeCloseTo(0.46, 10);
+  });
+
+  it('offhandCooldownReduction adds affinity CDR to the item value (additive)', () => {
+    const base = {
+      cooldownReduction: 0.10,
+      dragonAffinityCooldown: 0.08,
+      areaAffinityCooldown: 0.07,
+    };
+    const values = calculateDerivedStats(base, {
+      offhandCooldownReduction: { activeAffinities: ['Dragon', 'Area'] },
+    });
+    expect(values.offhandCooldownReduction).toBeCloseTo(0.25, 10);
+  });
+
+  it('offhandCooldownSeconds applies total CDR to the step base', () => {
+    const base = { cooldownReduction: 0.10, dragonAffinityCooldown: 0.10 };
+    const values = calculateDerivedStats(base, {
+      offhandCooldownReduction: { activeAffinities: ['Dragon'] },
+      offhandCooldownSeconds: { baseCooldown: 5.13, abilityName: 'Electric Dragons', offhandCount: 4 },
+    });
+    expect(values.offhandCooldownSeconds).toBeCloseTo(5.13 * 0.8, 10);
+  });
+
+  it('offhandCooldownSeconds is 0 without a detected ability', () => {
+    const values = calculateDerivedStats({}, {});
+    expect(values.offhandCooldownSeconds).toBe(0);
+  });
+});
+
+// =============================================================================
+// Race + level detection
+// =============================================================================
+
+describe('race and level detection', () => {
+  it('parses the E_CharacterRace enum index from the save', () => {
+    expect(parseCharacterRace(saveFixture)).toBe(2);
+  });
+
+  it('parses character level (racial grants cap at level 200)', () => {
+    expect(parseCharacterLevel(saveFixture)).toBe(741);
+    expect(RACE_LEVEL_CAP).toBe(200);
+  });
+
+  it('returns null race for empty saves', () => {
+    expect(parseCharacterRace({})).toBeNull();
+  });
+});

--- a/test/skillEffectAggregator.test.js
+++ b/test/skillEffectAggregator.test.js
@@ -72,8 +72,12 @@ describe('skillEffectAggregator', () => {
     });
 
     it('skips non-attribute grant tags (modifier grants)', () => {
+      // Stat-granting prefixes only — EasyRPG.Items.Modifiers.* behavior
+      // grants must never leak in. OffhandCategories.* are affinity stats.
       const contributions = aggregateSkillEffects(skillTree);
-      expect(contributions.every(c => c.tag.startsWith('EasyRPG.Attributes.'))).toBe(true);
+      expect(contributions.every(c =>
+        c.tag.startsWith('EasyRPG.Attributes.') || c.tag.startsWith('EasyRPG.OffhandCategories.'),
+      )).toBe(true);
     });
   });
 


### PR DESCRIPTION
Generate playerAbilities + mainTreeAffinity data from the new DT_PlayerAbilities / DT_GENERATED_SkillTree_Main exports; register the 12 OffhandCategories affinity damage/cooldown stat pairs (exact-tag patterns so the loose Damage% regex no longer misroutes them into physical damageBonus); aggregate the 236 main-tree affinity nodes; detect equipped offhand proc abilities including AffinityBehaviours modifier-added affinities (ED's AdditionalDragons adds Area) and the offhand-count cooldown steps; route active-affinity damage into edpsElemAdditive and affinity CDR additively into the new offhand cooldown stats; carry affinity tree nodes in v2 character shares; detect race enum index + level (racial grants cap at 200, mapping pending a race table extraction).


Claude-Session: https://claude.ai/code/session_01BxPbfmtsUMK2fzLJnmRZz7