### PR TITLE
Fix editable monogram layout and equipped item inventory

### DIFF
--- a/src/components/items/ItemsTab.jsx
+++ b/src/components/items/ItemsTab.jsx
@@ -6,7 +6,8 @@ import { transformAllItems } from '../../models/itemTransformer';
 import { createMonogramSet, matchMonogramSet } from '../../models/MonogramSet';
 import { useItemOverrides } from '../../hooks/useItemOverrides';
 import { useMonogramSets } from '../../hooks/useMonogramSets';
-import { inferEquipmentSlot, formatSlotLabel, getUniqueSlotKeyMap } from '../../utils/equipmentParser';
+import { formatSlotLabel, getUniqueSlotKeyMap } from '../../utils/equipmentParser';
+import { buildItemList, getListItemSlot } from '../../utils/itemList';
 
 const DEFAULT_FILTERS = '';
 
@@ -66,60 +67,36 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     clearSlot,
   } = itemOverrides || localOverrides;
 
-  const equippedLookup = useMemo(() => {
-    const lookup = new Map();
-    const equippedItems = itemStore?.equipped || [];
-
-    for (const item of equippedItems) {
-      if (!item?.rowName) continue;
-      const label = formatSlotLabel(item.slot) || item.slot || 'Equipped';
-      lookup.set(item.rowName, label);
-    }
-
-    return lookup;
+  const equippedItemBySlot = useMemo(() => {
+    return new Map(
+      Array.from(getUniqueSlotKeyMap(itemStore?.equipped || []), ([item, slotKey]) => [slotKey, item])
+    );
   }, [itemStore?.equipped]);
 
-  const equippedSlotLookup = useMemo(() => {
-    const lookup = new Map();
-    const equippedItems = itemStore?.equipped || [];
-
-    for (const item of equippedItems) {
-      if (!item?.rowName) continue;
-      lookup.set(item.rowName, item.slot || 'unknown');
-    }
-
-    return lookup;
-  }, [itemStore?.equipped]);
-
-  // Override keys for EQUIPPED items are their unique slot keys ('head',
-  // 'ring2', 'offhand3') — the key space useDerivedStats and the Character
-  // panel read, so edits made here flow into the stats panel. Non-equipped
-  // items fall back to the list key (their edits are tooltip-only).
-  const equippedOverrideKeyLookup = useMemo(() => {
-    const lookup = new Map();
-    for (const [item, slotKey] of getUniqueSlotKeyMap(itemStore?.equipped || [])) {
-      if (item.rowName) lookup.set(item.rowName, slotKey);
-    }
-    return lookup;
-  }, [itemStore?.equipped]);
+  // The visible layout is always the current effective state, not a saved-set
+  // preview. This makes it available on first render and directly editable.
+  const currentMonogramSet = useMemo(() => createMonogramSet(
+    'Current',
+    itemStore?.equipped || [],
+    overrides
+  ), [itemStore?.equipped, overrides]);
 
   const { items, totalItems } = useMemo(() => {
-    // Prefer itemStore inventory (already processed Item models)
-    if (itemStore?.inventory?.length) {
-      return {
-        items: itemStore.inventory,
-        totalItems: itemStore.totalInventoryCount || itemStore.inventory.length,
-      };
+    if (itemStore?.inventory?.length || itemStore?.equipped?.length) {
+      return buildItemList(
+        itemStore.equipped || [],
+        itemStore.inventory || [],
+        itemStore.totalInventoryCount
+      );
     }
 
-    // Fallback to saveData — transform to Item models
     if (!saveData?.raw && !saveData?.json) {
       return { items: [], totalItems: 0 };
     }
 
     const { items: transformed, totalCount } = transformAllItems(saveData.raw || saveData.json);
-    return { items: transformed, totalItems: totalCount };
-  }, [itemStore?.inventory, itemStore?.totalInventoryCount, saveData]);
+    return buildItemList([], transformed, totalCount);
+  }, [itemStore?.equipped, itemStore?.inventory, itemStore?.totalInventoryCount, saveData]);
 
   const filteredItems = useMemo(() => {
     const regexList = filterPatterns.map(pattern => new RegExp(pattern.replace(/\*/g, '.*'), 'i'));
@@ -147,21 +124,21 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
 
       if (!matchesFilter(item)) return false;
       if (!showEquippedOnly) return true;
-      return equippedLookup.has(item.rowName);
+      return item.isEquipped;
     });
-  }, [items, showEquippedOnly, equippedLookup, filterPatterns]);
+  }, [items, showEquippedOnly, filterPatterns]);
 
   const slotFilteredItems = useMemo(() => {
     if (selectedSlots.size === 0) return filteredItems;
     return filteredItems.filter(item => {
-      const slotKey = equippedSlotLookup.get(item.rowName) || 'unknown';
+      const slotKey = getListItemSlot(item);
       return selectedSlots.has(slotKey);
     });
-  }, [filteredItems, selectedSlots, equippedSlotLookup]);
+  }, [filteredItems, selectedSlots]);
 
   const equippedCount = useMemo(() => {
-    return slotFilteredItems.reduce((count, item) => count + (equippedLookup.has(item.rowName) ? 1 : 0), 0);
-  }, [slotFilteredItems, equippedLookup]);
+    return slotFilteredItems.reduce((count, item) => count + (item.isEquipped ? 1 : 0), 0);
+  }, [slotFilteredItems]);
 
   useEffect(() => {
     if (!selectedItemKeys.size) return;
@@ -201,7 +178,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
   // Overrides for the selected item live under its unique slot key when it's
   // equipped (so they reach the Character tab stats); list key otherwise.
   const selectedOverrideKey = selectedItem
-    ? (equippedOverrideKeyLookup.get(selectedItem.rowName) || selectedItemKey)
+    ? (selectedItem.equipmentSlotKey || selectedItemKey)
     : selectedItemKey;
 
   const itemAttributes = useMemo(() => {
@@ -281,6 +258,12 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     onLog?.(`Monogram set "${selectedMonogramSet.name}" applied to ${appliedCount} item(s)${skipped.length ? `; ${skipped.length} different/missing item(s) skipped` : ''}`);
   }, [applyMonogramSet, itemStore?.equipped, onLog, selectedMonogramSet]);
 
+  const handleSetCurrentMonogramSlot = useCallback((slotKey, index, monogramId) => {
+    const item = equippedItemBySlot.get(slotKey);
+    if (!item) return;
+    setMonogramSlot(slotKey, index, monogramId, item.monograms || item.model?.monograms || []);
+  }, [equippedItemBySlot, setMonogramSlot]);
+
   const handleDeleteMonogramSet = useCallback(() => {
     if (!selectedMonogramSet) return;
     deleteSet(selectedMonogramSet.name);
@@ -314,6 +297,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
         onNameChange={setMonogramSetName}
         savedSets={monogramSets}
         selectedSet={selectedMonogramSet}
+        currentEntries={currentMonogramSet.entries}
         onSelectSet={name => {
           setSelectedMonogramSetName(name);
           if (name) setMonogramSetName(name);
@@ -321,6 +305,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
         onSave={handleSaveMonogramSet}
         onApply={handleApplyMonogramSet}
         onDelete={handleDeleteMonogramSet}
+        onSetMonogramSlot={handleSetCurrentMonogramSlot}
       />
 
       <div className="controls">
@@ -409,8 +394,10 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
           ) : (
             slotFilteredItems.map((item, index) => {
               const itemKey = `${item.rowName || item.displayName}-${index}`;
-              const equippedLabel = equippedLookup.get(item.rowName);
-              const overrideKey = equippedOverrideKeyLookup.get(item.rowName) || itemKey;
+              const equippedLabel = item.isEquipped
+                ? (formatSlotLabel(item.slot) || item.slot || 'Equipped')
+                : null;
+              const overrideKey = item.equipmentSlotKey || itemKey;
               return (
                 <ItemListRow
                   key={itemKey}

--- a/src/components/items/MonogramSetPanel.jsx
+++ b/src/components/items/MonogramSetPanel.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { Button } from '../common';
-import { getMonogramName } from '../../utils/monogramRegistry.js';
+import { getMonogramsForSlot, getMonogramName } from '../../utils/monogramRegistry.js';
+import { getMonogramPoolForEquipmentSlot } from '../../models/MonogramSet.js';
 
 export function MonogramSetPanel({
   name,
   onNameChange,
   savedSets,
   selectedSet,
+  currentEntries,
   onSelectSet,
+  onSetMonogramSlot,
   onSave,
   onApply,
   onDelete,
@@ -47,24 +50,63 @@ export function MonogramSetPanel({
         </Button>
       </div>
 
-      {selectedSet && (
+      {currentEntries.length > 0 ? (
         <div className="monogram-set-preview">
-          {selectedSet.entries.map(entry => (
-            <div className="monogram-set-entry" key={entry.slotKey}>
-              <span className="monogram-set-item">
-                {entry.itemName} <small>({entry.slotKey})</small>
-              </span>
-              <span className="monogram-set-values">
-                {entry.monogramSlots.map((id, index) => (
-                  <span className="item-badge" key={index}>
-                    {id ? getMonogramName(id) : 'None'}
-                  </span>
-                ))}
-              </span>
-            </div>
+          {currentEntries.map(entry => (
+            <MonogramSetEntry
+              entry={entry}
+              key={entry.slotKey}
+              onSetMonogramSlot={onSetMonogramSlot}
+            />
           ))}
         </div>
+      ) : (
+        <div className="item-editor-empty">No equipped monogram items.</div>
       )}
+    </div>
+  );
+}
+
+function MonogramSetEntry({ entry, onSetMonogramSlot }) {
+  const pool = getMonogramPoolForEquipmentSlot(entry.slotKey);
+  const available = pool ? getMonogramsForSlot(pool) : [];
+  const optionMap = new Map(available.map(monogram => [monogram.id, monogram]));
+
+  for (const id of entry.monogramSlots) {
+    if (id && !optionMap.has(id)) {
+      optionMap.set(id, { id, name: getMonogramName(id) });
+    }
+  }
+
+  const options = Array.from(optionMap.values());
+
+  return (
+    <div className="monogram-set-entry">
+      <span className="monogram-set-item">
+        {entry.itemName} <small>({entry.slotKey})</small>
+      </span>
+      <span className="monogram-set-values">
+        {entry.monogramSlots.map((id, index) => (
+          <select
+            aria-label={`${entry.itemName} monogram ${index + 1}`}
+            className="stat-row-select monogram-select"
+            key={index}
+            value={id || ''}
+            onChange={event => onSetMonogramSlot(
+              entry.slotKey,
+              index,
+              event.target.value || null
+            )}
+          >
+            <option value="">None</option>
+            {options.map(monogram => (
+              <option key={monogram.id} value={monogram.id}>
+                {monogram.name}
+              </option>
+            ))}
+          </select>
+        ))}
+      </span>
     </div>
   );
 }

--- a/src/models/MonogramSet.js
+++ b/src/models/MonogramSet.js
@@ -15,6 +15,12 @@ export function isMonogramEquipmentSlot(slotKey) {
   return MONOGRAM_EQUIPMENT_SLOTS.has(baseSlot(slotKey));
 }
 
+export function getMonogramPoolForEquipmentSlot(slotKey) {
+  const slot = baseSlot(slotKey);
+  if (slot === 'neck') return 'amulet';
+  return MONOGRAM_EQUIPMENT_SLOTS.has(slot) ? slot : null;
+}
+
 export function createMonogramSet(name, equippedItems = [], overrides = {}, id = null) {
   const uniqueSlotKeys = getUniqueSlotKeyMap(equippedItems);
   const entries = [];

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2407,10 +2407,9 @@ h1::before {
   gap: 0.35rem;
 }
 
-.monogram-set-values .item-badge {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.monogram-set-values .monogram-select {
+  width: 100%;
+  min-width: 0;
 }
 
 @media (max-width: 760px) {

--- a/src/utils/itemList.js
+++ b/src/utils/itemList.js
@@ -1,0 +1,30 @@
+import { getUniqueSlotKeyMap, inferEquipmentSlot } from './equipmentParser.js';
+
+/**
+ * Build the Items-tab source as a union. Inventory extraction intentionally
+ * excludes equipped arrays, so the equipped instances must be added back.
+ */
+export function buildItemList(equipped = [], inventory = [], totalInventoryCount = 0) {
+  const equippedItems = Array.from(
+    getUniqueSlotKeyMap(equipped),
+    ([item, equipmentSlotKey]) => ({
+      ...item,
+      isEquipped: true,
+      equipmentSlotKey,
+    })
+  );
+  const inventoryItems = inventory.map(item => ({
+    ...item,
+    isEquipped: false,
+    equipmentSlotKey: null,
+  }));
+
+  return {
+    items: [...equippedItems, ...inventoryItems],
+    totalItems: (totalInventoryCount || inventory.length) + equippedItems.length,
+  };
+}
+
+export function getListItemSlot(item) {
+  return item?.slot || inferEquipmentSlot(item?.rowName) || 'unknown';
+}

--- a/test/MonogramSetPanel.test.jsx
+++ b/test/MonogramSetPanel.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { MonogramSetPanel } from '../src/components/items/MonogramSetPanel.jsx';
+
+describe('MonogramSetPanel', () => {
+  it('renders the current editable layout before a set is saved or selected', () => {
+    const html = renderToStaticMarkup(
+      <MonogramSetPanel
+        name=""
+        onNameChange={vi.fn()}
+        savedSets={[]}
+        selectedSet={null}
+        currentEntries={[{
+          slotKey: 'head',
+          itemRow: 'Armor_Head_A',
+          itemName: 'Spirit Clutch',
+          monogramSlots: ['Bloodlust.Base', null, null],
+        }]}
+        onSelectSet={vi.fn()}
+        onSetMonogramSlot={vi.fn()}
+        onSave={vi.fn()}
+        onApply={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(html).toContain('Spirit Clutch');
+    expect(html).toContain('Spirit Clutch monogram 1');
+    expect(html.match(/<select/g)).toHaveLength(4); // set picker + three positions
+    expect(html).toContain('value="Bloodlust.Base" selected=""');
+  });
+});

--- a/test/itemList.test.js
+++ b/test/itemList.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildItemList, getListItemSlot } from '../src/utils/itemList.js';
+
+describe('Items-tab item list', () => {
+  it('includes equipped instances that inventory extraction omits', () => {
+    const equipped = [
+      { rowName: 'Armor_Head_A', slot: 'head' },
+      { rowName: 'Ring_A', slot: 'ring' },
+      { rowName: 'Ring_B', slot: 'ring' },
+    ];
+    const inventory = [{ rowName: 'Armor_Boots_Inventory' }];
+
+    const result = buildItemList(equipped, inventory, 1);
+
+    expect(result.items).toHaveLength(4);
+    expect(result.items.filter(item => item.isEquipped)).toHaveLength(3);
+    expect(result.items.map(item => item.equipmentSlotKey))
+      .toEqual(['head', 'ring1', 'ring2', null]);
+    expect(result.totalItems).toBe(4);
+  });
+
+  it('infers equipment categories for unequipped inventory items', () => {
+    expect(getListItemSlot({ rowName: 'Armor_Boots_Zone_4' })).toBe('boots');
+    expect(getListItemSlot({ rowName: 'Consumable_Potion' })).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## What changed

- renders the current effective monogram layout immediately after a save loads
- replaces static monogram preview badges with three slot-valid `select` controls per equipped item
- keeps saved-set selection separate until Apply
- maps `neck` equipment to the amulet Codex pool and preserves ring1/ring2 pools
- removes the grid minimum-width behavior that made select sizing brittle in Firefox

### Items list

- builds the Items tab from an explicit union of equipped instances and inventory
- adds equipped items back because inventory extraction intentionally skips `EquipmentItems` and `HotbarItems`
- carries exact equipment identity and unique keys with each row instead of recovering them by row name
- makes Show Equipped Only operate on the equipped-instance flag
- infers slot categories for unequipped inventory items so equippable items populate Head/Boots/Ring/etc. filters
- preserves engine-only monogram overrides and never writes to the save

## Root cause

The set layout was gated on `selectedSet`, so nothing rendered until a set was saved or loaded. Its three displayed fields were spans rather than inputs, so they were not editable in Firefox or any other browser.

Separately, `transformAllItems` deliberately excludes equipped arrays, but the Items tab only rendered that inventory result and then tried to rediscover equipped rows by `rowName`. New saves could therefore show an empty equipped-only list even though `itemStore.equipped` was populated.

## Validation

- `npm run test:run` — 22 files, 375 tests passed
- `npm run build` — production build passed
- regression coverage verifies the initial unsaved layout contains three editable selects and the Items source includes uniquely keyed equipped instances
