### PR TITLE
Add three-slot monogram editing and named loadout sets

### DIFF
--- a/src/components/character/ItemEditor.jsx
+++ b/src/components/character/ItemEditor.jsx
@@ -1,148 +1,66 @@
-import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react';
-import { StatInput } from './StatInput';
-import { getDisplayName } from '../../utils/attributeDisplay';
-import { STAT_TYPES, getStatType } from '../../utils/statBuckets';
-import { getMonogramsForSlot, getMonogramName, SLOT_MONOGRAMS } from '../../utils/monogramRegistry';
-import {
-  getAllSkills,
-  getSkillModifiers,
-  getSkillModifierName,
-  getSkillDisplayName,
-} from '../../utils/skillModifierRegistry';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { getMonogramsForSlot, getMonogramName } from '../../utils/monogramRegistry';
+import { MONOGRAM_SLOT_COUNT, normalizeMonogramSlots } from '../../utils/monogramOverrides';
 
 /**
- * Map item type/row to monogram slot
- * Returns null if no monogram slot applies
+ * Map an item type/row to its Codex recipe pool.
  */
 function getMonogramSlot(itemType, itemRow) {
   const typeStr = (itemType || itemRow || '').toLowerCase();
 
-  // Check for slot keywords
   if (typeStr.includes('head') || typeStr.includes('helm') || typeStr.includes('hat') || typeStr.includes('casque')) return 'head';
   if (typeStr.includes('amulet') || typeStr.includes('neck')) return 'amulet';
   if (typeStr.includes('bracer') || typeStr.includes('wrist')) return 'bracer';
   if (typeStr.includes('boots') || typeStr.includes('feet')) return 'boots';
   if (typeStr.includes('pants') || typeStr.includes('legs') || typeStr.includes('greaves')) return 'pants';
   if (typeStr.includes('relic')) return 'relic';
+  if (typeStr.includes('ring')) return 'ring';
 
   return null;
 }
 
 /**
- * Check if an item is a weapon (can have skill modifiers)
- */
-function isWeaponSlot(itemType, itemRow) {
-  const typeStr = (itemType || itemRow || '').toLowerCase();
-
-  // Check for weapon keywords
-  if (typeStr.includes('weapon')) return true;
-  if (typeStr.includes('staff')) return true;
-  if (typeStr.includes('sword')) return true;
-  if (typeStr.includes('axe')) return true;
-  if (typeStr.includes('mace')) return true;
-  if (typeStr.includes('dagger')) return true;
-  if (typeStr.includes('wand')) return true;
-  if (typeStr.includes('bow')) return true;
-  if (typeStr.includes('crossbow')) return true;
-
-  return false;
-}
-
-/**
- * Panel for editing an individual item's stats
- *
- * @param {Object} props
- * @param {Object} props.item - The item being edited
- * @param {string} props.slotKey - The equipment slot key
- * @param {Object} props.slotOverrides - Current overrides for this slot
- * @param {Function} props.onUpdateMod - Update a modification
- * @param {Function} props.onAddMod - Add a new modification
- * @param {Function} props.onRemoveMod - Remove a modification
- * @param {Function} props.onRemoveBaseStat - Mark a base stat as removed
- * @param {Function} props.onRestoreBaseStat - Restore a removed base stat
- * @param {Function} props.onAddMonogram - Add a monogram to the item
- * @param {Function} props.onRemoveMonogram - Remove a monogram from the item
- * @param {Function} props.onAddSkillModifier - Add a skill modifier to a weapon
- * @param {Function} props.onRemoveSkillModifier - Remove a skill modifier from a weapon
- * @param {Function} props.onClearSlot - Clear all overrides for this slot
- * @param {Function} props.onClose - Close the editor
- * @param {Array} props.currentMonograms - Current monograms on the item (from model)
- * @param {Array} props.currentSkillModifiers - Current skill modifiers on the weapon (from model)
+ * Monogram-only what-if editor. It updates engine state and never writes to
+ * the imported save or item model.
  */
 export function ItemEditor({
   item,
-  slotKey,
   slotOverrides = {},
-  onUpdateMod,
-  onAddMod,
-  onRemoveMod,
-  onRemoveBaseStat,
-  onRestoreBaseStat,
-  onAddMonogram,
-  onRemoveMonogram,
-  onAddSkillModifier,
-  onRemoveSkillModifier,
+  onSetMonogramSlot,
   onClearSlot,
   onClose,
   currentMonograms = [],
-  currentSkillModifiers = [],
 }) {
   const editorRef = useRef(null);
 
-  // Scroll editor into view when it opens
   useEffect(() => {
-    if (editorRef.current) {
-      editorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }
-  }, [slotKey]);
-
-  const [selectedMonogram, setSelectedMonogram] = useState('');
-  const [selectedSkill, setSelectedSkill] = useState('');
-  const [selectedSkillModifier, setSelectedSkillModifier] = useState('');
+    editorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [item]);
 
   if (!item) return null;
 
-  // Support both Item model format and legacy format
-  const baseAttributes = item.baseStats
-    ? item.baseStats.map(s => ({ name: s.rawTag || s.stat, value: s.value }))
-    : (item.attributes || []);
   const itemType = item.type || item.itemType || '';
   const itemRow = item.rowName || item.itemRow || '';
   const itemName = item.displayName || item.name || 'Unknown';
-
-  const { mods = [], removedIndices = [], monograms: addedMonograms = [], skillModifiers: addedSkillModifiers = [] } = slotOverrides;
-
-  // Determine monogram slot for this item
   const monogramSlot = getMonogramSlot(itemType, itemRow);
-  const availableMonograms = monogramSlot ? getMonogramsForSlot(monogramSlot) : [];
+  const availableMonograms = useMemo(
+    () => monogramSlot ? getMonogramsForSlot(monogramSlot) : [],
+    [monogramSlot]
+  );
+  const monogramSlots = Array.isArray(slotOverrides.monogramSlots)
+    ? normalizeMonogramSlots(slotOverrides.monogramSlots)
+    : normalizeMonogramSlots(currentMonograms);
+  const hasChanges = Array.isArray(slotOverrides.monogramSlots);
 
-  // Check if item is a weapon (can have skill modifiers)
-  const isWeapon = isWeaponSlot(itemType, itemRow);
-  const allSkills = isWeapon ? getAllSkills() : [];
-  const availableSkillModifiers = selectedSkill ? getSkillModifiers(selectedSkill) : [];
-
-  const hasChanges = mods.length > 0 || removedIndices.length > 0 || addedMonograms.length > 0 || addedSkillModifiers.length > 0;
-
-  // Handle adding a new stat - store statId, not name
-  const handleAddStat = useCallback(() => {
-    onAddMod?.({ statId: '', value: 0, isNew: true });
-  }, [onAddMod]);
-
-  // Handle adding a monogram
-  const handleAddMonogram = useCallback(() => {
-    if (selectedMonogram && onAddMonogram) {
-      onAddMonogram({ id: selectedMonogram, value: 1 });
-      setSelectedMonogram('');
+  // Keep an imported/legacy ID selectable even if the registry fixture has
+  // not learned it yet.
+  const optionMap = new Map(availableMonograms.map(monogram => [monogram.id, monogram]));
+  for (const id of monogramSlots) {
+    if (id && !optionMap.has(id)) {
+      optionMap.set(id, { id, name: getMonogramName(id) });
     }
-  }, [selectedMonogram, onAddMonogram]);
-
-  // Handle adding a skill modifier
-  const handleAddSkillModifier = useCallback(() => {
-    if (selectedSkillModifier && onAddSkillModifier) {
-      onAddSkillModifier({ id: selectedSkillModifier, skillId: selectedSkill, value: 1 });
-      setSelectedSkillModifier('');
-    }
-  }, [selectedSkillModifier, selectedSkill, onAddSkillModifier]);
+  }
+  const options = Array.from(optionMap.values());
 
   return (
     <div className="item-editor" ref={editorRef}>
@@ -157,7 +75,7 @@ export function ItemEditor({
               type="button"
               className="item-editor-reset"
               onClick={onClearSlot}
-              title="Reset all changes"
+              title="Restore imported monograms"
             >
               Reset
             </button>
@@ -174,273 +92,44 @@ export function ItemEditor({
       </div>
 
       <div className="item-editor-content">
-        {/* Base stats from item */}
-        <div className="item-editor-section">
-          <div className="item-editor-section-title">Base Stats</div>
-          <div className="item-editor-stats">
-            {baseAttributes.map((attr, index) => {
-              const isRemoved = removedIndices.includes(index);
-              return (
-                <BaseStatRow
-                  key={index}
-                  attr={attr}
-                  isRemoved={isRemoved}
-                  onRemove={() => onRemoveBaseStat?.(index)}
-                  onRestore={() => onRestoreBaseStat?.(index)}
-                />
-              );
-            })}
-            {baseAttributes.length === 0 && (
-              <div className="item-editor-empty">No base stats</div>
-            )}
-          </div>
-        </div>
-
-        {/* Added/modified stats */}
-        <div className="item-editor-section">
-          <div className="item-editor-section-title">
-            Added Stats
-            <button
-              type="button"
-              className="item-editor-add-btn"
-              onClick={handleAddStat}
-            >
-              + Add
-            </button>
-          </div>
-          <div className="item-editor-stats">
-            {mods.map((mod, index) => (
-              <ModStatRow
-                key={mod.id}
-                mod={mod}
-                onUpdate={(updates) => onUpdateMod?.(index, updates)}
-                onRemove={() => onRemoveMod?.(index)}
-              />
-            ))}
-            {mods.length === 0 && (
-              <div className="item-editor-empty">
-                Click "+ Add" to add custom stats
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Monograms section - only show if slot has monograms */}
-        {availableMonograms.length > 0 && (
+        {monogramSlot ? (
           <div className="item-editor-section">
             <div className="item-editor-section-title">
               Monograms
-              <span className="item-editor-section-hint">({monogramSlot})</span>
+              <span className="item-editor-section-hint">({monogramSlot}, engine only)</span>
             </div>
-
-            {/* Current monograms from item */}
             <div className="item-editor-stats">
-              {currentMonograms.map((mono, index) => (
-                <div key={mono.id} className="item-editor-stat-row base-stat monogram-row">
-                  <span className="stat-row-name">{getMonogramName(mono.id)}</span>
-                  <span className="stat-row-value monogram-id">{mono.id}</span>
-                </div>
-              ))}
-
-              {/* Added monograms */}
-              {addedMonograms.map((mono, index) => (
-                <div key={mono.id} className="item-editor-stat-row mod-stat monogram-row">
-                  <span className="stat-row-name">{getMonogramName(mono.id)}</span>
-                  <span className="stat-row-value monogram-id added">{mono.id}</span>
-                  <button
-                    type="button"
-                    className="stat-row-remove"
-                    onClick={() => onRemoveMonogram?.(index)}
-                    title="Remove monogram"
+              {Array.from({ length: MONOGRAM_SLOT_COUNT }, (_, index) => (
+                <label
+                  key={index}
+                  className="item-editor-stat-row monogram-row"
+                >
+                  <span className="stat-row-name">Slot {index + 1}</span>
+                  <select
+                    className="stat-row-select monogram-select"
+                    value={monogramSlots[index] || ''}
+                    onChange={event => onSetMonogramSlot?.(index, event.target.value || null)}
                   >
-                    ×
-                  </button>
-                </div>
+                    <option value="">None</option>
+                    {options.map(monogram => (
+                      <option key={monogram.id} value={monogram.id}>
+                        {monogram.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               ))}
-
-              {currentMonograms.length === 0 && addedMonograms.length === 0 && (
-                <div className="item-editor-empty">No monograms</div>
-              )}
             </div>
-
-            {/* Add monogram selector */}
-            {availableMonograms.length > 0 && onAddMonogram && (
-              <div className="item-editor-add-row">
-                <select
-                  className="stat-row-select monogram-select"
-                  value={selectedMonogram}
-                  onChange={(e) => setSelectedMonogram(e.target.value)}
-                >
-                  <option value="">Select monogram...</option>
-                  {availableMonograms.map(mono => (
-                    <option key={mono.id} value={mono.id}>
-                      {mono.name}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  className="item-editor-add-btn"
-                  onClick={handleAddMonogram}
-                  disabled={!selectedMonogram}
-                >
-                  + Add
-                </button>
-              </div>
-            )}
+            <div className="item-editor-empty">
+              Hypothetical only; the save and imported item remain unchanged.
+            </div>
           </div>
-        )}
-
-        {/* Skill Modifiers section - only show for weapons */}
-        {isWeapon && (
-          <div className="item-editor-section">
-            <div className="item-editor-section-title">
-              Skill Modifiers
-              <span className="item-editor-section-hint">(weapon)</span>
-            </div>
-
-            {/* Current skill modifiers from item */}
-            <div className="item-editor-stats">
-              {currentSkillModifiers.map((mod, index) => (
-                <div key={`base-${mod.id}-${index}`} className="item-editor-stat-row base-stat skill-modifier-row">
-                  <span className="stat-row-name">{getSkillModifierName(mod.id)}</span>
-                </div>
-              ))}
-
-              {/* Added skill modifiers */}
-              {addedSkillModifiers.map((mod, index) => (
-                <div key={`added-${mod.id}-${index}`} className="item-editor-stat-row mod-stat skill-modifier-row">
-                  <span className="stat-row-name">{getSkillModifierName(mod.id)}</span>
-                  <span className="stat-row-value skill-id added">{mod.skillId}</span>
-                  <button
-                    type="button"
-                    className="stat-row-remove"
-                    onClick={() => onRemoveSkillModifier?.(index)}
-                    title="Remove skill modifier"
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
-
-              {currentSkillModifiers.length === 0 && addedSkillModifiers.length === 0 && (
-                <div className="item-editor-empty">No skill modifiers</div>
-              )}
-            </div>
-
-            {/* Add skill modifier selector */}
-            {allSkills.length > 0 && onAddSkillModifier && (
-              <div className="item-editor-add-row skill-modifier-add">
-                <select
-                  className="stat-row-select skill-select"
-                  value={selectedSkill}
-                  onChange={(e) => {
-                    setSelectedSkill(e.target.value);
-                    setSelectedSkillModifier('');
-                  }}
-                >
-                  <option value="">Filter by skill...</option>
-                  {allSkills.map(skill => (
-                    <option key={skill.id} value={skill.id}>
-                      {skill.name}
-                    </option>
-                  ))}
-                </select>
-                <select
-                  className="stat-row-select modifier-select"
-                  value={selectedSkillModifier}
-                  onChange={(e) => setSelectedSkillModifier(e.target.value)}
-                  disabled={!selectedSkill}
-                >
-                  <option value="">Select modifier...</option>
-                  {availableSkillModifiers.map(mod => (
-                    <option key={mod.id} value={mod.id}>
-                      {mod.name}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  className="item-editor-add-btn"
-                  onClick={handleAddSkillModifier}
-                  disabled={!selectedSkillModifier}
-                >
-                  + Add
-                </button>
-              </div>
-            )}
+        ) : (
+          <div className="item-editor-empty">
+            This item does not use a monogram recipe pool.
           </div>
         )}
       </div>
-    </div>
-  );
-}
-
-/**
- * Row displaying a base stat with remove/restore toggle
- */
-function BaseStatRow({ attr, isRemoved, onRemove, onRestore }) {
-  const displayName = getDisplayName(attr.name);
-  const displayValue = typeof attr.value === 'number'
-    ? attr.value.toFixed(attr.value % 1 === 0 ? 0 : 2)
-    : attr.value;
-
-  return (
-    <div className={`item-editor-stat-row base-stat ${isRemoved ? 'removed' : ''}`}>
-      <span className="stat-row-name">{displayName}</span>
-      <span className="stat-row-value">{displayValue}</span>
-      <button
-        type="button"
-        className={`stat-row-toggle ${isRemoved ? 'restore' : 'remove'}`}
-        onClick={isRemoved ? onRestore : onRemove}
-        title={isRemoved ? 'Restore stat' : 'Remove stat'}
-      >
-        {isRemoved ? '↩' : '×'}
-      </button>
-    </div>
-  );
-}
-
-/**
- * Row for editing an added/modified stat
- * Now uses statId to track which stat is selected
- */
-function ModStatRow({ mod, onUpdate, onRemove }) {
-  // Look up stat type by statId
-  const statType = mod.statId ? getStatType(mod.statId) : null;
-  const isPercent = statType?.isPercent || false;
-
-  return (
-    <div className="item-editor-stat-row mod-stat">
-      <select
-        className="stat-row-select"
-        value={mod.statId || ''}
-        onChange={(e) => onUpdate({ statId: e.target.value })}
-      >
-        <option value="">Select stat...</option>
-        {STAT_TYPES.map(stat => (
-          <option key={stat.id} value={stat.id}>
-            {stat.name}
-          </option>
-        ))}
-      </select>
-
-      <StatInput
-        value={mod.value}
-        onChange={(value) => onUpdate({ value })}
-        isPercent={isPercent}
-        disabled={!mod.statId}
-        step={isPercent ? 1 : 1}
-      />
-
-      <button
-        type="button"
-        className="stat-row-remove"
-        onClick={onRemove}
-        title="Remove stat"
-      >
-        ×
-      </button>
     </div>
   );
 }

--- a/src/components/character/ItemEditor.jsx
+++ b/src/components/character/ItemEditor.jsx
@@ -37,11 +37,9 @@ export function ItemEditor({
     editorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }, [item]);
 
-  if (!item) return null;
-
-  const itemType = item.type || item.itemType || '';
-  const itemRow = item.rowName || item.itemRow || '';
-  const itemName = item.displayName || item.name || 'Unknown';
+  const itemType = item?.type || item?.itemType || '';
+  const itemRow = item?.rowName || item?.itemRow || '';
+  const itemName = item?.displayName || item?.name || 'Unknown';
   const monogramSlot = getMonogramSlot(itemType, itemRow);
   const availableMonograms = useMemo(
     () => monogramSlot ? getMonogramsForSlot(monogramSlot) : [],

--- a/src/components/items/CLAUDE.md
+++ b/src/components/items/CLAUDE.md
@@ -8,6 +8,7 @@ The Items tab provides a browsable list of all items parsed from a save file wit
 |-----------|------|---------|
 | `ItemsTab` | `ItemsTab.jsx` | Main tab container with filtering and item list |
 | `ItemListRow` | `ItemsTab.jsx` | Individual item row with tooltip and selection |
+| `MonogramSetPanel` | `MonogramSetPanel.jsx` | Named-set controls and three-position loadout preview |
 
 ## Features
 
@@ -22,11 +23,13 @@ The Items tab provides a browsable list of all items parsed from a save file wit
 - **Equipped only**: Toggle to show only equipped items
 - **Slot filter**: Checkboxes to filter by equipment slot type
 
-### Stat Editing
-- Click any item to open the ItemEditor panel
-- View and modify base stats
-- Add custom stats for theorycrafting
-- Changes reflected in real-time
+### Monogram Theorycrafting
+- Click an equipped monogram item to edit its three nullable positions
+- Overrides are engine-only and never mutate the imported item or save
+- Named sets capture the complete effective layout across equipped items
+- Sets persist in localStorage, update by name, and can be previewed/applied/deleted
+- Applying a set requires both the unique slot and item row to match; changed gear is skipped
+- Derived stats update in real time
 
 ## Data Flow
 

--- a/src/components/items/CLAUDE.md
+++ b/src/components/items/CLAUDE.md
@@ -72,7 +72,7 @@ Items are transformed into a clean model (see `src/models/Item.js`):
     pool3: [{rowName, dataTable}],
   },
 
-  // Monograms (Codex modifiers, up to 4 per item)
+  // Imported monograms (Codex modifiers, up to 3 per item)
   monograms: [{id, value, rawTag}],
 
   upgradeCount: number, // Gamble/anvil upgrades
@@ -123,10 +123,10 @@ getMonogramsForSlot('head'); // [{id, name, category, description}, ...]
 
 ## Hooks Used
 
-- `useItemOverrides` - Manages stat and monogram modifications for theorycrafting
-  - `addMod`, `removeMod`, `updateMod` - Stat modifications
-  - `addMonogram`, `removeMonogram` - Monogram modifications
-  - `removeBaseStat`, `restoreBaseStat` - Base stat toggling
+- `useItemOverrides` - Holds engine-only theorycraft state shared across tabs
+  - `setMonogramSlot(slotKey, index, id, imported)` replaces one of three nullable positions
+  - Reset removes the override and restores all imported monograms
+  - The serializable three-position array is the foundation for named monogram sets
 
 ## Slot Types
 

--- a/src/components/items/ItemsTab.jsx
+++ b/src/components/items/ItemsTab.jsx
@@ -53,8 +53,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     removeMod,
     removeBaseStat,
     restoreBaseStat,
-    addMonogram,
-    removeMonogram,
+    setMonogramSlot,
     addSkillModifier,
     removeSkillModifier,
     clearSlot,
@@ -253,7 +252,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
       <div className="items-header">
         <h2>Items</h2>
         <p className="items-description">
-          Browse all items parsed from your save file. Equipped items are tagged and can be filtered.
+          Browse imported items and try three-slot monogram loadouts without changing the save.
         </p>
       </div>
 
@@ -380,15 +379,12 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
               item={editorItem}
               slotKey={selectedOverrideKey}
               slotOverrides={getSlotOverrides(selectedOverrideKey)}
-              onUpdateMod={(modIndex, updates) => updateMod(selectedOverrideKey, modIndex, updates)}
-              onAddMod={(mod) => addMod(selectedOverrideKey, mod)}
-              onRemoveMod={(modIndex) => removeMod(selectedOverrideKey, modIndex)}
-              onRemoveBaseStat={(index) => removeBaseStat(selectedOverrideKey, index)}
-              onRestoreBaseStat={(index) => restoreBaseStat(selectedOverrideKey, index)}
-              onAddMonogram={(mono) => addMonogram(selectedOverrideKey, mono)}
-              onRemoveMonogram={(index) => removeMonogram(selectedOverrideKey, index)}
-              onAddSkillModifier={(mod) => addSkillModifier(selectedOverrideKey, mod)}
-              onRemoveSkillModifier={(index) => removeSkillModifier(selectedOverrideKey, index)}
+              onSetMonogramSlot={(index, monogramId) => setMonogramSlot(
+                selectedOverrideKey,
+                index,
+                monogramId,
+                selectedItem?.monograms || []
+              )}
               onClearSlot={() => clearSlot(selectedOverrideKey)}
               onClose={handleCloseEditor}
               currentMonograms={selectedItem?.monograms || []}

--- a/src/components/items/ItemsTab.jsx
+++ b/src/components/items/ItemsTab.jsx
@@ -1,8 +1,11 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { ItemDetailTooltip } from '../character/ItemDetailTooltip';
 import { ItemEditor } from '../character/ItemEditor';
+import { MonogramSetPanel } from './MonogramSetPanel';
 import { transformAllItems } from '../../models/itemTransformer';
+import { createMonogramSet, matchMonogramSet } from '../../models/MonogramSet';
 import { useItemOverrides } from '../../hooks/useItemOverrides';
+import { useMonogramSets } from '../../hooks/useMonogramSets';
 import { inferEquipmentSlot, formatSlotLabel, getUniqueSlotKeyMap } from '../../utils/equipmentParser';
 
 const DEFAULT_FILTERS = '';
@@ -38,6 +41,9 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
   const [selectedItemKeys, setSelectedItemKeys] = useState(new Set());
   const [singleSelectMode, setSingleSelectMode] = useState(true);
   const [selectedSlots, setSelectedSlots] = useState(new Set());
+  const [monogramSetName, setMonogramSetName] = useState('');
+  const [selectedMonogramSetName, setSelectedMonogramSetName] = useState('');
+  const { sets: monogramSets, saveSet, deleteSet } = useMonogramSets();
 
   // Item overrides for editing. App shares one instance across tabs so edits
   // flow into the Character tab's stats and survive tab switches (this tab
@@ -54,6 +60,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     removeBaseStat,
     restoreBaseStat,
     setMonogramSlot,
+    applyMonogramSet,
     addSkillModifier,
     removeSkillModifier,
     clearSlot,
@@ -236,6 +243,52 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     setSelectedItemKeys(new Set());
   }, []);
 
+  const selectedMonogramSet = useMemo(
+    () => monogramSets.find(monogramSet => monogramSet.name === selectedMonogramSetName) || null,
+    [monogramSets, selectedMonogramSetName]
+  );
+
+  const handleSaveMonogramSet = useCallback(() => {
+    const name = monogramSetName.trim();
+    if (!name) return;
+
+    const existing = monogramSets.find(monogramSet => monogramSet.name === name);
+    const monogramSet = createMonogramSet(
+      name,
+      itemStore?.equipped || [],
+      overrides,
+      existing?.id
+    );
+
+    if (monogramSet.entries.length === 0) {
+      onLog?.('No equipped monogram items to save');
+      return;
+    }
+
+    saveSet(monogramSet);
+    setSelectedMonogramSetName(name);
+    onLog?.(`Monogram set "${name}" saved (${monogramSet.entries.length} items)`);
+  }, [itemStore?.equipped, monogramSetName, monogramSets, onLog, overrides, saveSet]);
+
+  const handleApplyMonogramSet = useCallback(() => {
+    if (!selectedMonogramSet) return;
+    const { monogramSlotsByEquipment, skipped } = matchMonogramSet(
+      selectedMonogramSet,
+      itemStore?.equipped || []
+    );
+    const appliedCount = Object.keys(monogramSlotsByEquipment).length;
+    applyMonogramSet(monogramSlotsByEquipment);
+    onLog?.(`Monogram set "${selectedMonogramSet.name}" applied to ${appliedCount} item(s)${skipped.length ? `; ${skipped.length} different/missing item(s) skipped` : ''}`);
+  }, [applyMonogramSet, itemStore?.equipped, onLog, selectedMonogramSet]);
+
+  const handleDeleteMonogramSet = useCallback(() => {
+    if (!selectedMonogramSet) return;
+    deleteSet(selectedMonogramSet.name);
+    setSelectedMonogramSetName('');
+    if (monogramSetName === selectedMonogramSet.name) setMonogramSetName('');
+    onLog?.(`Monogram set "${selectedMonogramSet.name}" deleted`);
+  }, [deleteSet, monogramSetName, onLog, selectedMonogramSet]);
+
   if (!itemStore?.hasItems && !saveData) {
     return (
       <div className="tab-content active">
@@ -255,6 +308,20 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
           Browse imported items and try three-slot monogram loadouts without changing the save.
         </p>
       </div>
+
+      <MonogramSetPanel
+        name={monogramSetName}
+        onNameChange={setMonogramSetName}
+        savedSets={monogramSets}
+        selectedSet={selectedMonogramSet}
+        onSelectSet={name => {
+          setSelectedMonogramSetName(name);
+          if (name) setMonogramSetName(name);
+        }}
+        onSave={handleSaveMonogramSet}
+        onApply={handleApplyMonogramSet}
+        onDelete={handleDeleteMonogramSet}
+      />
 
       <div className="controls">
         <div className="control-row">
@@ -393,9 +460,9 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
           ) : (
             <div className="items-editor-empty-state">
               <div className="empty-state-icon">✎</div>
-              <div>Select an item to view and edit stats.</div>
+              <div>Select an equipped item to edit its monograms.</div>
               <div className="empty-state-hint">
-                Use the editor to add, modify, or remove stat values for theorycrafting.
+                Saved sets capture and reapply the complete effective monogram loadout.
               </div>
             </div>
           )}

--- a/src/components/items/MonogramSetPanel.jsx
+++ b/src/components/items/MonogramSetPanel.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Button } from '../common';
+import { getMonogramName } from '../../utils/monogramRegistry.js';
+
+export function MonogramSetPanel({
+  name,
+  onNameChange,
+  savedSets,
+  selectedSet,
+  onSelectSet,
+  onSave,
+  onApply,
+  onDelete,
+}) {
+  return (
+    <div className="monogram-set-panel">
+      <div className="monogram-set-controls">
+        <label className="config-label">
+          Monogram Set
+          <input
+            className="config-profile-name"
+            value={name}
+            onChange={event => onNameChange(event.target.value)}
+            placeholder="e.g., Boss breakpoint"
+          />
+        </label>
+        <Button icon="💾" onClick={onSave} disabled={!name.trim()}>
+          Save Current
+        </Button>
+        <select
+          className="config-profile-select"
+          value={selectedSet?.name || ''}
+          onChange={event => onSelectSet(event.target.value)}
+        >
+          <option value="">Load set...</option>
+          {savedSets.map(monogramSet => (
+            <option key={monogramSet.id} value={monogramSet.name}>
+              {monogramSet.name}
+            </option>
+          ))}
+        </select>
+        <Button icon="↻" variant="primary" onClick={onApply} disabled={!selectedSet}>
+          Apply
+        </Button>
+        <Button icon="🗑️" onClick={onDelete} disabled={!selectedSet}>
+          Delete
+        </Button>
+      </div>
+
+      {selectedSet && (
+        <div className="monogram-set-preview">
+          {selectedSet.entries.map(entry => (
+            <div className="monogram-set-entry" key={entry.slotKey}>
+              <span className="monogram-set-item">
+                {entry.itemName} <small>({entry.slotKey})</small>
+              </span>
+              <span className="monogram-set-values">
+                {entry.monogramSlots.map((id, index) => (
+                  <span className="item-badge" key={index}>
+                    {id ? getMonogramName(id) : 'None'}
+                  </span>
+                ))}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDerivedStats.js
+++ b/src/hooks/useDerivedStats.js
@@ -3,6 +3,7 @@ import { calculateDerivedStats, calculateDerivedStatsDetailed, DERIVED_STATS, LA
 import { getStatType } from '../utils/statBuckets.js';
 import { STAT_REGISTRY } from '../utils/statRegistry.js';
 import { MONOGRAM_CALC_CONFIGS, applyExclusiveMonogramRules } from '../utils/monogramConfigs.js';
+import { resolveEffectiveMonograms } from '../utils/monogramOverrides.js';
 import { inferWeaponStance, getUniqueSlotKeyMap } from '../utils/equipmentParser.js';
 import { aggregateSkillEffects, hasWeaponSkillData, collectMainTreeModifierGrants } from '../utils/skillEffectAggregator.js';
 import { detectEquippedAbilities, getStepCooldown, unionAffinities } from '../utils/offhandAbilities.js';
@@ -177,27 +178,15 @@ export function useDerivedStats(options = {}) {
     const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
 
     for (const item of equippedItems) {
-      // Monograms from item (direct or nested model)
-      const itemMonograms = item?.monograms || item?.model?.monograms;
-      if (itemMonograms && Array.isArray(itemMonograms)) {
-        for (const mono of itemMonograms) {
-          monograms.push({
-            id: mono.id,
-            value: mono.value,
-            source: 'item',
-            itemSlot: item.slot,
-          });
-        }
-      }
-
-      // Added monograms from overrides (keyed by unique slot key)
+      const itemMonograms = item?.monograms || item?.model?.monograms || [];
       const slotKey = uniqueSlotKeys.get(item) || item?.slotKey || item?.slot || '';
-      const overrides = itemOverrides[slotKey] || {};
-      for (const mono of overrides.monograms || []) {
+      const slotOverride = itemOverrides[slotKey] || {};
+
+      // Overrides replace the imported three positions exactly. This is what
+      // makes a dropdown selection a swap rather than an extra fourth effect.
+      for (const mono of resolveEffectiveMonograms(itemMonograms, slotOverride)) {
         monograms.push({
-          id: mono.id,
-          value: mono.value || 1,
-          source: 'override',
+          ...mono,
           itemSlot: item?.slot,
         });
       }

--- a/src/hooks/useItemOverrides.js
+++ b/src/hooks/useItemOverrides.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from 'react';
 import { getStatType } from '../utils/statBuckets';
+import { MONOGRAM_SLOT_COUNT, normalizeMonogramSlots } from '../utils/monogramOverrides';
 
 /**
  * Hook for managing per-item stat overrides
@@ -15,12 +16,13 @@ import { getStatType } from '../utils/statBuckets';
 export function useItemOverrides(options = {}) {
   const { initialOverrides, onChange } = options;
 
-  // State: { slotKey: { mods: [...], removedIndices: [], monograms: [...], skillModifiers: [...] } }
+  // monogramSlots is null/absent until the user edits an item. Once present,
+  // its three nullable positions replace the imported monograms exactly.
   const [overrides, setOverrides] = useState(() => initialOverrides || {});
 
   // Get overrides for a specific slot
   const getSlotOverrides = useCallback((slotKey) => {
-    return overrides[slotKey] || { mods: [], removedIndices: [], monograms: [], skillModifiers: [] };
+    return overrides[slotKey] || { mods: [], removedIndices: [], monogramSlots: null, skillModifiers: [] };
   }, [overrides]);
 
   // Update a stat modification for an item
@@ -129,41 +131,23 @@ export function useItemOverrides(options = {}) {
     });
   }, [onChange]);
 
-  // Add a monogram to an item (duplicates allowed)
-  const addMonogram = useCallback((slotKey, monogram) => {
+  // Replace one of the three monogram positions. The first edit snapshots the
+  // imported positions so changing slot 2 does not discard slots 1 and 3.
+  // Null is an explicit "None" selection; duplicate IDs are valid.
+  const setMonogramSlot = useCallback((slotKey, monogramIndex, monogramId, importedMonograms = []) => {
+    if (monogramIndex < 0 || monogramIndex >= MONOGRAM_SLOT_COUNT) return;
+
     setOverrides(prev => {
-      const slotData = prev[slotKey] || { mods: [], removedIndices: [], monograms: [] };
-      const monograms = slotData.monograms || [];
+      const slotData = prev[slotKey] || { mods: [], removedIndices: [], skillModifiers: [] };
+      const monogramSlots = Array.isArray(slotData.monogramSlots)
+        ? normalizeMonogramSlots(slotData.monogramSlots)
+        : normalizeMonogramSlots(importedMonograms);
+      monogramSlots[monogramIndex] = monogramId || null;
 
       const newOverrides = {
         ...prev,
-        [slotKey]: {
-          ...slotData,
-          monograms: [...monograms, monogram],
-        },
+        [slotKey]: { ...slotData, monogramSlots },
       };
-
-      onChange?.(newOverrides);
-      return newOverrides;
-    });
-  }, [onChange]);
-
-  // Remove a monogram from an item
-  const removeMonogram = useCallback((slotKey, monogramIndex) => {
-    setOverrides(prev => {
-      const slotData = prev[slotKey] || { mods: [], removedIndices: [], monograms: [], skillModifiers: [] };
-      const monograms = (slotData.monograms || []).filter((_, i) => i !== monogramIndex);
-
-      const newOverrides = {
-        ...prev,
-        [slotKey]: { ...slotData, monograms },
-      };
-
-      // Clean up if no overrides left
-      const skillMods = slotData.skillModifiers || [];
-      if (slotData.mods.length === 0 && slotData.removedIndices.length === 0 && monograms.length === 0 && skillMods.length === 0) {
-        delete newOverrides[slotKey];
-      }
 
       onChange?.(newOverrides);
       return newOverrides;
@@ -233,7 +217,7 @@ export function useItemOverrides(options = {}) {
     if (!slotData) return false;
     return slotData.mods.length > 0 ||
            slotData.removedIndices.length > 0 ||
-           (slotData.monograms || []).length > 0 ||
+           Array.isArray(slotData.monogramSlots) ||
            (slotData.skillModifiers || []).length > 0;
   }, [overrides]);
 
@@ -286,8 +270,7 @@ export function useItemOverrides(options = {}) {
     removeMod,
     removeBaseStat,
     restoreBaseStat,
-    addMonogram,
-    removeMonogram,
+    setMonogramSlot,
     addSkillModifier,
     removeSkillModifier,
     clearSlot,

--- a/src/hooks/useItemOverrides.js
+++ b/src/hooks/useItemOverrides.js
@@ -215,8 +215,8 @@ export function useItemOverrides(options = {}) {
   const hasSlotOverrides = useCallback((slotKey) => {
     const slotData = overrides[slotKey];
     if (!slotData) return false;
-    return slotData.mods.length > 0 ||
-           slotData.removedIndices.length > 0 ||
+    return (slotData.mods || []).length > 0 ||
+           (slotData.removedIndices || []).length > 0 ||
            Array.isArray(slotData.monogramSlots) ||
            (slotData.skillModifiers || []).length > 0;
   }, [overrides]);
@@ -233,12 +233,13 @@ export function useItemOverrides(options = {}) {
     if (!slotData) return baseAttributes;
 
     // Filter out removed base stats
+    const removedIndices = slotData.removedIndices || [];
     let result = baseAttributes.filter((_, index) =>
-      !slotData.removedIndices.includes(index)
+      !removedIndices.includes(index)
     );
 
     // Add new/modified stats using attributeName for pattern matching
-    for (const mod of slotData.mods) {
+    for (const mod of slotData.mods || []) {
       if (mod.statId && mod.value !== undefined) {
         const statType = getStatType(mod.statId);
         if (statType) {

--- a/src/hooks/useItemOverrides.js
+++ b/src/hooks/useItemOverrides.js
@@ -154,6 +154,24 @@ export function useItemOverrides(options = {}) {
     });
   }, [onChange]);
 
+  // Apply a named set atomically. Only matching equipment keys are supplied
+  // by MonogramSet.matchMonogramSet; unrelated override fields are preserved.
+  const applyMonogramSet = useCallback((monogramSlotsByEquipment) => {
+    setOverrides(prev => {
+      const newOverrides = { ...prev };
+
+      for (const [slotKey, monogramSlots] of Object.entries(monogramSlotsByEquipment)) {
+        newOverrides[slotKey] = {
+          ...(newOverrides[slotKey] || {}),
+          monogramSlots: normalizeMonogramSlots(monogramSlots),
+        };
+      }
+
+      onChange?.(newOverrides);
+      return newOverrides;
+    });
+  }, [onChange]);
+
   // Add a skill modifier to an item (for weapons, duplicates allowed)
   const addSkillModifier = useCallback((slotKey, skillModifier) => {
     setOverrides(prev => {
@@ -272,6 +290,7 @@ export function useItemOverrides(options = {}) {
     removeBaseStat,
     restoreBaseStat,
     setMonogramSlot,
+    applyMonogramSet,
     addSkillModifier,
     removeSkillModifier,
     clearSlot,

--- a/src/hooks/useMonogramSets.js
+++ b/src/hooks/useMonogramSets.js
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react';
+import { deserializeMonogramSet, serializeMonogramSet } from '../models/MonogramSet.js';
+
+const STORAGE_KEY = 'dwarfStats.monogramSets';
+
+function loadSetsFromStorage() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(entry => deserializeMonogramSet(JSON.stringify(entry)))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function saveSetsToStorage(sets) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sets));
+  } catch {
+    // localStorage may be disabled or full; the in-memory list still works.
+  }
+}
+
+export function useMonogramSets() {
+  const [sets, setSets] = useState(() => loadSetsFromStorage());
+
+  const saveSet = useCallback(monogramSet => {
+    setSets(previous => {
+      const stored = JSON.parse(serializeMonogramSet(monogramSet));
+      const index = previous.findIndex(entry => entry.name === monogramSet.name);
+      const next = index >= 0
+        ? previous.map((entry, entryIndex) => entryIndex === index ? stored : entry)
+        : [...previous, stored];
+      saveSetsToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const deleteSet = useCallback(name => {
+    setSets(previous => {
+      const next = previous.filter(entry => entry.name !== name);
+      saveSetsToStorage(next);
+      return next;
+    });
+  }, []);
+
+  return { sets, saveSet, deleteSet };
+}

--- a/src/models/MonogramSet.js
+++ b/src/models/MonogramSet.js
@@ -1,0 +1,101 @@
+import { getUniqueSlotKeyMap } from '../utils/equipmentParser.js';
+import { normalizeMonogramSlots } from '../utils/monogramOverrides.js';
+
+export const MONOGRAM_SET_VERSION = 1;
+
+const MONOGRAM_EQUIPMENT_SLOTS = new Set([
+  'head', 'neck', 'bracer', 'boots', 'pants', 'relic', 'ring',
+]);
+
+function baseSlot(slotKey = '') {
+  return slotKey.replace(/\d+$/, '');
+}
+
+export function isMonogramEquipmentSlot(slotKey) {
+  return MONOGRAM_EQUIPMENT_SLOTS.has(baseSlot(slotKey));
+}
+
+export function createMonogramSet(name, equippedItems = [], overrides = {}, id = null) {
+  const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
+  const entries = [];
+
+  for (const item of equippedItems) {
+    const slotKey = uniqueSlotKeys.get(item) || item?.slotKey || item?.slot || '';
+    if (!isMonogramEquipmentSlot(slotKey)) continue;
+
+    const slotOverride = overrides[slotKey] || {};
+    const monogramSlots = Array.isArray(slotOverride.monogramSlots)
+      ? normalizeMonogramSlots(slotOverride.monogramSlots)
+      : normalizeMonogramSlots(item?.monograms || item?.model?.monograms || []);
+
+    entries.push({
+      slotKey,
+      itemRow: item?.rowName || item?.model?.rowName || '',
+      itemName: item?.displayName || item?.model?.displayName || slotKey,
+      monogramSlots,
+    });
+  }
+
+  return {
+    version: MONOGRAM_SET_VERSION,
+    id: id || `monogram-set-${Date.now()}`,
+    name: name.trim(),
+    entries,
+  };
+}
+
+export function matchMonogramSet(monogramSet, equippedItems = []) {
+  const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
+  const equippedBySlot = new Map();
+
+  for (const item of equippedItems) {
+    const slotKey = uniqueSlotKeys.get(item) || item?.slotKey || item?.slot || '';
+    equippedBySlot.set(slotKey, item);
+  }
+
+  const monogramSlotsByEquipment = {};
+  const skipped = [];
+
+  for (const entry of monogramSet?.entries || []) {
+    const item = equippedBySlot.get(entry.slotKey);
+    const currentRow = item?.rowName || item?.model?.rowName || '';
+
+    if (!item || currentRow !== entry.itemRow) {
+      skipped.push(entry);
+      continue;
+    }
+
+    monogramSlotsByEquipment[entry.slotKey] = normalizeMonogramSlots(entry.monogramSlots);
+  }
+
+  return { monogramSlotsByEquipment, skipped };
+}
+
+export function serializeMonogramSet(monogramSet) {
+  return JSON.stringify(monogramSet);
+}
+
+export function deserializeMonogramSet(json) {
+  try {
+    const parsed = JSON.parse(json);
+    if (!parsed?.name || !Array.isArray(parsed.entries)) return null;
+
+    const entries = parsed.entries
+      .filter(entry => entry?.slotKey && isMonogramEquipmentSlot(entry.slotKey))
+      .map(entry => ({
+        slotKey: entry.slotKey,
+        itemRow: entry.itemRow || '',
+        itemName: entry.itemName || entry.slotKey,
+        monogramSlots: normalizeMonogramSlots(entry.monogramSlots),
+      }));
+
+    return {
+      version: MONOGRAM_SET_VERSION,
+      id: parsed.id || `monogram-set-${Date.now()}`,
+      name: parsed.name,
+      entries,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2361,3 +2361,60 @@ h1::before {
   border-radius: 4px;
   border: 1px dashed var(--border-color);
 }
+
+
+.monogram-set-panel {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+}
+
+.monogram-set-controls {
+  display: flex;
+  align-items: end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.monogram-set-controls .config-label {
+  min-width: 14rem;
+}
+
+.monogram-set-preview {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.monogram-set-entry {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) minmax(18rem, 2fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.monogram-set-item small {
+  color: var(--text-secondary);
+}
+
+.monogram-set-values {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.monogram-set-values .item-badge {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .monogram-set-entry {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/utils/monogramOverrides.js
+++ b/src/utils/monogramOverrides.js
@@ -1,0 +1,42 @@
+export const MONOGRAM_SLOT_COUNT = 3;
+
+/**
+ * Normalize strings or parsed monogram entries into the engine-only
+ * three-position shape used by item overrides and future named sets.
+ *
+ * @param {Array<string|{id?: string}|null>} monograms
+ * @returns {Array<string|null>}
+ */
+export function normalizeMonogramSlots(monograms = []) {
+  return Array.from({ length: MONOGRAM_SLOT_COUNT }, (_, index) => {
+    const monogram = monograms[index];
+    if (typeof monogram === 'string') return monogram || null;
+    return monogram?.id || null;
+  });
+}
+
+/**
+ * Resolve the exact monograms used by calculations.
+ * An explicit monogramSlots array replaces imported values position-for-position;
+ * an absent array preserves the imported item.
+ *
+ * @param {Array<string|{id?: string, value?: number}|null>} importedMonograms
+ * @param {{monogramSlots?: Array<string|null>}} slotOverride
+ * @returns {Array<{id: string, value: number, source: 'item'|'override'}>}
+ */
+export function resolveEffectiveMonograms(importedMonograms = [], slotOverride = {}) {
+  const hasOverride = Array.isArray(slotOverride.monogramSlots);
+  const slots = hasOverride
+    ? normalizeMonogramSlots(slotOverride.monogramSlots)
+    : normalizeMonogramSlots(importedMonograms);
+
+  return slots.flatMap((id, index) => {
+    if (!id) return [];
+    const imported = importedMonograms[index];
+    return [{
+      id,
+      value: !hasOverride && typeof imported === 'object' ? (imported.value ?? 1) : 1,
+      source: hasOverride ? 'override' : 'item',
+    }];
+  });
+}

--- a/src/utils/monogramRegistry.js
+++ b/src/utils/monogramRegistry.js
@@ -1420,7 +1420,7 @@ export function getMonogramName(id) {
 export function getMonogramsForSlot(slot) {
   const ids = SLOT_MONOGRAMS[slot.toLowerCase()] || [];
   return ids
-    .map(id => MONOGRAM_REGISTRY[id])
+    .map(id => getMonogramById(id))
     .filter(Boolean);
 }
 

--- a/test/MonogramSet.test.js
+++ b/test/MonogramSet.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMonogramSet,
+  deserializeMonogramSet,
+  matchMonogramSet,
+  serializeMonogramSet,
+} from '../src/models/MonogramSet.js';
+
+const equipped = [
+  {
+    slot: 'head',
+    rowName: 'Equipment_Armor_Head_A',
+    displayName: 'A Head',
+    monograms: [{ id: 'Bloodlust.Base' }, { id: 'Shroud' }],
+  },
+  {
+    slot: 'ring',
+    rowName: 'Equipment_Ring_A',
+    displayName: 'A Ring',
+    monograms: [{ id: 'ExtraHp%' }],
+  },
+  {
+    slot: 'ring',
+    rowName: 'Equipment_Ring_B',
+    displayName: 'B Ring',
+    monograms: [{ id: 'ExtraArmor%' }],
+  },
+  { slot: 'weapon', rowName: 'Equipment_Weapon_A', displayName: 'Weapon' },
+];
+
+describe('MonogramSet', () => {
+  it('captures the complete effective loadout and ignores non-monogram equipment', () => {
+    const monogramSet = createMonogramSet('Boss', equipped, {
+      head: { monogramSlots: ['Colossus.Base', null, 'Shroud'] },
+    });
+
+    expect(monogramSet.entries.map(entry => entry.slotKey))
+      .toEqual(['head', 'ring1', 'ring2']);
+    expect(monogramSet.entries[0].monogramSlots)
+      .toEqual(['Colossus.Base', null, 'Shroud']);
+    expect(monogramSet.entries[1].monogramSlots)
+      .toEqual(['ExtraHp%', null, null]);
+  });
+
+  it('applies only when both the unique slot and item identity match', () => {
+    const monogramSet = createMonogramSet('Boss', equipped, {});
+    const changedGear = equipped.map(item => item.slot === 'head'
+      ? { ...item, rowName: 'Equipment_Armor_Head_B' }
+      : item);
+
+    const { monogramSlotsByEquipment, skipped } = matchMonogramSet(monogramSet, changedGear);
+
+    expect(monogramSlotsByEquipment.head).toBeUndefined();
+    expect(monogramSlotsByEquipment.ring1).toEqual(['ExtraHp%', null, null]);
+    expect(skipped.map(entry => entry.slotKey)).toEqual(['head']);
+  });
+
+  it('round-trips through the localStorage representation', () => {
+    const monogramSet = createMonogramSet('Boss', equipped, {});
+    expect(deserializeMonogramSet(serializeMonogramSet(monogramSet)))
+      .toEqual(monogramSet);
+  });
+
+  it('rejects malformed serialized sets', () => {
+    expect(deserializeMonogramSet('{}')).toBeNull();
+    expect(deserializeMonogramSet('not json')).toBeNull();
+  });
+});

--- a/test/itemOverridesFlow.test.js
+++ b/test/itemOverridesFlow.test.js
@@ -93,7 +93,9 @@ describe('override monograms reach derived stats', () => {
       equippedItems,
       stanceContext,
       skillTree,
-      itemOverrides: { head: { monograms: [{ id: 'MeleeParagon.BaseDamage', value: 1 }] } },
+      itemOverrides: {
+        head: { monogramSlots: ['MeleeParagon.BaseDamage', null, null] },
+      },
     });
 
     // Tree node = 2/level; tree + helmet = 4/level (2 instances)

--- a/test/monogramOverrides.test.js
+++ b/test/monogramOverrides.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MONOGRAM_SLOT_COUNT,
+  normalizeMonogramSlots,
+  resolveEffectiveMonograms,
+} from '../src/utils/monogramOverrides.js';
+
+describe('monogram overrides', () => {
+  const imported = [
+    { id: 'Bloodlust.Base', value: 1 },
+    { id: 'Shroud', value: 1 },
+    { id: 'AllowPhasing', value: 1 },
+  ];
+
+  it('normalizes every item to three nullable positions', () => {
+    expect(MONOGRAM_SLOT_COUNT).toBe(3);
+    expect(normalizeMonogramSlots([{ id: 'Bloodlust.Base' }]))
+      .toEqual(['Bloodlust.Base', null, null]);
+  });
+
+  it('uses imported monograms when no override exists', () => {
+    expect(resolveEffectiveMonograms(imported, {})).toEqual([
+      { id: 'Bloodlust.Base', value: 1, source: 'item' },
+      { id: 'Shroud', value: 1, source: 'item' },
+      { id: 'AllowPhasing', value: 1, source: 'item' },
+    ]);
+  });
+
+  it('replaces positions instead of adding a fourth monogram', () => {
+    const effective = resolveEffectiveMonograms(imported, {
+      monogramSlots: ['Colossus.Base', 'Shroud', 'AllowPhasing'],
+    });
+
+    expect(effective).toHaveLength(3);
+    expect(effective.map(monogram => monogram.id))
+      .toEqual(['Colossus.Base', 'Shroud', 'AllowPhasing']);
+    expect(effective.every(monogram => monogram.source === 'override')).toBe(true);
+  });
+
+  it('treats None as an explicit removal', () => {
+    expect(resolveEffectiveMonograms(imported, {
+      monogramSlots: ['Bloodlust.Base', null, null],
+    }).map(monogram => monogram.id)).toEqual(['Bloodlust.Base']);
+  });
+
+  it('allows duplicate monograms in separate positions', () => {
+    expect(resolveEffectiveMonograms(imported, {
+      monogramSlots: ['Shroud', 'Shroud', 'Shroud'],
+    }).map(monogram => monogram.id)).toEqual(['Shroud', 'Shroud', 'Shroud']);
+  });
+
+  it('ignores positions beyond the three-slot engine model', () => {
+    expect(resolveEffectiveMonograms([], {
+      monogramSlots: ['A', 'B', 'C', 'D'],
+    }).map(monogram => monogram.id)).toEqual(['A', 'B', 'C']);
+  });
+});


### PR DESCRIPTION
## What changed

### Step 1 — item monogram editing

- replaces additive monogram edits with three nullable, position-aware dropdowns
- makes `None` an explicit removal and keeps duplicate monograms valid
- resolves imported or overridden monograms once, so hypothetical selections no longer double-count the saved item
- limits the item theorycraft editor to monograms and makes the engine-only/no-save-write behavior explicit
- enables the existing ring monogram pool in the editor
- includes generated registry entries in slot dropdowns

### Step 2 — named monogram sets

- captures the complete effective monogram loadout across equipped monogram items
- stores item identity, unique equipment key, and three positions per entry
- saves and updates sets by name in browser localStorage, following the existing filter-profile workflow
- provides compact set preview, apply, and delete controls in the Items tab
- applies matching entries atomically while preserving unrelated internal overrides
- distinguishes `ring1` and `ring2`
- skips and reports entries when the equipped item changed or is missing instead of applying stale item metadata
- version-tags and validates the serialized set model for later sharing/migration

## Why

The previous editor modeled monograms as unlimited additions layered over imported monograms. It could not represent replacing a position or setting it to None, and derived stats counted both the imported and hypothetical effects.

Named sets now cover the immediate theorycrafting loop: edit a complete monogram layout, save it, switch to another layout on the same equipment, and inspect the recalculated stats. Saves and imported items remain immutable.

## Deliberate boundary

This PR does not yet add cross-item substitution, URL sharing for sets, or pinned DPS/EHP comparisons. The set model is structured so those can be added without changing the three-position or equipment-identity semantics.

## Validation

- `npm run test:run` — 21 files, 373 tests passed
- `npm run build` — production build passed
