### PR TITLE
Show effective monograms in tooltips and fix generic mythic slot pool

### DIFF
--- a/src/components/character/CharacterPanel.jsx
+++ b/src/components/character/CharacterPanel.jsx
@@ -4,6 +4,7 @@ import { StatsPanel } from './StatsPanel';
 import { mapItemsToSlots } from '../../utils/equipmentParser';
 import { useItemOverrides } from '../../hooks/useItemOverrides';
 import { getRaceName } from '../../utils/raceBonuses';
+import { applyMonogramOverrideToItem } from '../../utils/monogramOverrides';
 
 export function CharacterPanel({ characterData, itemOverrides }) {
   // What-if edits are made in the Items tab editor; App shares that overrides
@@ -46,7 +47,10 @@ export function CharacterPanel({ characterData, itemOverrides }) {
           value: a.value,
           rawTag: a.name,
         }));
-        result[slotKey] = { ...item, baseStats: modifiedBaseStats };
+        result[slotKey] = applyMonogramOverrideToItem(
+          { ...item, baseStats: modifiedBaseStats },
+          overrides[slotKey]
+        );
       } else {
         result[slotKey] = item;
       }

--- a/src/components/character/ItemEditor.jsx
+++ b/src/components/character/ItemEditor.jsx
@@ -1,12 +1,18 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { getMonogramsForSlot, getMonogramName } from '../../utils/monogramRegistry';
 import { MONOGRAM_SLOT_COUNT, normalizeMonogramSlots } from '../../utils/monogramOverrides';
+import { getMonogramPoolForEquipmentSlot } from '../../models/MonogramSet.js';
 
 /**
  * Map an item type/row to its Codex recipe pool.
  */
-function getMonogramSlot(itemType, itemRow) {
-  const typeStr = (itemType || itemRow || '').toLowerCase();
+export function getMonogramSlot(itemType, itemRow, equipmentSlotKey = '') {
+  const explicitPool = getMonogramPoolForEquipmentSlot(equipmentSlotKey);
+  if (explicitPool) return explicitPool;
+
+  // Generated item types are often generic (e.g. "Armor Mythic"). Always
+  // retain the row name, which carries the actual slot (_Helmet, _Ring, etc.).
+  const typeStr = `${itemType || ''} ${itemRow || ''}`.toLowerCase();
 
   if (typeStr.includes('head') || typeStr.includes('helm') || typeStr.includes('hat') || typeStr.includes('casque')) return 'head';
   if (typeStr.includes('amulet') || typeStr.includes('neck')) return 'amulet';
@@ -25,6 +31,7 @@ function getMonogramSlot(itemType, itemRow) {
  */
 export function ItemEditor({
   item,
+  slotKey = '',
   slotOverrides = {},
   onSetMonogramSlot,
   onClearSlot,
@@ -40,7 +47,7 @@ export function ItemEditor({
   const itemType = item?.type || item?.itemType || '';
   const itemRow = item?.rowName || item?.itemRow || '';
   const itemName = item?.displayName || item?.name || 'Unknown';
-  const monogramSlot = getMonogramSlot(itemType, itemRow);
+  const monogramSlot = getMonogramSlot(itemType, itemRow, slotKey);
   const availableMonograms = useMemo(
     () => monogramSlot ? getMonogramsForSlot(monogramSlot) : [],
     [monogramSlot]

--- a/src/components/items/ItemsTab.jsx
+++ b/src/components/items/ItemsTab.jsx
@@ -8,6 +8,7 @@ import { useItemOverrides } from '../../hooks/useItemOverrides';
 import { useMonogramSets } from '../../hooks/useMonogramSets';
 import { formatSlotLabel, getUniqueSlotKeyMap } from '../../utils/equipmentParser';
 import { buildItemList, getListItemSlot } from '../../utils/itemList';
+import { applyMonogramOverrideToItem } from '../../utils/monogramOverrides';
 
 const DEFAULT_FILTERS = '';
 
@@ -98,6 +99,16 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
     return buildItemList([], transformed, totalCount);
   }, [itemStore?.equipped, itemStore?.inventory, itemStore?.totalInventoryCount, saveData]);
 
+  // Equipped rows and their hover tooltips must show the active engine state,
+  // not the immutable monograms imported from the save.
+  const effectiveItems = useMemo(() => items.map(item => {
+    if (!item.isEquipped || !item.equipmentSlotKey) return item;
+    return applyMonogramOverrideToItem(
+      item,
+      overrides[item.equipmentSlotKey] || {}
+    );
+  }), [items, overrides]);
+
   const filteredItems = useMemo(() => {
     const regexList = filterPatterns.map(pattern => new RegExp(pattern.replace(/\*/g, '.*'), 'i'));
 
@@ -117,7 +128,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
       return names.some(attr => regexList.some(regex => regex.test(attr)));
     };
 
-    return items.filter(item => {
+    return effectiveItems.filter(item => {
       // Filter out invalid/empty items
       const name = item.displayName || item.rowName;
       if (!name || name === 'None' || name === '(unknown)') return false;
@@ -126,7 +137,7 @@ export function ItemsTab({ saveData, itemStore, itemOverrides, onLog }) {
       if (!showEquippedOnly) return true;
       return item.isEquipped;
     });
-  }, [items, showEquippedOnly, filterPatterns]);
+  }, [effectiveItems, showEquippedOnly, filterPatterns]);
 
   const slotFilteredItems = useMemo(() => {
     if (selectedSlots.size === 0) return filteredItems;

--- a/src/utils/monogramOverrides.js
+++ b/src/utils/monogramOverrides.js
@@ -40,3 +40,22 @@ export function resolveEffectiveMonograms(importedMonograms = [], slotOverride =
     }];
   });
 }
+
+/**
+ * Return an item model suitable for what-if UI surfaces. The imported item is
+ * left untouched; an explicit three-slot override replaces only the displayed
+ * monograms.
+ *
+ * @param {Object} item
+ * @param {{monogramSlots?: Array<string|null>}} slotOverride
+ * @returns {Object}
+ */
+export function applyMonogramOverrideToItem(item, slotOverride = {}) {
+  if (!item || !Array.isArray(slotOverride.monogramSlots)) return item;
+
+  const importedMonograms = item.monograms || item.model?.monograms || [];
+  return {
+    ...item,
+    monograms: resolveEffectiveMonograms(importedMonograms, slotOverride),
+  };
+}

--- a/test/ItemEditor.test.js
+++ b/test/ItemEditor.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { getMonogramSlot, ItemEditor } from '../src/components/character/ItemEditor.jsx';
+
+describe('ItemEditor monogram slot resolution', () => {
+  it('uses the authoritative equipment key for generic generated item types', () => {
+    expect(getMonogramSlot(
+      'Armor Mythic',
+      'Armor_Mythic_Plate_Helmet',
+      'head'
+    )).toBe('head');
+  });
+
+  it('still reads the row when a nonempty generic type is present', () => {
+    expect(getMonogramSlot(
+      'Armor Mythic',
+      'Armor_Mythic_Plate_Helmet'
+    )).toBe('head');
+  });
+
+  it('renders three editable fields for the Spirit Clutch fixture shape', () => {
+    const html = renderToStaticMarkup(React.createElement(ItemEditor, {
+      item: {
+        name: 'Spirit Clutch',
+        itemType: 'Armor Mythic',
+        itemRow: 'Armor_Mythic_Plate_Helmet',
+      },
+      slotKey: 'head',
+      slotOverrides: {},
+      currentMonograms: [{ id: 'ElementForCritChance.Arcane' }],
+      onSetMonogramSlot: vi.fn(),
+      onClearSlot: vi.fn(),
+      onClose: vi.fn(),
+    }));
+
+    expect(html.match(/<select/g)).toHaveLength(3);
+    expect(html).not.toContain('does not use a monogram recipe pool');
+  });
+});

--- a/test/MonogramSetPanel.test.js
+++ b/test/MonogramSetPanel.test.js
@@ -5,25 +5,23 @@ import { MonogramSetPanel } from '../src/components/items/MonogramSetPanel.jsx';
 
 describe('MonogramSetPanel', () => {
   it('renders the current editable layout before a set is saved or selected', () => {
-    const html = renderToStaticMarkup(
-      <MonogramSetPanel
-        name=""
-        onNameChange={vi.fn()}
-        savedSets={[]}
-        selectedSet={null}
-        currentEntries={[{
-          slotKey: 'head',
-          itemRow: 'Armor_Head_A',
-          itemName: 'Spirit Clutch',
-          monogramSlots: ['Bloodlust.Base', null, null],
-        }]}
-        onSelectSet={vi.fn()}
-        onSetMonogramSlot={vi.fn()}
-        onSave={vi.fn()}
-        onApply={vi.fn()}
-        onDelete={vi.fn()}
-      />
-    );
+    const html = renderToStaticMarkup(React.createElement(MonogramSetPanel, {
+      name: '',
+      onNameChange: vi.fn(),
+      savedSets: [],
+      selectedSet: null,
+      currentEntries: [{
+        slotKey: 'head',
+        itemRow: 'Armor_Head_A',
+        itemName: 'Spirit Clutch',
+        monogramSlots: ['Bloodlust.Base', null, null],
+      }],
+      onSelectSet: vi.fn(),
+      onSetMonogramSlot: vi.fn(),
+      onSave: vi.fn(),
+      onApply: vi.fn(),
+      onDelete: vi.fn(),
+    }));
 
     expect(html).toContain('Spirit Clutch');
     expect(html).toContain('Spirit Clutch monogram 1');

--- a/test/monogramOverrides.test.js
+++ b/test/monogramOverrides.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyMonogramOverrideToItem,
   MONOGRAM_SLOT_COUNT,
   normalizeMonogramSlots,
   resolveEffectiveMonograms,
@@ -53,5 +54,35 @@ describe('monogram overrides', () => {
     expect(resolveEffectiveMonograms([], {
       monogramSlots: ['A', 'B', 'C', 'D'],
     }).map(monogram => monogram.id)).toEqual(['A', 'B', 'C']);
+  });
+});
+
+describe('effective monogram item display', () => {
+  const importedItem = {
+    displayName: 'Spirit Clutch',
+    monograms: [{ id: 'ElementForCritChance.Arcane', value: 7 }],
+  };
+
+  it('shows applied slots without mutating the imported save item', () => {
+    const displayed = applyMonogramOverrideToItem(importedItem, {
+      monogramSlots: ['MeleeParagon.BaseDamage', null, 'Shroud'],
+    });
+
+    expect(displayed.monograms.map(monogram => monogram.id))
+      .toEqual(['MeleeParagon.BaseDamage', 'Shroud']);
+    expect(displayed.monograms.every(monogram => monogram.source === 'override'))
+      .toBe(true);
+    expect(importedItem.monograms)
+      .toEqual([{ id: 'ElementForCritChance.Arcane', value: 7 }]);
+  });
+
+  it('uses exactly the same effective values as the calculation engine', () => {
+    const slotOverride = { monogramSlots: ['Bloodlust.Base', null, null] };
+    expect(applyMonogramOverrideToItem(importedItem, slotOverride).monograms)
+      .toEqual(resolveEffectiveMonograms(importedItem.monograms, slotOverride));
+  });
+
+  it('preserves the original item identity when there is no applied set', () => {
+    expect(applyMonogramOverrideToItem(importedItem, {})).toBe(importedItem);
   });
 });


### PR DESCRIPTION
Display override-set monograms in both the Items-list and Character-slot tooltip surfaces using the same resolver as the calculation engine, while keeping imported save items immutable. Resolve the monogram recipe pool from the authoritative equipment slot key so generic generated item types (e.g. "Armor Mythic") still map to the correct slot instead of failing row parsing.


Claude-Session: https://claude.ai/code/session_01PLowZPZsSaFdcB4WBRZNxw