### PR TITLE
Claude/offhand affinities dps 4fva6x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,10 +456,22 @@ Save data at `HostPlayerData_0.Struct.Struct.CharacterSkills_77_*` contains 4 sk
   - `TREE_KEYSTONES` - Manually curated main-tree keystones (proximity, mastery, affinity, utility)
 
 ### Main tree keystones (user-input checklist)
-Opaque node IDs can't be auto-detected. `TREE_KEYSTONES` provides a checklist of notable effects that overlap with monograms or grant unique bonuses:
-- Close/Far Distance (proximity damage), Melee/Ranged Mastery (damage/armor)
+`TREE_KEYSTONES` provides a checklist of notable effects that overlap with monograms or grant unique bonuses:
+- Close/Far Distance (proximity damage)
 - Fire/Arcane/Lightning Affinity (CDR ~35%, damage ~100% additive)
 - Extra inventory slots, extra potions
+
+**Melee/Ranged Mastery nodes are now AUTO-DETECTED** — no checklist needed:
+main-tree nodes granting `EasyRPG.Items.Modifiers.*` tags are generated into
+`mainTreeModifiers.generated.json` (155 nodes; `_TextTag` suffix stripped so
+ids match `MONOGRAM_CALC_CONFIGS`). `collectMainTreeModifierGrants(skillTree)`
+surfaces the allocated ones and `useDerivedStats` feeds them through the
+applied-monogram pipeline: only ids with a calc config fire, and
+`MeleeParagon.*`/`RangedParagon.*` grants are gated by the active weapon
+family. Paragon per-level effects (+2 flat both-types damage, +15 armor, +10
+HP per stance mastery level) stack ADDITIVELY per source — tree node + helmet
+monogram of the same id = 2× per level (`instanceCount` in the paragon calcs).
+These node rows travel in v2 character shares via `st.mh`.
 
 ### Card registry — populated from game data
 `getCardDef()` merges generated data (`src/data/cards.generated.json`, all 81
@@ -665,6 +677,7 @@ node extraction/generate-registries.mjs
 | `src/data/mainTreeAffinity.generated.json` | 236 main-tree affinity nodes: OffhandCategories effects + node names | `skillEffectAggregator.js` main-tree pass |
 | `src/data/playerAbilities.generated.json` | 26 offhand proc abilities: affinities, element, cooldown steps, AffinityBehaviours | `offhandAbilities.js` detection |
 | `src/data/races.generated.json` | 4 races: enum index → name + 6 threshold racial skills with effects | `raceBonuses.js` |
+| `src/data/mainTreeModifiers.generated.json` | 155 main-tree nodes granting `EasyRPG.Items.Modifiers.*` tags (`_TextTag` stripped) | `skillEffectAggregator.js` `collectMainTreeModifierGrants()` |
 
 The generator also emits a drift report (`extraction/out/drift-report.md`,
 gitignored) flagging rollable affix tags `findStatForAttribute()` cannot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ uesave-wasm/pkg/         # Pre-built WASM module (do not modify)
 | Skill→stat contributions (cards/skills/buffs) | `src/utils/skillEffectAggregator.js` |
 | Skill/card/keystone registry | `src/utils/skillTreeRegistry.js` |
 | Offhand ability/affinity detection | `src/utils/offhandAbilities.js` |
+| Racial bonuses | `src/utils/raceBonuses.js` |
 | Styling/theming | `src/styles/index.css` |
 
 ## Tab Architecture
@@ -91,6 +92,10 @@ App.jsx (state holder)
 │   ├── equippedSlotMap   → Items by slot key
 │   └── metadata          → Filename, load time, stanceContext,
 │                           allocatedAttributes, maxHealth, skillTree
+├── itemOverrides   → What-if edits (useItemOverrides), ONE instance shared
+│                     across Items tab (editor) and Character tab (stats).
+│                     Keyed by UNIQUE slot keys ('head', 'ring2', 'offhand3'
+│                     — getUniqueSlotKeyMap); cleared on save load/clear.
 ├── sharedFilterModel → Decoded filter from URL hash (consumed once)
 ├── status/statusType → UI feedback messages
 ├── logs            → Debug log buffer
@@ -327,10 +332,19 @@ them into physical `damageBonus`.
   (`src/data/mainTreeAffinity.generated.json`, with node display names like
   "Dragon Force"). Aggregated by `skillEffectAggregator` alongside health nodes
   and preserved in v2 character shares (`st.mh` carries health + affinity rows).
-- **Race** (pending): races grant affinity bonuses scaling with character level
-  capped at 200 (`RACE_LEVEL_CAP`). Race enum index is detected from the save
-  (`parseCharacterRace` → `metadata.characterRace`; `E_CharacterRace::NewEnumeratorN`),
-  but the index→name/bonus mapping awaits a race table extraction.
+- **Race** (`src/utils/raceBonuses.js` + `src/data/races.generated.json`):
+  each race (Human/Orc/Dwarf/Undead) has 6 racial skills that are THRESHOLD
+  unlocks at character level 10/25/50/100/150/200 (not per-level scaling —
+  `RACE_LEVEL_CAP` 200 is just the last unlock). L25 grants 3 affinity
+  damage% (10% each), L100 the same affinities' CDR (10%), L200 the same
+  affinities again (25%); L10/L50 grant weapon stance damage/crit and L150
+  `EasyRPG.StanceMultiplier.*` ("Damage Augmentation" — provisionally routed
+  additively into the matching stance damage stat). Race enum index is
+  detected from the save (`parseCharacterRace` → `metadata.characterRace`;
+  `E_CharacterRace::NewEnumeratorN`) and travels in character shares (`rc`);
+  bonuses recompute from race+level on load. Affinity pairings: Human
+  Sky/Momentum/Hazard, Orc Explosion/Totem/Dragon, Dwarf Blade/Creature/Area,
+  Undead Projectile/Ground/Orbit.
 
 **Which affinities are active** (`src/utils/offhandAbilities.js`): equipped
 offhand items carry `EasyRPG.Attributes.Abilities.<Ability>.*` stats;
@@ -480,6 +494,8 @@ npm run test:coverage  # With coverage report
 - `test/characterShare.test.js` - Character sharing codec/round-trip tests
 - `test/skillTreeParser.test.js` - Skill tree parsing/registry tests
 - `test/offhandAffinities.test.js` - Offhand ability/affinity detection, tree affinity aggregation, race/level parse
+- `test/raceBonuses.test.js` - Racial skill thresholds, tag resolution, eDPS routing
+- `test/itemOverridesFlow.test.js` - What-if overrides → derived stats (unique slot keys, paragon regression)
 
 ### Key Testable Modules
 | Module | Pure Functions | Notes |
@@ -494,6 +510,7 @@ npm run test:coverage  # With coverage report
 | `skillTreeRegistry.js` | `getWeaponSkillDef()`, `getCraftingSkillDef()`, `getCardDef()` | Skill/card/keystone lookups |
 | `offhandAbilities.js` | `detectEquippedAbilities()`, `getStepCooldown()`, `unionAffinities()` | Offhand ability/affinity detection |
 | `healthParser.js` | `parseCharacterRace()`, `parseCharacterLevel()`, `parseHealthProgression()` | Character identity/progression |
+| `raceBonuses.js` | `getRaceDef()`, `getRaceName()`, `getRacialContributions()` | Racial skill bonuses |
 
 ## Test Fixtures
 
@@ -571,14 +588,16 @@ Options keys: `h`=minHitsPerPool, `c`=closeMinTotal, `w`=includeWeapons, `t`=min
   },
   "cn": "NesPasJeter",                             // character name (omitted if unknown)
   "lv": 560,                                       // character level (omitted if unknown)
-  "cb": 6                                          // campaign bosses defeated 0-6 (omitted if 0)
+  "cb": 6,                                         // campaign bosses defeated 0-6 (omitted if 0)
+  "rc": 2                                          // race enum index (omitted if unknown; 0=Human is valid)
 }
 ```
 
-**Identity fields (`cn`/`lv`/`cb`):** name/level drive the Character header;
+**Identity fields (`cn`/`lv`/`cb`/`rc`):** name/level drive the Character header;
 level + campaign-boss count rebuild the progression health pool on load
 (`calculateLevelHealth(lv) + cb × 100`), so shared builds compute the same max
-health as a direct save load.
+health as a direct save load. Race + level recompute racial skill bonuses on
+the receiving side (they don't travel as stats).
 
 **Stat values:** Raw decimals from save file. Percentages are stored as decimals (0.316 = 31.6%). Flat stats as-is (Armor = 197.57). No conversion — `useDerivedStats` already handles the raw format.
 
@@ -645,6 +664,7 @@ node extraction/generate-registries.mjs
 | `src/data/statusEffects.generated.json` | 170 buffs/debuffs: name, description, duration, stacks, effect values | joined into weapon skills; standalone lookup TBD |
 | `src/data/mainTreeAffinity.generated.json` | 236 main-tree affinity nodes: OffhandCategories effects + node names | `skillEffectAggregator.js` main-tree pass |
 | `src/data/playerAbilities.generated.json` | 26 offhand proc abilities: affinities, element, cooldown steps, AffinityBehaviours | `offhandAbilities.js` detection |
+| `src/data/races.generated.json` | 4 races: enum index → name + 6 threshold racial skills with effects | `raceBonuses.js` |
 
 The generator also emits a drift report (`extraction/out/drift-report.md`,
 gitignored) flagging rollable affix tags `findStatForAttribute()` cannot
@@ -661,6 +681,7 @@ Key source tables in `extraction/data/`:
 - `DT_StatusEffects.json` — buff/status lexicon
 - `DT_GENERATED_SkillTree_Main.json` — main passive tree (1677 nodes; health + affinity extraction)
 - `DT_PlayerAbilities.json` — offhand proc abilities (affinities, AffinityBehaviours, cooldown steps)
+- `DT_PlayerRaces.json` + `E_CharacterRace.json` — race definitions (racial skill unlocks) + enum index→name
 
 ## Integration TODOs
 
@@ -701,14 +722,12 @@ adjusted to game values.
   (`mainTreeAffinity.generated.json`), routed by the equipped offhand abilities'
   affinities, and fed into `edpsElemAdditive` automatically. Manual `affinity`
   config remains as an extra/override.
-- **Racial bonuses — pending race table**: race grants affinity bonuses scaling
-  with character level capped at 200 (`RACE_LEVEL_CAP`). The save's race enum
-  index is detected (`metadata.characterRace`), but `E_CharacterRace`
-  enumerator→name and race→affinity-grant data still need extraction from game
-  files (likely the race blueprints under
-  `/Game/EasySurvivalRPG/Blueprints/Characters/Base/Races/`). The generated
-  `Affinity_*` affix rows (base 3, +0.5/level, canRoll=false) look like the
-  scaling definition those grants use.
+- **Racial bonuses — DONE**: `DT_PlayerRaces` + `E_CharacterRace` are
+  extracted; racial skills are threshold unlocks (see "Offhand Affinities"
+  section) computed from race + level via `raceBonuses.js`. The earlier
+  "scales per level" hypothesis (from the `Affinity_*` affix rows) was wrong.
+  Remaining unknown: whether `EasyRPG.StanceMultiplier.*` applies additively
+  (current model) or multiplicatively to stance damage.
 - **Cooldown application model — provisional**: `offhandCooldownSeconds` uses
   `stepBase × (1 − CDR)`; confirm in-game whether CDR applies that way or as
   `base / (1 + CDR)`, and whether a CDR cap exists.

--- a/extraction/generate-registries.mjs
+++ b/extraction/generate-registries.mjs
@@ -17,6 +17,8 @@
  *   DT_GENERATED_SkillTree_Main.json — optional main-tree UI-node effects
  *   DT_PlayerAbilities.json         — optional offhand ability definitions
  *                                     (affinities, cooldown steps, modifiers)
+ *   DT_PlayerRaces.json + E_CharacterRace.json — optional race definitions
+ *                                     (racial skill unlocks by level)
  *
  * Outputs (committed, consumed by src/):
  *   src/data/attributeBonuses.generated.json
@@ -29,6 +31,7 @@
  *   src/data/mainTreeHealth.generated.json (when the optional export exists)
  *   src/data/mainTreeAffinity.generated.json (when the optional export exists)
  *   src/data/playerAbilities.generated.json (when the optional export exists)
+ *   src/data/races.generated.json (when the optional exports exist)
  *
  * Also prints a drift report comparing affix tags against STAT_REGISTRY
  * patterns (written to extraction/out/drift-report.md, gitignored).
@@ -334,6 +337,51 @@ function generatePlayerAbilities(abilityRows) {
 }
 
 // ---------------------------------------------------------------------------
+// Player races (DT_PlayerRaces + E_CharacterRace enum)
+//
+// Saves store race as an opaque E_CharacterRace byte (NewEnumeratorN); the
+// enum export maps N → display name ("Dwarf"), which uppercases to the race
+// table's row key ("DWARF"). Each race has 6 RacialSkills — threshold unlocks
+// at character level 10/25/50/100/150/200 (NOT per-level scaling; 200 is
+// simply the last unlock) granting weapon damage/crit, offhand affinity
+// damage/CDR, and StanceMultiplier bonuses.
+// ---------------------------------------------------------------------------
+
+function loadEnum(fileName) {
+  const raw = JSON.parse(fs.readFileSync(path.join(DATA_DIR, fileName), 'utf8'));
+  const objects = Array.isArray(raw) ? raw : [raw];
+  const enumExport = objects.find((o) => o?.Type === 'UserDefinedEnum');
+  if (!enumExport) throw new Error(`No UserDefinedEnum found in ${fileName}`);
+  return enumExport;
+}
+
+function generatePlayerRaces(raceRows, raceEnum) {
+  const races = {};
+  for (const entry of raceEnum?.Properties?.DisplayNameMap ?? []) {
+    const match = entry?.Key?.match(/NewEnumerator(\d+)$/);
+    const name = textOf(entry?.Value);
+    if (!match || !name) continue;
+
+    const row = raceRows[name.toUpperCase()];
+    if (!row) {
+      console.warn(`  (race enum ${entry.Key} "${name}" has no DT_PlayerRaces row)`);
+      continue;
+    }
+
+    races[Number(match[1])] = {
+      key: name.toUpperCase(),
+      name,
+      racialSkills: (prop(row, 'RacialSkills') ?? []).map((skill) => ({
+        requiredLevel: prop(skill, 'RequiredLevel') ?? 0,
+        name: textOf(prop(skill, 'GroupName')) ?? '',
+        effects: effectList(prop(skill, 'Attributes')),
+      })),
+    };
+  }
+  return races;
+}
+
+// ---------------------------------------------------------------------------
 // Weapon stance skills (DT_Skills_* — STR_SkillInstance rows)
 //
 // Same row struct as cards: one SkillLevels entry whose BonusAttributes apply
@@ -474,6 +522,12 @@ try {
 } catch {
   console.warn('  (skipping DT_PlayerAbilities.json — not present)');
 }
+let playerRaces = null;
+try {
+  playerRaces = generatePlayerRaces(loadTable('DT_PlayerRaces.json'), loadEnum('E_CharacterRace.json'));
+} catch {
+  console.warn('  (skipping DT_PlayerRaces.json / E_CharacterRace.json — not present)');
+}
 
 const monograms = generateMonograms(attributeRows);
 const attributeBonuses = generateAttributeBonuses(attributeRows);
@@ -517,6 +571,10 @@ if (playerAbilities) {
   fs.writeFileSync(path.join(GEN_DIR, 'playerAbilities.generated.json'),
     JSON.stringify({ ...banner, _source: 'DT_PlayerAbilities', abilities: playerAbilities }, null, 2));
 }
+if (playerRaces) {
+  fs.writeFileSync(path.join(GEN_DIR, 'races.generated.json'),
+    JSON.stringify({ ...banner, _source: 'DT_PlayerRaces + E_CharacterRace enum', races: playerRaces }, null, 2));
+}
 
 console.log(`Attributes:     ${Object.keys(attributeBonuses).length}`);
 console.log(`Monograms:      ${Object.keys(monograms).length}`);
@@ -528,6 +586,7 @@ console.log(`Status effects: ${Object.keys(statusEffects).length}`);
 if (mainTreeHealth) console.log(`Main-tree health nodes: ${Object.keys(mainTreeHealth).length}`);
 if (mainTreeAffinity) console.log(`Main-tree affinity nodes: ${Object.keys(mainTreeAffinity.effectsByRow).length}`);
 if (playerAbilities) console.log(`Player abilities: ${Object.keys(playerAbilities).length}`);
+if (playerRaces) console.log(`Player races: ${Object.keys(playerRaces).length}`);
 
 const { reportPath, missing } = await driftReport(affixes);
 console.log(`Drift:     ${missing} rollable affixes unmatched by STAT_REGISTRY patterns`);

--- a/extraction/generate-registries.mjs
+++ b/extraction/generate-registries.mjs
@@ -270,6 +270,41 @@ function generateMainTreeAffinity(mainTreeRows) {
 }
 
 // ---------------------------------------------------------------------------
+// Main passive tree modifier grants (DT_GENERATED_SkillTree_Main)
+//
+// Some nodes grant EasyRPG.Items.Modifiers.* behavior tags instead of stats —
+// e.g. "Melee Mastery: Damage" grants MeleeParagon.BaseDamage_TextTag (+2
+// flat per stance mastery level, additive with the helmet monogram of the
+// same id). Emitted with the Modifiers prefix and _TextTag suffix stripped so
+// the ids line up with MONOGRAM_CALC_CONFIGS; the app applies only the ids it
+// has calc configs for.
+// ---------------------------------------------------------------------------
+
+function generateMainTreeModifiers(mainTreeRows) {
+  const grantsByRow = {};
+  const namesByRow = {};
+
+  for (const [rowName, row] of Object.entries(mainTreeRows)) {
+    const grants = [];
+    for (const level of prop(row, 'SkillLevels') ?? []) {
+      for (const effect of effectList(prop(level, 'BonusAttributes'))) {
+        if (!effect.tag.startsWith(MODIFIER_PREFIX)) continue;
+        grants.push({
+          id: effect.tag.slice(MODIFIER_PREFIX.length).replace(/_TextTag$/, ''),
+          value: effect.value,
+        });
+      }
+    }
+    if (grants.length > 0) {
+      grantsByRow[rowName] = grants;
+      const name = textOf(prop(row, 'SkillName'));
+      if (name) namesByRow[rowName] = name;
+    }
+  }
+  return { grantsByRow, namesByRow };
+}
+
+// ---------------------------------------------------------------------------
 // Offhand abilities (DT_PlayerAbilities)
 //
 // One row per proc ability (Electric Dragons, Vortex, …). Each carries:
@@ -509,10 +544,12 @@ const cardRows = loadTable('DT_Crystal_Cards_Skills.json');
 const statusRows = loadTable('DT_StatusEffects.json');
 let mainTreeHealth = null;
 let mainTreeAffinity = null;
+let mainTreeModifiers = null;
 try {
   const mainTreeRows = loadTable('DT_GENERATED_SkillTree_Main.json');
   mainTreeHealth = generateMainTreeHealth(mainTreeRows);
   mainTreeAffinity = generateMainTreeAffinity(mainTreeRows);
+  mainTreeModifiers = generateMainTreeModifiers(mainTreeRows);
 } catch {
   console.warn('  (skipping DT_GENERATED_SkillTree_Main.json — not present)');
 }
@@ -575,6 +612,15 @@ if (playerRaces) {
   fs.writeFileSync(path.join(GEN_DIR, 'races.generated.json'),
     JSON.stringify({ ...banner, _source: 'DT_PlayerRaces + E_CharacterRace enum', races: playerRaces }, null, 2));
 }
+if (mainTreeModifiers) {
+  fs.writeFileSync(path.join(GEN_DIR, 'mainTreeModifiers.generated.json'),
+    JSON.stringify({
+      ...banner,
+      _source: 'DT_GENERATED_SkillTree_Main (EasyRPG.Items.Modifiers.* grants, _TextTag stripped)',
+      grantsByRow: mainTreeModifiers.grantsByRow,
+      namesByRow: mainTreeModifiers.namesByRow,
+    }, null, 2));
+}
 
 console.log(`Attributes:     ${Object.keys(attributeBonuses).length}`);
 console.log(`Monograms:      ${Object.keys(monograms).length}`);
@@ -587,6 +633,7 @@ if (mainTreeHealth) console.log(`Main-tree health nodes: ${Object.keys(mainTreeH
 if (mainTreeAffinity) console.log(`Main-tree affinity nodes: ${Object.keys(mainTreeAffinity.effectsByRow).length}`);
 if (playerAbilities) console.log(`Player abilities: ${Object.keys(playerAbilities).length}`);
 if (playerRaces) console.log(`Player races: ${Object.keys(playerRaces).length}`);
+if (mainTreeModifiers) console.log(`Main-tree modifier-grant nodes: ${Object.keys(mainTreeModifiers.grantsByRow).length}`);
 
 const { reportPath, missing } = await driftReport(affixes);
 console.log(`Drift:     ${missing} rollable affixes unmatched by STAT_REGISTRY patterns`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { initWasm } from './utils/wasm';
 import { detectPlatform } from './utils/platform';
 import { useLogger } from './hooks/useLogger';
 import { useItemStore } from './hooks/useItemStore';
+import { useItemOverrides } from './hooks/useItemOverrides';
 import { parseShareFromHash, decodeFilterShare, decodeCharacterShareAny } from './utils/shareUrl';
 import { masteryShareToData, allocatedAttributesShareToData, skillTreeShareToData } from './models/CharacterShareModel';
 
@@ -34,6 +35,11 @@ export default function App() {
 
   // Central item store - all UI reads from here, not from raw saveData
   const itemStore = useItemStore();
+
+  // What-if item overrides (stat edits + added monograms), shared across tabs:
+  // edits made in the Items tab editor must reach the Character tab's stats
+  // panel, and must survive tab switches (tabs unmount when inactive).
+  const itemOverrides = useItemOverrides();
 
   // Initialize WASM and detect platform
   useEffect(() => {
@@ -66,12 +72,14 @@ export default function App() {
       name: decoded.cn ?? '',
       level: decoded.lv ?? 0,
       campaignBossCount: decoded.cb ?? 0,
+      race: decoded.rc ?? null,
     };
     itemStore.loadFromShare(decoded.e ?? [], masteryData, allocatedAttributes, decoded.hp ?? 0, skillTree, identity);
+    itemOverrides.clearAll();
     setActiveTab('character');
     log(`Loaded shared character build${identity.name ? `: ${identity.name}` : ''}`);
     return true;
-  }, [itemStore, log]);
+  }, [itemStore, itemOverrides, log]);
 
   // Paste-import: accepts a full share URL or a bare share code
   const handleImportShare = useCallback(async (text) => {
@@ -125,18 +133,21 @@ export default function App() {
 
   const handleFileLoaded = useCallback((data) => {
     setSaveData(data);
-    // Load items into central store from parsed save data
+    // Load items into central store from parsed save data. What-if overrides
+    // are keyed by slot, so a different character's gear must not inherit them.
     itemStore.loadFromSave(data.parsed || data.raw, data.filename);
+    itemOverrides.clearAll();
     setActiveTab('character');
     log(`🎮 Save loaded: ${data.filename}`);
-  }, [log, itemStore]);
+  }, [log, itemStore, itemOverrides]);
 
   const handleClearSave = useCallback(() => {
     setSaveData(null);
     itemStore.clear();
+    itemOverrides.clearAll();
     setActiveTab('upload');
     log('🗑️ Save data cleared');
-  }, [log, itemStore]);
+  }, [log, itemStore, itemOverrides]);
 
   // Determine which tabs are disabled
   const disabledTabs = [
@@ -162,13 +173,14 @@ export default function App() {
             <CharacterTab
               saveData={saveData}
               itemStore={itemStore}
+              itemOverrides={itemOverrides}
               onClearSave={handleClearSave}
               onLog={log}
               onStatusChange={handleStatusChange}
             />
           )}
           {activeTab === 'items' && saveData && (
-            <ItemsTab saveData={saveData} itemStore={itemStore} onLog={log} />
+            <ItemsTab saveData={saveData} itemStore={itemStore} itemOverrides={itemOverrides} onLog={log} />
           )}
           {activeTab === 'filter' && (saveData || filterTabUnlocked) && (
             <FilterTab

--- a/src/components/character/CharacterPanel.jsx
+++ b/src/components/character/CharacterPanel.jsx
@@ -3,13 +3,18 @@ import { InventorySlot } from './InventorySlot';
 import { StatsPanel } from './StatsPanel';
 import { mapItemsToSlots } from '../../utils/equipmentParser';
 import { useItemOverrides } from '../../hooks/useItemOverrides';
+import { getRaceName } from '../../utils/raceBonuses';
 
-export function CharacterPanel({ characterData }) {
+export function CharacterPanel({ characterData, itemOverrides }) {
+  // What-if edits are made in the Items tab editor; App shares that overrides
+  // instance so they reach this panel's stats. The local instance is only a
+  // fallback for callers that don't pass one (always empty).
+  const localOverrides = useItemOverrides();
   const {
     overrides,
     hasSlotOverrides,
     applyOverridesToItem,
-  } = useItemOverrides();
+  } = itemOverrides || localOverrides;
 
   if (!characterData) return null;
 
@@ -109,34 +114,13 @@ export function CharacterPanel({ characterData }) {
     createSlot('Offhand', 'offhand4', true),
   ];
 
-  // Build modified items for stats calculation
-  // Item model uses baseStats, not attributes
-  const modifiedItems = useMemo(() => {
-    return equippedItems.map(item => {
-      const slotKey = item.slot;
-      if (!slotKey || !hasSlotOverrides(slotKey)) return item;
-
-      // Convert baseStats to attrs format for override application
-      const attrs = (item.baseStats || []).map(s => ({
-        name: s.rawTag || s.stat,
-        value: s.value,
-      }));
-      const modifiedAttrs = applyOverridesToItem(slotKey, attrs);
-      // Convert back to baseStats format
-      const modifiedBaseStats = modifiedAttrs.map(a => ({
-        stat: a.name?.split('.').pop() || a.name,
-        value: a.value,
-        rawTag: a.name,
-      }));
-      return { ...item, baseStats: modifiedBaseStats };
-    });
-  }, [equippedItems, overrides, hasSlotOverrides, applyOverridesToItem]);
-
-  // Modified character data for stats panel
+  // Character data for the stats panel: raw items + the shared overrides map.
+  // useDerivedStats applies removals/mods/added monograms itself, so nothing
+  // is pre-baked here (baking AND passing overrides would double-count mods).
   const modifiedCharacterData = useMemo(() => ({
     ...characterData,
-    equippedItems: modifiedItems,
-  }), [characterData, modifiedItems]);
+    itemOverrides: overrides,
+  }), [characterData, overrides]);
 
   // Render slot helper - click now freezes tooltip instead of opening editor
   const renderSlot = (slot) => (
@@ -157,7 +141,10 @@ export function CharacterPanel({ characterData }) {
       <div className="character-header">
         <span className="character-name">{displayName}</span>
         {characterData.characterLevel > 0 && (
-          <span className="character-class">Level {characterData.characterLevel}</span>
+          <span className="character-class">
+            Level {characterData.characterLevel}
+            {getRaceName(characterData.characterRace) ? ` · ${getRaceName(characterData.characterRace)}` : ''}
+          </span>
         )}
       </div>
 

--- a/src/components/character/CharacterTab.jsx
+++ b/src/components/character/CharacterTab.jsx
@@ -4,7 +4,7 @@ import { CharacterPanel } from './CharacterPanel';
 import { createCharacterSharePayload } from '../../models/CharacterShareModel';
 import { encodeCharacterShareCompressed, buildCharacterShareUrlCompressed } from '../../utils/shareUrl';
 
-export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
+export function CharacterTab({ saveData, itemStore, itemOverrides, onClearSave, onLog }) {
   const [shareFeedback, setShareFeedback] = useState(null);
   const [codeFeedback, setCodeFeedback] = useState(null);
 
@@ -14,6 +14,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
     filename: itemStore.metadata.filename || saveData?.filename,
     characterName: itemStore.metadata.characterName,
     characterLevel: itemStore.metadata.characterLevel,
+    characterRace: itemStore.metadata.characterRace ?? null,
     equippedItems: itemStore.equipped,
     timestamp: itemStore.metadata.loadedAt,
     stanceContext: itemStore.metadata.stanceContext,
@@ -36,6 +37,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
       name: itemStore.metadata?.characterName || '',
       level: itemStore.metadata?.characterLevel || 0,
       campaignBossCount: itemStore.metadata?.healthProgression?.campaignBosses?.length || 0,
+      race: itemStore.metadata?.characterRace ?? null,
     },
   ), [itemStore.equipped, itemStore.metadata, characterData?.stanceContext]);
 
@@ -90,7 +92,7 @@ export function CharacterTab({ saveData, itemStore, onClearSave, onLog }) {
       </div>
 
       {characterData && (
-        <CharacterPanel characterData={characterData} />
+        <CharacterPanel characterData={characterData} itemOverrides={itemOverrides} />
       )}
     </div>
   );

--- a/src/components/items/ItemsTab.jsx
+++ b/src/components/items/ItemsTab.jsx
@@ -3,7 +3,7 @@ import { ItemDetailTooltip } from '../character/ItemDetailTooltip';
 import { ItemEditor } from '../character/ItemEditor';
 import { transformAllItems } from '../../models/itemTransformer';
 import { useItemOverrides } from '../../hooks/useItemOverrides';
-import { inferEquipmentSlot, formatSlotLabel } from '../../utils/equipmentParser';
+import { inferEquipmentSlot, formatSlotLabel, getUniqueSlotKeyMap } from '../../utils/equipmentParser';
 
 const DEFAULT_FILTERS = '';
 
@@ -29,7 +29,7 @@ function parseFilterString(filterStr) {
   return filterStr.split(',').map(pattern => pattern.trim()).filter(Boolean);
 }
 
-export function ItemsTab({ saveData, itemStore, onLog }) {
+export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
   const [filterValue, setFilterValue] = useState(DEFAULT_FILTERS);
   const [filterPatterns, setFilterPatterns] = useState(parseFilterString(DEFAULT_FILTERS));
   const [showEquippedOnly, setShowEquippedOnly] = useState(true);
@@ -39,7 +39,10 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
   const [singleSelectMode, setSingleSelectMode] = useState(true);
   const [selectedSlots, setSelectedSlots] = useState(new Set());
 
-  // Item overrides for editing
+  // Item overrides for editing. App shares one instance across tabs so edits
+  // flow into the Character tab's stats and survive tab switches (this tab
+  // unmounts when inactive). Local instance is a fallback for direct use.
+  const localOverrides = useItemOverrides();
   const {
     overrides,
     hasSlotOverrides,
@@ -55,7 +58,7 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
     addSkillModifier,
     removeSkillModifier,
     clearSlot,
-  } = useItemOverrides();
+  } = itemOverrides || localOverrides;
 
   const equippedLookup = useMemo(() => {
     const lookup = new Map();
@@ -79,6 +82,18 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
       lookup.set(item.rowName, item.slot || 'unknown');
     }
 
+    return lookup;
+  }, [itemStore?.equipped]);
+
+  // Override keys for EQUIPPED items are their unique slot keys ('head',
+  // 'ring2', 'offhand3') — the key space useDerivedStats and the Character
+  // panel read, so edits made here flow into the stats panel. Non-equipped
+  // items fall back to the list key (their edits are tooltip-only).
+  const equippedOverrideKeyLookup = useMemo(() => {
+    const lookup = new Map();
+    for (const [item, slotKey] of getUniqueSlotKeyMap(itemStore?.equipped || [])) {
+      if (item.rowName) lookup.set(item.rowName, slotKey);
+    }
     return lookup;
   }, [itemStore?.equipped]);
 
@@ -177,6 +192,12 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
   }, [onLog]);
 
   // Build item attributes for display, applying any overrides
+  // Overrides for the selected item live under its unique slot key when it's
+  // equipped (so they reach the Character tab stats); list key otherwise.
+  const selectedOverrideKey = selectedItem
+    ? (equippedOverrideKeyLookup.get(selectedItem.rowName) || selectedItemKey)
+    : selectedItemKey;
+
   const itemAttributes = useMemo(() => {
     if (!selectedItem) return [];
 
@@ -186,11 +207,11 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
     }));
 
     // Apply overrides if we have a selected item key
-    if (selectedItemKey && hasSlotOverrides(selectedItemKey)) {
-      return applyOverridesToItem(selectedItemKey, baseAttributes);
+    if (selectedOverrideKey && hasSlotOverrides(selectedOverrideKey)) {
+      return applyOverridesToItem(selectedOverrideKey, baseAttributes);
     }
     return baseAttributes;
-  }, [selectedItem, selectedItemKey, hasSlotOverrides, applyOverridesToItem]);
+  }, [selectedItem, selectedOverrideKey, hasSlotOverrides, applyOverridesToItem]);
 
   // Build item object for ItemEditor (matches character tab format)
   const editorItem = useMemo(() => {
@@ -323,13 +344,14 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
             slotFilteredItems.map((item, index) => {
               const itemKey = `${item.rowName || item.displayName}-${index}`;
               const equippedLabel = equippedLookup.get(item.rowName);
+              const overrideKey = equippedOverrideKeyLookup.get(item.rowName) || itemKey;
               return (
                 <ItemListRow
                   key={itemKey}
                   item={item}
                   equippedLabel={equippedLabel}
                   isSelected={selectedItemKeys.has(itemKey)}
-                  hasOverrides={hasSlotOverrides(itemKey)}
+                  hasOverrides={hasSlotOverrides(overrideKey)}
                   onSelect={() => {
                     setSelectedItem(item);
                     setSelectedItemKey(itemKey);
@@ -356,18 +378,18 @@ export function ItemsTab({ saveData, itemStore, onLog }) {
           {selectedItem && editorItem ? (
             <ItemEditor
               item={editorItem}
-              slotKey={selectedItemKey}
-              slotOverrides={getSlotOverrides(selectedItemKey)}
-              onUpdateMod={(modIndex, updates) => updateMod(selectedItemKey, modIndex, updates)}
-              onAddMod={(mod) => addMod(selectedItemKey, mod)}
-              onRemoveMod={(modIndex) => removeMod(selectedItemKey, modIndex)}
-              onRemoveBaseStat={(index) => removeBaseStat(selectedItemKey, index)}
-              onRestoreBaseStat={(index) => restoreBaseStat(selectedItemKey, index)}
-              onAddMonogram={(mono) => addMonogram(selectedItemKey, mono)}
-              onRemoveMonogram={(index) => removeMonogram(selectedItemKey, index)}
-              onAddSkillModifier={(mod) => addSkillModifier(selectedItemKey, mod)}
-              onRemoveSkillModifier={(index) => removeSkillModifier(selectedItemKey, index)}
-              onClearSlot={() => clearSlot(selectedItemKey)}
+              slotKey={selectedOverrideKey}
+              slotOverrides={getSlotOverrides(selectedOverrideKey)}
+              onUpdateMod={(modIndex, updates) => updateMod(selectedOverrideKey, modIndex, updates)}
+              onAddMod={(mod) => addMod(selectedOverrideKey, mod)}
+              onRemoveMod={(modIndex) => removeMod(selectedOverrideKey, modIndex)}
+              onRemoveBaseStat={(index) => removeBaseStat(selectedOverrideKey, index)}
+              onRestoreBaseStat={(index) => restoreBaseStat(selectedOverrideKey, index)}
+              onAddMonogram={(mono) => addMonogram(selectedOverrideKey, mono)}
+              onRemoveMonogram={(index) => removeMonogram(selectedOverrideKey, index)}
+              onAddSkillModifier={(mod) => addSkillModifier(selectedOverrideKey, mod)}
+              onRemoveSkillModifier={(index) => removeSkillModifier(selectedOverrideKey, index)}
+              onClearSlot={() => clearSlot(selectedOverrideKey)}
               onClose={handleCloseEditor}
               currentMonograms={selectedItem?.monograms || []}
               currentSkillModifiers={selectedItem?.skillModifiers || []}

--- a/src/data/mainTreeModifiers.generated.json
+++ b/src/data/mainTreeModifiers.generated.json
@@ -1,0 +1,1093 @@
+{
+  "_generated": "by extraction/generate-registries.mjs — do not edit by hand",
+  "_source": "DT_GENERATED_SkillTree_Main (EasyRPG.Items.Modifiers.* grants, _TextTag stripped)",
+  "grantsByRow": {
+    "UI_SkillTreeNode_Large_15": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Large_78": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.04
+      }
+    ],
+    "UI_SkillTreeNode_Large_81": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_488": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.02
+      }
+    ],
+    "UI_SkillTreeNode_Small_490": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.02
+      }
+    ],
+    "UI_SkillTreeNode_Small_491": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.02
+      }
+    ],
+    "UI_SkillTreeNode_Small_493": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.02
+      }
+    ],
+    "UI_SkillTreeNode_Large_96": [
+      {
+        "id": "DistanceProcsDamage_Near",
+        "value": 0.5
+      }
+    ],
+    "UI_SkillTreeNode_Large_97": [
+      {
+        "id": "DistanceProcsDamage",
+        "value": 0.5
+      }
+    ],
+    "UI_SkillTreeNode_Large_98": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack.Large",
+        "value": 0.0003
+      }
+    ],
+    "UI_SkillTreeNode_Large_99": [
+      {
+        "id": "Bloodlust.CritBonusPerStack.Large",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Large_101": [
+      {
+        "id": "ChargedSecondaryBuff.Armor",
+        "value": 250
+      }
+    ],
+    "UI_SkillTreeNode_Large_103": [
+      {
+        "id": "MeleeParagon.BaseDamage",
+        "value": 2
+      }
+    ],
+    "UI_SkillTreeNode_Large_135": [
+      {
+        "id": "Colossus.ElementalBonus.Large.Fire",
+        "value": 0.5
+      }
+    ],
+    "UI_SkillTreeNode_Large_106": [
+      {
+        "id": "SecondaryAttackDoubleDamage.Large",
+        "value": 0.5
+      }
+    ],
+    "UI_SkillTreeNode_Large_107": [
+      {
+        "id": "RangedParagon.BaseDamage",
+        "value": 2
+      }
+    ],
+    "UI_SkillTreeNode_Large_108": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Large",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Large_109": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%.Large",
+        "value": 0.015
+      }
+    ],
+    "UI_SkillTreeNode_Large_110": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%.Large",
+        "value": 0.002
+      }
+    ],
+    "UI_SkillTreeNode_Large_112": [
+      {
+        "id": "DamageCircle.ExtraDamage",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Large_113": [
+      {
+        "id": "DamageCircle.BiggerRadius",
+        "value": 0.5
+      }
+    ],
+    "UI_SkillTreeNode_Large_114": [
+      {
+        "id": "RangedParagon.Armor",
+        "value": 15
+      }
+    ],
+    "UI_SkillTreeNode_Large_115": [
+      {
+        "id": "MeleeParagon.Armor",
+        "value": 15
+      }
+    ],
+    "UI_SkillTreeNode_Large_116": [
+      {
+        "id": "AttackSpeedMultiplier",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Large_117": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 2
+      }
+    ],
+    "UI_SkillTreeNode_Large_118": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack.Large",
+        "value": 0.02
+      }
+    ],
+    "UI_SkillTreeNode_Large_119": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack.Large",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_667": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_668": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_669": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_670": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_671": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_672": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_673": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_674": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_675": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_676": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_677": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_678": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_679": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_680": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_681": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_682": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_683": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_684": [
+      {
+        "id": "Bloodlust.DamageReductionPerStack",
+        "value": 0.00005
+      }
+    ],
+    "UI_SkillTreeNode_Small_687": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_688": [
+      {
+        "id": "Bloodlust.CritBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_717": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_718": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_719": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_720": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_721": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_722": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_723": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_724": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_725": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_726": [
+      {
+        "id": "ChargedSecondaryBuff.Armor.Small",
+        "value": 25
+      }
+    ],
+    "UI_SkillTreeNode_Small_727": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_728": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_729": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_730": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_731": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_732": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_733": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_734": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_735": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_736": [
+      {
+        "id": "SecondaryAttackDoubleDamage",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_971": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_972": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_754": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_755": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_756": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_757": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_758": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_759": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_760": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_761": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_762": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_763": [
+      {
+        "id": "Colossus.HpForEliteKill.SkillTree.Small.Text",
+        "value": 0.2
+      }
+    ],
+    "UI_SkillTreeNode_Small_795": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_796": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_797": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_798": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_799": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_800": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_801": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_802": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_803": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_804": [
+      {
+        "id": "Phasing.PhasingTrance.Damage%",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_805": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_806": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_807": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_808": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_809": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_810": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_811": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_812": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_813": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_814": [
+      {
+        "id": "Phasing.PhasingTrance.HealthRegan%",
+        "value": 0.0005
+      }
+    ],
+    "UI_SkillTreeNode_Small_823": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_824": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_825": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_826": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_827": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_828": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_829": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_830": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_831": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_832": [
+      {
+        "id": "DamageCircle.BonusRadius",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_833": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_834": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_835": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_836": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_837": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_838": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_839": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_840": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_841": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_842": [
+      {
+        "id": "DamageCircle.BonusArmor%",
+        "value": 0.01
+      }
+    ],
+    "UI_SkillTreeNode_Small_853": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_854": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_855": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_856": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_857": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_858": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 1
+      }
+    ],
+    "UI_SkillTreeNode_Small_859": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 2
+      }
+    ],
+    "UI_SkillTreeNode_Small_860": [
+      {
+        "id": "AdditionalPotionSlots.1",
+        "value": 2
+      }
+    ],
+    "UI_SkillTreeNode_Small_869": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_870": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_871": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_872": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_873": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_874": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_875": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_876": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_877": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_878": [
+      {
+        "id": "Shroud.ExposedStrike.DamageBonusPerStack",
+        "value": 0.001
+      }
+    ],
+    "UI_SkillTreeNode_Small_879": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_880": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_881": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_882": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_883": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_884": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_885": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_886": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_887": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_888": [
+      {
+        "id": "Shroud.ExposedStrike.LifeStealPerStack",
+        "value": 0.0001
+      }
+    ],
+    "UI_SkillTreeNode_Small_973": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_974": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_975": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_976": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_977": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_978": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_979": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ],
+    "UI_SkillTreeNode_Small_980": [
+      {
+        "id": "Colossus.ElementalBonus.Small.Fire",
+        "value": 0.05
+      }
+    ]
+  },
+  "namesByRow": {
+    "UI_SkillTreeNode_Large_15": "Beastslayer",
+    "UI_SkillTreeNode_Large_78": "Rapid Combat",
+    "UI_SkillTreeNode_Large_81": "Beast Mode",
+    "UI_SkillTreeNode_Small_488": "Swiftness",
+    "UI_SkillTreeNode_Small_490": "Swiftness",
+    "UI_SkillTreeNode_Small_491": "Swiftness",
+    "UI_SkillTreeNode_Small_493": "Swiftness",
+    "UI_SkillTreeNode_Large_96": "Proximity Destruction",
+    "UI_SkillTreeNode_Large_97": "Distance Demolition",
+    "UI_SkillTreeNode_Large_98": "Tough Exterior",
+    "UI_SkillTreeNode_Large_99": "Blood Boil",
+    "UI_SkillTreeNode_Large_101": "Protective Strike",
+    "UI_SkillTreeNode_Large_103": "Melee Mastery: Damage",
+    "UI_SkillTreeNode_Large_135": "Fury of the Elements",
+    "UI_SkillTreeNode_Large_106": "Charged Strike",
+    "UI_SkillTreeNode_Large_107": "Ranged Mastery: Damage",
+    "UI_SkillTreeNode_Large_108": "Infuriated Health",
+    "UI_SkillTreeNode_Large_109": "Phase Zen",
+    "UI_SkillTreeNode_Large_110": "Phasing Transcendence",
+    "UI_SkillTreeNode_Large_112": "Void Intensity",
+    "UI_SkillTreeNode_Large_113": "Endless Void",
+    "UI_SkillTreeNode_Large_114": "Ranged Mastery: Armor",
+    "UI_SkillTreeNode_Large_115": "Melee Mastery: Armor",
+    "UI_SkillTreeNode_Large_116": "Beastslayer",
+    "UI_SkillTreeNode_Large_117": "More Potions",
+    "UI_SkillTreeNode_Large_118": "Uncovered Assault",
+    "UI_SkillTreeNode_Large_119": "Vampiric Strikes",
+    "UI_SkillTreeNode_Small_667": "Thickened Skin",
+    "UI_SkillTreeNode_Small_668": "Thickened Skin",
+    "UI_SkillTreeNode_Small_669": "Thickened Skin",
+    "UI_SkillTreeNode_Small_670": "Thickened Skin",
+    "UI_SkillTreeNode_Small_671": "Thickened Skin",
+    "UI_SkillTreeNode_Small_672": "Thickened Skin",
+    "UI_SkillTreeNode_Small_673": "Thickened Skin",
+    "UI_SkillTreeNode_Small_674": "Thickened Skin",
+    "UI_SkillTreeNode_Small_675": "Blood Rage",
+    "UI_SkillTreeNode_Small_676": "Blood Rage",
+    "UI_SkillTreeNode_Small_677": "Blood Rage",
+    "UI_SkillTreeNode_Small_678": "Blood Rage",
+    "UI_SkillTreeNode_Small_679": "Blood Rage",
+    "UI_SkillTreeNode_Small_680": "Blood Rage",
+    "UI_SkillTreeNode_Small_681": "Blood Rage",
+    "UI_SkillTreeNode_Small_682": "Blood Rage",
+    "UI_SkillTreeNode_Small_683": "Thickened Skin",
+    "UI_SkillTreeNode_Small_684": "Thickened Skin",
+    "UI_SkillTreeNode_Small_687": "Blood Rage",
+    "UI_SkillTreeNode_Small_688": "Blood Rage",
+    "UI_SkillTreeNode_Small_717": "Charged Defense",
+    "UI_SkillTreeNode_Small_718": "Charged Defense",
+    "UI_SkillTreeNode_Small_719": "Charged Defense",
+    "UI_SkillTreeNode_Small_720": "Charged Defense",
+    "UI_SkillTreeNode_Small_721": "Charged Defense",
+    "UI_SkillTreeNode_Small_722": "Charged Defense",
+    "UI_SkillTreeNode_Small_723": "Charged Defense",
+    "UI_SkillTreeNode_Small_724": "Charged Defense",
+    "UI_SkillTreeNode_Small_725": "Charged Defense",
+    "UI_SkillTreeNode_Small_726": "Charged Defense",
+    "UI_SkillTreeNode_Small_727": "Charged Strike",
+    "UI_SkillTreeNode_Small_728": "Charged Strike",
+    "UI_SkillTreeNode_Small_729": "Charged Strike",
+    "UI_SkillTreeNode_Small_730": "Charged Strike",
+    "UI_SkillTreeNode_Small_731": "Charged Strike",
+    "UI_SkillTreeNode_Small_732": "Charged Strike",
+    "UI_SkillTreeNode_Small_733": "Charged Strike",
+    "UI_SkillTreeNode_Small_734": "Charged Strike",
+    "UI_SkillTreeNode_Small_735": "Charged Strike",
+    "UI_SkillTreeNode_Small_736": "Charged Strike",
+    "UI_SkillTreeNode_Small_971": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_972": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_754": "Healthy Fury",
+    "UI_SkillTreeNode_Small_755": "Healthy Fury",
+    "UI_SkillTreeNode_Small_756": "Healthy Fury",
+    "UI_SkillTreeNode_Small_757": "Healthy Fury",
+    "UI_SkillTreeNode_Small_758": "Healthy Fury",
+    "UI_SkillTreeNode_Small_759": "Healthy Fury",
+    "UI_SkillTreeNode_Small_760": "Healthy Fury",
+    "UI_SkillTreeNode_Small_761": "Healthy Fury",
+    "UI_SkillTreeNode_Small_762": "Healthy Fury",
+    "UI_SkillTreeNode_Small_763": "Healthy Fury",
+    "UI_SkillTreeNode_Small_795": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_796": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_797": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_798": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_799": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_800": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_801": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_802": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_803": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_804": "Phasing Transcendence",
+    "UI_SkillTreeNode_Small_805": "Phase Zen",
+    "UI_SkillTreeNode_Small_806": "Phase Zen",
+    "UI_SkillTreeNode_Small_807": "Phase Zen",
+    "UI_SkillTreeNode_Small_808": "Phase Zen",
+    "UI_SkillTreeNode_Small_809": "Phase Zen",
+    "UI_SkillTreeNode_Small_810": "Phase Zen",
+    "UI_SkillTreeNode_Small_811": "Phase Zen",
+    "UI_SkillTreeNode_Small_812": "Phase Zen",
+    "UI_SkillTreeNode_Small_813": "Phase Zen",
+    "UI_SkillTreeNode_Small_814": "Phase Zen",
+    "UI_SkillTreeNode_Small_823": "Unholy Reach",
+    "UI_SkillTreeNode_Small_824": "Unholy Reach",
+    "UI_SkillTreeNode_Small_825": "Unholy Reach",
+    "UI_SkillTreeNode_Small_826": "Unholy Reach",
+    "UI_SkillTreeNode_Small_827": "Unholy Reach",
+    "UI_SkillTreeNode_Small_828": "Unholy Reach",
+    "UI_SkillTreeNode_Small_829": "Unholy Reach",
+    "UI_SkillTreeNode_Small_830": "Unholy Reach",
+    "UI_SkillTreeNode_Small_831": "Unholy Reach",
+    "UI_SkillTreeNode_Small_832": "Unholy Reach",
+    "UI_SkillTreeNode_Small_833": "Void Armor",
+    "UI_SkillTreeNode_Small_834": "Void Armor",
+    "UI_SkillTreeNode_Small_835": "Void Armor",
+    "UI_SkillTreeNode_Small_836": "Void Armor",
+    "UI_SkillTreeNode_Small_837": "Void Armor",
+    "UI_SkillTreeNode_Small_838": "Void Armor",
+    "UI_SkillTreeNode_Small_839": "Void Armor",
+    "UI_SkillTreeNode_Small_840": "Void Armor",
+    "UI_SkillTreeNode_Small_841": "Void Armor",
+    "UI_SkillTreeNode_Small_842": "Void Armor",
+    "UI_SkillTreeNode_Small_853": "More Potions",
+    "UI_SkillTreeNode_Small_854": "More Potions",
+    "UI_SkillTreeNode_Small_855": "More Potions",
+    "UI_SkillTreeNode_Small_856": "More Potions",
+    "UI_SkillTreeNode_Small_857": "More Potions",
+    "UI_SkillTreeNode_Small_858": "More Potions",
+    "UI_SkillTreeNode_Small_859": "More Potions",
+    "UI_SkillTreeNode_Small_860": "More Potions",
+    "UI_SkillTreeNode_Small_869": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_870": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_871": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_872": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_873": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_874": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_875": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_876": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_877": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_878": "Uncovered Attack",
+    "UI_SkillTreeNode_Small_879": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_880": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_881": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_882": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_883": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_884": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_885": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_886": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_887": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_888": "Leaching Strikes",
+    "UI_SkillTreeNode_Small_973": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_974": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_975": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_976": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_977": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_978": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_979": "Fury of the Elements",
+    "UI_SkillTreeNode_Small_980": "Fury of the Elements"
+  }
+}

--- a/src/data/races.generated.json
+++ b/src/data/races.generated.json
@@ -1,0 +1,446 @@
+{
+  "_generated": "by extraction/generate-registries.mjs — do not edit by hand",
+  "_source": "DT_PlayerRaces + E_CharacterRace enum",
+  "races": {
+    "0": {
+      "key": "HUMAN",
+      "name": "Human",
+      "racialSkills": [
+        {
+          "requiredLevel": 10,
+          "name": "Disciplined Edge",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Spear%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Archery.Damage%",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 25,
+          "name": "Awakened Spirit",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 50,
+          "name": "Tactical Strikes",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.SpearCritcalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.SpearCritcalChance%",
+              "value": 0.05
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Archery.CriticalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Archery.CriticalChance%",
+              "value": 0.05
+            }
+          ]
+        },
+        {
+          "requiredLevel": 100,
+          "name": "Rhythm of the Cosmos",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Sky.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Charging.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Hazard.CooldownBonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 150,
+          "name": "Master’s Execution",
+          "effects": [
+            {
+              "tag": "EasyRPG.StanceMultiplier.Spear",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.StanceMultiplier.Archery",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 200,
+          "name": "Grandmaster’s Legacy",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Sky.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Charging.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Hazard.Damage%Bonus",
+              "value": 0.25
+            }
+          ]
+        }
+      ]
+    },
+    "1": {
+      "key": "ORC",
+      "name": "Orc",
+      "racialSkills": [
+        {
+          "requiredLevel": 10,
+          "name": "Brutal Foundation",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.TwoHanded%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Fists.Damage%",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 25,
+          "name": "Primal Awakening",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 50,
+          "name": "Unchained Fury",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.TwoHandCritcalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.TwoHandCritcalChance%",
+              "value": 0.05
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Fists.CriticalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Fists.CriticalChance%",
+              "value": 0.05
+            }
+          ]
+        },
+        {
+          "requiredLevel": 100,
+          "name": "Blood of the Ancients",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Explosion.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Totem.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Dragon.CooldownBonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 150,
+          "name": "Tribal Wrath",
+          "effects": [
+            {
+              "tag": "EasyRPG.StanceMultiplier.Axes",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.StanceMultiplier.Fists",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 200,
+          "name": "Warlord's Dominion",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Explosion.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Totem.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Dragon.Damage%Bonus",
+              "value": 0.25
+            }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "key": "DWARF",
+      "name": "Dwarf",
+      "racialSkills": [
+        {
+          "requiredLevel": 10,
+          "name": "Ancestral Craft",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Magery.Damage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.PoleArm%",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 25,
+          "name": "Runes of Power",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 50,
+          "name": "Iron Nerves",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.PoleArmCriticalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.PoleArmCriticalChance%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Magery.CriticalDamage%",
+              "value": 0.05
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Magery.CriticalChance%",
+              "value": 0.05
+            }
+          ]
+        },
+        {
+          "requiredLevel": 100,
+          "name": "Pulse of the Forge",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Blade.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Creature.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Area.CooldownBonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 150,
+          "name": "Mountain’s Grasp",
+          "effects": [
+            {
+              "tag": "EasyRPG.StanceMultiplier.Mauls",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.StanceMultiplier.Magery",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 200,
+          "name": "Runecrafted Legacy",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Blade.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Creature.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Area.Damage%Bonus",
+              "value": 0.25
+            }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "key": "UNDEAD",
+      "name": "Undead",
+      "racialSkills": [
+        {
+          "requiredLevel": 10,
+          "name": "Cold Resolve",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.OneHanded%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Scythe.Damage%",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 25,
+          "name": "Dark Ascension",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 50,
+          "name": "Final Judgement",
+          "effects": [
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.OneHandCritcalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.OneHandedCritcalChance%",
+              "value": 0.05
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Scythe.CriticalDamage%",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.Attributes.DamageSystem.Damage.Scythe.CriticalChance%",
+              "value": 0.05
+            }
+          ]
+        },
+        {
+          "requiredLevel": 100,
+          "name": "Cadence of the Dead",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Projectile.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Ground.CooldownBonus",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Orbit.CooldownBonus",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 150,
+          "name": "Revenant’s Force",
+          "effects": [
+            {
+              "tag": "EasyRPG.StanceMultiplier.Swords",
+              "value": 0.1
+            },
+            {
+              "tag": "EasyRPG.StanceMultiplier.Scythe",
+              "value": 0.1
+            }
+          ]
+        },
+        {
+          "requiredLevel": 200,
+          "name": "Ethereal Surge",
+          "effects": [
+            {
+              "tag": "EasyRPG.OffhandCategories.Projectile.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Ground.Damage%Bonus",
+              "value": 0.25
+            },
+            {
+              "tag": "EasyRPG.OffhandCategories.Orbit.Damage%Bonus",
+              "value": 0.25
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -4,7 +4,7 @@ import { getStatType } from '../utils/statBuckets.js';
 import { STAT_REGISTRY } from '../utils/statRegistry.js';
 import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
 import { inferWeaponStance, getUniqueSlotKeyMap } from '../utils/equipmentParser.js';
-import { aggregateSkillEffects, hasWeaponSkillData } from '../utils/skillEffectAggregator.js';
+import { aggregateSkillEffects, hasWeaponSkillData, collectMainTreeModifierGrants } from '../utils/skillEffectAggregator.js';
 import { detectEquippedAbilities, getStepCooldown, unionAffinities } from '../utils/offhandAbilities.js';
 import { getRacialContributions } from '../utils/raceBonuses.js';
 import { ATTRIBUTE_BONUSES } from '../utils/attributeBonuses.js';
@@ -203,8 +203,27 @@ export function useDerivedStats(options = {}) {
       }
     }
 
+    // Main-tree modifier grants (e.g. Melee Mastery: Damage = the
+    // MeleeParagon.BaseDamage effect, +2 flat per mastery level). These stack
+    // ADDITIVELY with helmet monograms of the same id — the shared
+    // instanceCount makes the paragon calcs scale per source. Only ids with a
+    // calc config matter; Melee/Ranged grants are gated by the active weapon
+    // family ("While using a melee/ranged weapon…").
+    const family = stanceContext?.activeStance?.monogramFamily || null;
+    for (const grant of collectMainTreeModifierGrants(skillTree)) {
+      if (!MONOGRAM_CALC_CONFIGS[grant.id]) continue;
+      if (family && grant.id.startsWith('MeleeParagon') && family !== 'melee') continue;
+      if (family && grant.id.startsWith('RangedParagon') && family !== 'ranged') continue;
+      monograms.push({
+        id: grant.id,
+        value: 1,
+        source: 'mainTree',
+        itemSlot: 'skilltree',
+      });
+    }
+
     return monograms;
-  }, [equippedItems, itemOverrides]);
+  }, [equippedItems, itemOverrides, skillTree, stanceContext]);
 
   // Count how many instances of each monogram ID are applied
   const monogramInstanceCounts = useMemo(() => {

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -3,9 +3,10 @@ import { calculateDerivedStats, calculateDerivedStatsDetailed, DERIVED_STATS, LA
 import { getStatType } from '../utils/statBuckets.js';
 import { STAT_REGISTRY } from '../utils/statRegistry.js';
 import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
-import { inferWeaponStance } from '../utils/equipmentParser.js';
+import { inferWeaponStance, getUniqueSlotKeyMap } from '../utils/equipmentParser.js';
 import { aggregateSkillEffects, hasWeaponSkillData } from '../utils/skillEffectAggregator.js';
 import { detectEquippedAbilities, getStepCooldown, unionAffinities } from '../utils/offhandAbilities.js';
+import { getRacialContributions } from '../utils/raceBonuses.js';
 import { ATTRIBUTE_BONUSES } from '../utils/attributeBonuses.js';
 
 // Re-export for backward compatibility
@@ -24,7 +25,11 @@ export { MONOGRAM_CALC_CONFIGS } from '../utils/monogramConfigs.js';
  * @returns {Object} Aggregated and calculated stats
  */
 export function useDerivedStats(options = {}) {
-  const { equippedItems = [], itemOverrides = {}, characterStats = {}, stanceContext = null, maxHealth = 0, skillTree = null } = options;
+  const {
+    equippedItems = [], itemOverrides = {}, characterStats = {},
+    stanceContext = null, maxHealth = 0, skillTree = null,
+    characterRace = null, characterLevel = 0,
+  } = options;
 
   // Aggregate base stats from all equipped items WITH source tracking
   // Returns { [statId]: { total: number, sources: [{ itemName, slot, value }] } }
@@ -63,6 +68,21 @@ export function useDerivedStats(options = {}) {
       }
     }
 
+    // Racial skill contributions: threshold unlocks by character level
+    // (weapon damage/crit, offhand affinity damage/CDR, stance multipliers)
+    for (const contrib of getRacialContributions(characterRace, characterLevel)) {
+      if (!stats[contrib.statId]) {
+        stats[contrib.statId] = { total: 0, sources: [] };
+      }
+      stats[contrib.statId].total += contrib.value;
+      stats[contrib.statId].sources.push({
+        itemName: contrib.source,
+        slot: 'race',
+        value: contrib.value,
+        sourceType: 'race',
+      });
+    }
+
     // Active stance mastery approximation: +1% stance damage per mastery
     // level. Only used when real skill data is unavailable (shared builds) —
     // otherwise the paragon node's actual per-level effects cover it.
@@ -81,6 +101,10 @@ export function useDerivedStats(options = {}) {
       });
     }
 
+    // Overrides are keyed by unique slot keys ('ring2', 'offhand3') — the same
+    // key space the Items tab editor writes and the Character panel displays.
+    const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
+
     for (const item of equippedItems) {
       // Get base stats from any of the supported formats:
       //   - item.baseStats (direct from Item model via extractEquippedItems)
@@ -89,7 +113,7 @@ export function useDerivedStats(options = {}) {
       const baseStats = item?.baseStats || item?.model?.baseStats || item?.attributes;
       if (!baseStats || !Array.isArray(baseStats)) continue;
 
-      const slotKey = item.slotKey || item.slot || '';
+      const slotKey = uniqueSlotKeys.get(item) || item.slotKey || item.slot || '';
       const itemName = item?.displayName || item?.model?.displayName || item?.name || slotKey;
       const overrides = itemOverrides[slotKey] || {};
       const removedIndices = overrides.removedIndices || [];
@@ -133,7 +157,7 @@ export function useDerivedStats(options = {}) {
     }
 
     return stats;
-  }, [equippedItems, itemOverrides, characterStats, stanceContext, skillTree]);
+  }, [equippedItems, itemOverrides, characterStats, stanceContext, skillTree, characterRace, characterLevel]);
 
   // Flatten to simple { [statId]: total } for backward compatibility
   const aggregatedBaseStats = useMemo(() => {
@@ -150,6 +174,7 @@ export function useDerivedStats(options = {}) {
   //   - item.model.monograms (nested model format)
   const appliedMonograms = useMemo(() => {
     const monograms = [];
+    const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
 
     for (const item of equippedItems) {
       // Monograms from item (direct or nested model)
@@ -165,8 +190,8 @@ export function useDerivedStats(options = {}) {
         }
       }
 
-      // Added monograms from overrides
-      const slotKey = item?.slotKey || item?.slot || '';
+      // Added monograms from overrides (keyed by unique slot key)
+      const slotKey = uniqueSlotKeys.get(item) || item?.slotKey || item?.slot || '';
       const overrides = itemOverrides[slotKey] || {};
       for (const mono of overrides.monograms || []) {
         monograms.push({

--- a/src/hooks/useItemStore.js
+++ b/src/hooks/useItemStore.js
@@ -125,6 +125,9 @@ export function useItemStore() {
       loadedAt: new Date().toISOString(),
       characterName: identity?.name || '',
       characterLevel: level,
+      // Race enum index from the share (`rc`); racial skill bonuses recompute
+      // from race + level on the receiving side, so they don't travel as stats
+      characterRace: identity?.race ?? null,
       stanceContext: convertMasteryToStanceContext(masteryData),
       allocatedAttributes: allocatedAttributes || {},
       characterStats,

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -20,7 +20,7 @@ import {
 } from '../utils/shareCodec.js';
 import { findStatForAttribute, getStatById } from '../utils/statRegistry.js';
 import { getWeaponSkillDef } from '../utils/skillTreeRegistry.js';
-import { hasMainTreeHealthEffect, hasMainTreeAffinityEffect } from '../utils/skillEffectAggregator.js';
+import { hasMainTreeHealthEffect, hasMainTreeAffinityEffect, hasMainTreeModifierGrant } from '../utils/skillEffectAggregator.js';
 import { createEmptySkillTreeData } from './SkillTree.js';
 import { createEmptyItem } from './Item.js';
 
@@ -167,11 +167,14 @@ export function createSkillTreeShare(skillTree) {
   if (ws.length > 0) st.ws = ws;
 
   // Main-tree rows are normally too numerous for a share URL. Preserve only
-  // the generated nodes with known effects (health + offhand affinity) so
-  // shared health and affinity eDPS remain consistent with an imported save.
+  // the generated nodes with known effects (health, offhand affinity,
+  // modifier grants like the Melee/Ranged Mastery paragon nodes) so shared
+  // builds compute the same health/affinity/paragon numbers as a save import.
   const mainNodes = (skillTree.mainTree ?? [])
     .filter(skill => skill.rowName
-      && (hasMainTreeHealthEffect(skill.rowName) || hasMainTreeAffinityEffect(skill.rowName)))
+      && (hasMainTreeHealthEffect(skill.rowName)
+        || hasMainTreeAffinityEffect(skill.rowName)
+        || hasMainTreeModifierGrant(skill.rowName)))
     .map(skill => skill.rowName);
   if (mainNodes.length > 0) st.mh = mainNodes;
 
@@ -202,7 +205,9 @@ export function skillTreeShareToData(st) {
   }
 
   for (const rowName of st.mh || []) {
-    if (!rowName || !(hasMainTreeHealthEffect(rowName) || hasMainTreeAffinityEffect(rowName))) continue;
+    if (!rowName || !(hasMainTreeHealthEffect(rowName)
+      || hasMainTreeAffinityEffect(rowName)
+      || hasMainTreeModifierGrant(rowName))) continue;
     tree.mainTree.push({ rowName, level: 1, category: 'main' });
   }
 

--- a/src/models/CharacterShareModel.js
+++ b/src/models/CharacterShareModel.js
@@ -286,6 +286,9 @@ export function createCharacterSharePayload(equippedItems, stanceContext = null,
   if (identity?.name) payload.cn = identity.name;
   if (identity?.level > 0) payload.lv = identity.level;
   if (identity?.campaignBossCount > 0) payload.cb = identity.campaignBossCount;
+  // Race enum index (0 = Human is meaningful, so only null/undefined omit).
+  // Level + race let the receiving side recompute racial skill bonuses.
+  if (identity?.race != null) payload.rc = identity.race;
 
   return payload;
 }

--- a/src/utils/derivedStats.js
+++ b/src/utils/derivedStats.js
@@ -1402,6 +1402,10 @@ export const DERIVED_STATS = {
     format: v => v.toFixed(0),
     description: 'Paragon level (from stance XP, 3500 per level)',
   },
+  // Paragon per-level effects stack ADDITIVELY per source: the helmet
+  // monogram and the main-tree Melee/Ranged Mastery node grant the same
+  // effect id, so instanceCount (set by useDerivedStats from the applied
+  // count) multiplies the per-level value — tree + helmet = 2× per level.
   paragonArmorBonus: {
     id: 'paragonArmorBonus',
     name: 'Paragon Armor',
@@ -1414,10 +1418,10 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.paragonArmorBonus.config;
       const level = stats.paragonLevel || 0;
-      return level * config.armorPerLevel;
+      return level * config.armorPerLevel * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}`,
-    description: 'Flat armor from Paragon level (15 per level)',
+    description: 'Flat armor from Paragon level (15 per level per source; helmet + tree node stack)',
   },
   paragonDamageBonus: {
     id: 'paragonDamageBonus',
@@ -1431,10 +1435,10 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.paragonDamageBonus.config;
       const level = stats.paragonLevel || 0;
-      return level * config.damagePerLevel;
+      return level * config.damagePerLevel * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}`,
-    description: 'Flat damage from Paragon level (2 per level)',
+    description: 'Flat damage (both types) from Paragon level (2 per level per source; helmet + tree node stack)',
   },
   paragonHpBonus: {
     id: 'paragonHpBonus',
@@ -1448,10 +1452,10 @@ export const DERIVED_STATS = {
     calculate: (stats, cfg) => {
       const config = cfg || DERIVED_STATS.paragonHpBonus.config;
       const level = stats.paragonLevel || 0;
-      return level * config.hpPerLevel;
+      return level * config.hpPerLevel * (config.instanceCount || 1);
     },
     format: v => `+${v.toFixed(0)}`,
-    description: 'Flat HP from Paragon level (10 per level)',
+    description: 'Flat HP from Paragon level (10 per level per source)',
   },
 
   // ---------------------------------------------------------------------------

--- a/src/utils/equipmentParser.js
+++ b/src/utils/equipmentParser.js
@@ -311,6 +311,26 @@ export function mapItemsToSlots(equippedItems) {
 }
 
 /**
+ * Per-item unique slot keys ('head', 'ring2', 'offhand3') for a list of
+ * equipped items — the inverse of mapItemsToSlots, so numbering is identical
+ * to the Character panel layout. This is the canonical key space for what-if
+ * item overrides: the editor stores under these keys and useDerivedStats
+ * looks items up by them (a bare item.slot like 'offhand' is ambiguous across
+ * the four offhand slots).
+ *
+ * @param {Array} equippedItems - Equipped items in Item model format
+ * @returns {Map<Object, string>} item reference → unique slot key
+ */
+export function getUniqueSlotKeyMap(equippedItems) {
+  const slots = mapItemsToSlots(equippedItems || []);
+  const map = new Map();
+  for (const [slotKey, item] of Object.entries(slots)) {
+    if (item) map.set(item, slotKey);
+  }
+  return map;
+}
+
+/**
  * Create compressed log output for console
  * Updated to use Item model format
  * @param {Array} equippedItems - Array of equipped items in Item model format

--- a/src/utils/raceBonuses.js
+++ b/src/utils/raceBonuses.js
@@ -1,0 +1,92 @@
+/**
+ * Racial Bonuses
+ *
+ * Each race (Human/Orc/Dwarf/Undead) has 6 racial skills that unlock at fixed
+ * character-level thresholds — 10/25/50/100/150/200 (threshold unlocks, NOT
+ * per-level scaling; RACE_LEVEL_CAP=200 is simply the last unlock). Grants
+ * per race follow one shape:
+ *   L10  two weapon-stance damage%          L100 3 affinity cooldown bonuses
+ *   L25  three offhand affinity damage%     L150 two StanceMultiplier bonuses
+ *   L50  stance crit chance/damage          L200 the same 3 affinities, bigger
+ *
+ * Race is detected from the save (parseCharacterRace → E_CharacterRace enum
+ * index); the generated table maps index → name + skills.
+ *
+ * @module utils/raceBonuses
+ */
+
+import racesGenerated from '../data/races.generated.json';
+import { findStatForAttribute } from './statRegistry.js';
+
+const RACES = racesGenerated.races || {};
+
+// EasyRPG.StanceMultiplier.* ("<Stance> Damage Augmentation") has no registry
+// stat; provisionally routed additively into the matching stance damage%
+// bucket. The racial L10/L150 stance pairings line up per race (e.g. Dwarf:
+// Magery+PoleArm damage% then Mauls+Magery multipliers), confirming the
+// stance identity — only the additive-vs-multiplicative application is
+// unconfirmed. Note the game's TwoHanded stance is Axes.
+const STANCE_MULTIPLIER_STATS = {
+  'EasyRPG.StanceMultiplier.Swords': 'swordDamage',
+  'EasyRPG.StanceMultiplier.Axes': 'twohandDamage',
+  'EasyRPG.StanceMultiplier.Magery': 'mageryDamage',
+  'EasyRPG.StanceMultiplier.Archery': 'archeryDamage',
+  'EasyRPG.StanceMultiplier.Mauls': 'maulDamage',
+  'EasyRPG.StanceMultiplier.Spear': 'spearDamage',
+  'EasyRPG.StanceMultiplier.Fists': 'unarmedDamage',
+  'EasyRPG.StanceMultiplier.Scythe': 'scytheDamage',
+};
+
+/** @returns {Object|null} Generated race definition for an enum index. */
+export function getRaceDef(raceIndex) {
+  if (raceIndex === null || raceIndex === undefined) return null;
+  return RACES[raceIndex] ?? null;
+}
+
+/** @returns {string|null} Display name ('Dwarf') for a race enum index. */
+export function getRaceName(raceIndex) {
+  return getRaceDef(raceIndex)?.name ?? null;
+}
+
+/**
+ * @typedef {Object} RaceContribution
+ * @property {string} tag - Full game attribute tag
+ * @property {string|null} statId - Resolved STAT_REGISTRY id
+ * @property {number} value - Contribution (raw decimal, 0.1 = 10%)
+ * @property {string} source - Human-readable origin ("Runes of Power (Dwarf L25)")
+ * @property {'race'} kind
+ */
+
+/**
+ * Flat stat contributions from the racial skills unlocked at the character's
+ * level. Same raw-decimal convention as item baseStats / skill contributions.
+ *
+ * @param {number|null} raceIndex - E_CharacterRace enum index from the save
+ * @param {number} characterLevel
+ * @returns {RaceContribution[]}
+ */
+export function getRacialContributions(raceIndex, characterLevel) {
+  const def = getRaceDef(raceIndex);
+  const level = Number(characterLevel) || 0;
+  if (!def || level <= 0) return [];
+
+  const contributions = [];
+  for (const skill of def.racialSkills ?? []) {
+    if (level < (skill.requiredLevel || 0)) continue;
+    for (const eff of skill.effects ?? []) {
+      if (!eff.tag || !eff.value) continue;
+      const statId = STANCE_MULTIPLIER_STATS[eff.tag]
+        ?? findStatForAttribute(eff.tag)?.id
+        ?? null;
+      if (!statId) continue;
+      contributions.push({
+        tag: eff.tag,
+        statId,
+        value: eff.value,
+        source: `${skill.name} (${def.name} L${skill.requiredLevel})`,
+        kind: 'race',
+      });
+    }
+  }
+  return contributions;
+}

--- a/src/utils/skillEffectAggregator.js
+++ b/src/utils/skillEffectAggregator.js
@@ -22,6 +22,7 @@ import cardsGenerated from '../data/cards.generated.json';
 import weaponSkillsGenerated from '../data/weaponSkills.generated.json';
 import mainTreeHealthGenerated from '../data/mainTreeHealth.generated.json';
 import mainTreeAffinityGenerated from '../data/mainTreeAffinity.generated.json';
+import mainTreeModifiersGenerated from '../data/mainTreeModifiers.generated.json';
 import { findStatForAttribute } from './statRegistry.js';
 
 const GENERATED_CARDS = cardsGenerated.cards || {};
@@ -29,6 +30,8 @@ const GENERATED_WEAPON_SKILLS = weaponSkillsGenerated.weaponSkills || {};
 const MAIN_TREE_HEALTH_EFFECTS = mainTreeHealthGenerated.effectsByRow || {};
 const MAIN_TREE_AFFINITY_EFFECTS = mainTreeAffinityGenerated.effectsByRow || {};
 const MAIN_TREE_AFFINITY_NAMES = mainTreeAffinityGenerated.namesByRow || {};
+const MAIN_TREE_MODIFIER_GRANTS = mainTreeModifiersGenerated.grantsByRow || {};
+const MAIN_TREE_MODIFIER_NAMES = mainTreeModifiersGenerated.namesByRow || {};
 
 export function hasMainTreeHealthEffect(rowName) {
   return !!MAIN_TREE_HEALTH_EFFECTS[rowName];
@@ -36,6 +39,34 @@ export function hasMainTreeHealthEffect(rowName) {
 
 export function hasMainTreeAffinityEffect(rowName) {
   return !!MAIN_TREE_AFFINITY_EFFECTS[rowName];
+}
+
+export function hasMainTreeModifierGrant(rowName) {
+  return !!MAIN_TREE_MODIFIER_GRANTS[rowName];
+}
+
+/**
+ * Modifier grants from the allocated main-tree nodes — nodes that grant an
+ * EasyRPG.Items.Modifiers.* behavior tag rather than a stat (e.g. "Melee
+ * Mastery: Damage" grants MeleeParagon.BaseDamage, +2 flat per stance mastery
+ * level, additive with the helmet monogram of the same id). These flow into
+ * useDerivedStats' applied-monogram pipeline; ids without a calc config are
+ * inert there.
+ *
+ * @param {Object|null} skillTree - Result of extractSkillTree(saveData)
+ * @returns {Array<{id: string, value: number, source: string}>}
+ */
+export function collectMainTreeModifierGrants(skillTree) {
+  const grants = [];
+  for (const skill of skillTree?.mainTree ?? []) {
+    const nodeGrants = MAIN_TREE_MODIFIER_GRANTS[skill.rowName];
+    if (!nodeGrants) continue;
+    const label = MAIN_TREE_MODIFIER_NAMES[skill.rowName] || skill.rowName;
+    for (const grant of nodeGrants) {
+      grants.push({ id: grant.id, value: grant.value, source: label });
+    }
+  }
+  return grants;
 }
 
 // UE row names (FNames) are case-insensitive: saves contain e.g.

--- a/test/itemOverridesFlow.test.js
+++ b/test/itemOverridesFlow.test.js
@@ -1,0 +1,102 @@
+/**
+ * What-if override flow: edits made in the Items tab editor (stored in the
+ * shared useItemOverrides instance, keyed by UNIQUE slot keys) must reach
+ * useDerivedStats. Regression for "paragon isn't picking up flat phys/ele":
+ * editor-added monograms used to be keyed by list position and never matched
+ * the hook's slot lookup, so MeleeParagon.BaseDamage (+2 flat per mastery
+ * level, both damage types) never fired.
+ *
+ * The hook is exercised for real via renderToString (no test renderer dep).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { useDerivedStats } from '../src/hooks/useDerivedStats.js';
+import { extractEquippedItems, getUniqueSlotKeyMap } from '../src/utils/equipmentParser.js';
+import { parseStanceContext } from '../src/utils/stanceSkills.js';
+import { extractSkillTree } from '../src/utils/skillTreeParser.js';
+
+function probeHook(options) {
+  let out;
+  function Probe() { out = useDerivedStats(options); return null; }
+  renderToString(React.createElement(Probe));
+  return out;
+}
+
+let equippedItems;
+let stanceContext;
+let skillTree;
+
+beforeAll(() => {
+  const save = JSON.parse(fs.readFileSync(
+    path.join(import.meta.dirname, 'fixtures', 'dr-full-inventory.json'), 'utf8'));
+  equippedItems = extractEquippedItems(save);
+  stanceContext = parseStanceContext(save, equippedItems);
+  skillTree = extractSkillTree(save);
+});
+
+describe('unique slot keys', () => {
+  it('assigns numbered keys matching the character panel layout', () => {
+    const map = getUniqueSlotKeyMap(equippedItems);
+    const keys = [...map.values()];
+    expect(keys).toContain('head');
+    expect(keys).toContain('ring1');
+    expect(keys).toContain('ring2');
+    expect(keys.filter(k => k.startsWith('offhand')).sort())
+      .toEqual(['offhand1', 'offhand2', 'offhand3', 'offhand4']);
+  });
+});
+
+describe('override monograms reach derived stats', () => {
+  it('MeleeParagon.BaseDamage added on head feeds flat phys AND elem', () => {
+    const withoutOverride = probeHook({ equippedItems, stanceContext, skillTree });
+    const withOverride = probeHook({
+      equippedItems,
+      stanceContext,
+      skillTree,
+      itemOverrides: { head: { monograms: [{ id: 'MeleeParagon.BaseDamage', value: 1 }] } },
+    });
+
+    // Mastery 733 × 2 flat damage, both damage types
+    const mastery = stanceContext.activeStance.mastery;
+    expect(withOverride.values.paragonDamageBonus).toBe(mastery * 2);
+    expect(withOverride.values.edpsPhysFlat - withoutOverride.values.edpsPhysFlat)
+      .toBe(mastery * 2);
+    expect(withOverride.values.edpsElemFlat - withoutOverride.values.edpsElemFlat)
+      .toBe(mastery * 2);
+  });
+
+  it('override stat mods apply through unique slot keys', () => {
+    const base = probeHook({ equippedItems, stanceContext, skillTree });
+    const modded = probeHook({
+      equippedItems,
+      stanceContext,
+      skillTree,
+      itemOverrides: { offhand2: { mods: [{ statId: 'strength', value: 50 }] } },
+    });
+    expect((modded.values.strength || 0) - (base.values.strength || 0)).toBe(50);
+  });
+});
+
+describe('racial bonuses through the hook', () => {
+  it('Dwarf at level 741 contributes affinity + stance stats', () => {
+    const withRace = probeHook({
+      equippedItems, stanceContext, skillTree,
+      characterRace: 2, characterLevel: 741,
+    });
+    const withoutRace = probeHook({ equippedItems, stanceContext, skillTree });
+
+    // Racial Area affinity (10% + 25%) on top of tree-sourced Area nodes
+    expect((withRace.baseStats.areaAffinityDamage || 0) - (withoutRace.baseStats.areaAffinityDamage || 0))
+      .toBeCloseTo(0.35, 10);
+    // Racial PoleArm/Mauls grants: L10 damage 10% + L150 stance multiplier 10%
+    expect((withRace.baseStats.maulDamage || 0) - (withoutRace.baseStats.maulDamage || 0))
+      .toBeCloseTo(0.2, 10);
+    // Active affinities (Dragon/Orbit/Area from Electric Dragons) route the
+    // racial Area damage into the elemental bucket automatically
+    expect(withRace.values.edpsElemAdditive - withoutRace.values.edpsElemAdditive)
+      .toBeCloseTo(0.35, 5);
+  });
+});

--- a/test/itemOverridesFlow.test.js
+++ b/test/itemOverridesFlow.test.js
@@ -49,8 +49,45 @@ describe('unique slot keys', () => {
   });
 });
 
+describe('main-tree paragon nodes (Melee/Ranged Mastery)', () => {
+  it('tree-allocated Melee Mastery nodes grant paragon flat + armor with NO helmet monogram', () => {
+    // The DR save has UI_SkillTreeNode_Large_103 (Melee Mastery: Damage) and
+    // UI_SkillTreeNode_Large_115 (Melee Mastery: Armor) allocated — the
+    // original "paragon isn't picking up for flat phys and ele" report.
+    const { values } = probeHook({ equippedItems, stanceContext, skillTree });
+    const mastery = stanceContext.activeStance.mastery;
+    expect(values.paragonDamageBonus).toBe(mastery * 2);
+    expect(values.paragonArmorBonus).toBe(mastery * 15);
+  });
+
+  it('paragon nodes survive the character share round-trip', async () => {
+    const { createSkillTreeShare, skillTreeShareToData } = await import('../src/models/CharacterShareModel.js');
+    const { collectMainTreeModifierGrants } = await import('../src/utils/skillEffectAggregator.js');
+    const restored = skillTreeShareToData(createSkillTreeShare(skillTree));
+    // The collector returns ALL modifier grants (potion/inventory slots too);
+    // useDerivedStats filters to calc-config ids. The paragon pair must survive.
+    const paragonIds = collectMainTreeModifierGrants(restored)
+      .map(g => g.id).filter(id => id.includes('Paragon')).sort();
+    expect(paragonIds).toEqual(['MeleeParagon.Armor', 'MeleeParagon.BaseDamage']);
+  });
+
+  it('ranged tree nodes are inert for a melee (maul) build', () => {
+    // Family gating: "While using a ranged weapon…" nodes must not fire
+    const rangedTree = {
+      ...skillTree,
+      mainTree: [
+        ...skillTree.mainTree,
+        { rowName: 'UI_SkillTreeNode_Large_107', level: 1, category: 'main' }, // Ranged Mastery: Damage
+      ],
+    };
+    const base = probeHook({ equippedItems, stanceContext, skillTree });
+    const withRanged = probeHook({ equippedItems, stanceContext, skillTree: rangedTree });
+    expect(withRanged.values.paragonDamageBonus).toBe(base.values.paragonDamageBonus);
+  });
+});
+
 describe('override monograms reach derived stats', () => {
-  it('MeleeParagon.BaseDamage added on head feeds flat phys AND elem', () => {
+  it('helmet MeleeParagon.BaseDamage stacks ADDITIVELY with the tree node', () => {
     const withoutOverride = probeHook({ equippedItems, stanceContext, skillTree });
     const withOverride = probeHook({
       equippedItems,
@@ -59,9 +96,10 @@ describe('override monograms reach derived stats', () => {
       itemOverrides: { head: { monograms: [{ id: 'MeleeParagon.BaseDamage', value: 1 }] } },
     });
 
-    // Mastery 733 × 2 flat damage, both damage types
+    // Tree node = 2/level; tree + helmet = 4/level (2 instances)
     const mastery = stanceContext.activeStance.mastery;
-    expect(withOverride.values.paragonDamageBonus).toBe(mastery * 2);
+    expect(withoutOverride.values.paragonDamageBonus).toBe(mastery * 2);
+    expect(withOverride.values.paragonDamageBonus).toBe(mastery * 4);
     expect(withOverride.values.edpsPhysFlat - withoutOverride.values.edpsPhysFlat)
       .toBe(mastery * 2);
     expect(withOverride.values.edpsElemFlat - withoutOverride.values.edpsElemFlat)

--- a/test/raceBonuses.test.js
+++ b/test/raceBonuses.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { getRaceDef, getRaceName, getRacialContributions } from '../src/utils/raceBonuses.js';
+import { calculateDerivedStats, DERIVED_STATS } from '../src/utils/derivedStats.js';
+
+describe('race definitions', () => {
+  it('maps E_CharacterRace enum indices to names', () => {
+    expect(getRaceName(0)).toBe('Human');
+    expect(getRaceName(1)).toBe('Orc');
+    expect(getRaceName(2)).toBe('Dwarf');
+    expect(getRaceName(3)).toBe('Undead');
+    expect(getRaceName(null)).toBeNull();
+    expect(getRaceName(99)).toBeNull();
+  });
+
+  it('each race has 6 threshold racial skills at 10/25/50/100/150/200', () => {
+    for (const index of [0, 1, 2, 3]) {
+      const def = getRaceDef(index);
+      expect(def.racialSkills.map(s => s.requiredLevel)).toEqual([10, 25, 50, 100, 150, 200]);
+    }
+  });
+});
+
+describe('getRacialContributions', () => {
+  it('gates skills by character level (threshold unlocks, not scaling)', () => {
+    // Level 30 Dwarf: only L10 (Ancestral Craft) + L25 (Runes of Power)
+    const contribs = getRacialContributions(2, 30);
+    const sources = new Set(contribs.map(c => c.source));
+    expect([...sources].some(s => s.startsWith('Ancestral Craft'))).toBe(true);
+    expect([...sources].some(s => s.startsWith('Runes of Power'))).toBe(true);
+    expect([...sources].some(s => s.startsWith('Iron Nerves'))).toBe(false);
+    expect([...sources].some(s => s.startsWith('Runecrafted Legacy'))).toBe(false);
+  });
+
+  it('level 200+ unlocks everything; level 0 / no race yields nothing', () => {
+    expect(new Set(getRacialContributions(2, 741).map(c => c.source)).size).toBe(6);
+    expect(getRacialContributions(2, 0)).toEqual([]);
+    expect(getRacialContributions(null, 741)).toEqual([]);
+  });
+
+  it('resolves every racial effect tag to a registry stat (all 4 races)', () => {
+    for (const index of [0, 1, 2, 3]) {
+      const contribs = getRacialContributions(index, 200);
+      expect(contribs.length).toBeGreaterThanOrEqual(15);
+      for (const c of contribs) expect(c.statId, c.tag).toBeTruthy();
+    }
+  });
+
+  it('Dwarf affinity grants stack: L25 10% + L200 25% per category', () => {
+    const contribs = getRacialContributions(2, 741);
+    const area = contribs.filter(c => c.statId === 'areaAffinityDamage');
+    expect(area.map(c => c.value).sort()).toEqual([0.1, 0.25]);
+    const bladeCdr = contribs.filter(c => c.statId === 'bladeAffinityCooldown');
+    expect(bladeCdr.map(c => c.value)).toEqual([0.1]);
+  });
+
+  it('maps StanceMultiplier tags to stance damage stats (provisional additive)', () => {
+    // Dwarf L150 "Mountain's Grasp": Mauls + Magery augmentation
+    const contribs = getRacialContributions(2, 150);
+    const stanceMult = contribs.filter(c => c.tag.startsWith('EasyRPG.StanceMultiplier.'));
+    expect(stanceMult.map(c => c.statId).sort()).toEqual(['mageryDamage', 'maulDamage']);
+    // Orc's Axes multiplier lands on the TwoHanded (= axes) stance bucket
+    const orc = getRacialContributions(1, 150).filter(c => c.tag === 'EasyRPG.StanceMultiplier.Axes');
+    expect(orc[0]?.statId).toBe('twohandDamage');
+  });
+
+  it('routes racial affinity damage into the eDPS elemental bucket when active', () => {
+    // Aggregate a Dwarf L741's affinity contributions the way the hook does,
+    // then activate the Area affinity (e.g. Electric Dragons + AdditionalDragons)
+    const base = {};
+    for (const c of getRacialContributions(2, 741)) {
+      base[c.statId] = (base[c.statId] || 0) + c.value;
+    }
+    const withArea = calculateDerivedStats(base, {
+      edpsElemAdditive: { ...DERIVED_STATS.edpsElemAdditive.config, activeAffinities: ['Area'] },
+    });
+    const without = calculateDerivedStats(base, {});
+    expect(withArea.edpsElemAdditive - without.edpsElemAdditive).toBeCloseTo(0.35, 10);
+  });
+});


### PR DESCRIPTION
Root cause: the main tree's "Melee Mastery: Damage/Armor" and "Ranged Mastery: Damage/Armor" nodes (UI_SkillTreeNode_Large_103/115/107/114) grant EasyRPG.Items.Modifiers.MeleeParagon.BaseDamage_TextTag / .Armor_TextTag tags with the per-level values embedded (2 flat, 15 armor). The skill aggregator deliberately drops all Items.Modifiers.* grants as "behavior tags", so tree-sourced paragon never existed in the calc — and your character has both melee nodes allocated with no helmet paragon monogram, which is exactly why flat phys/ele showed nothing.

The fix:

    The generator now emits mainTreeModifiers.generated.json — all 155 main-tree nodes that grant modifier tags, with _TextTag stripped so the ids line up with MONOGRAM_CALC_CONFIGS.
    collectMainTreeModifierGrants(skillTree) surfaces the allocated ones, and useDerivedStats pushes them through the existing applied-monogram pipeline. Only ids with a calc config fire (the potion/inventory-slot grants stay inert), and MeleeParagon.*/RangedParagon.* are gated by the detected weapon family, so a ranged node on your maul build does nothing.
    Additive stacking: the paragon calcs now multiply by instanceCount, so tree node + helmet monogram of the same id = 4 flat/level (and 30 armor/level). Verified against your fixture: tree alone gives mastery 733 × 2 = +1,466 flat into both edpsPhysFlat and edpsElemFlat (and +10,995 paragon armor); adding the helmet monogram via the editor doubles it.
    The paragon node rows travel in v2 character shares (st.mh), so shared builds compute the same numbers.

This push also carries the earlier commit from this session: racial bonuses (threshold unlocks at 10/25/50/100/150/200, affinity routing, rc share field, race in the header) and the what-if override wiring fix (shared overrides instance + unique slot keys), which remains relevant — it's what makes the helmet-stacking scenario testable in the UI at all.

One modeling note: HP paragon (MeleeParagon.MaxHp, 10/level) also scales per instance now, but no tree node grants it — helmet-only, unchanged in practice.